### PR TITLE
Increase python unit test CI timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,10 +108,12 @@ jobs:
         BRANCH: gh-pages
         FOLDER: website/public
 
+  # FIXME: These timeouts are egregiously long right now.
+  # See Also: https://github.com/microsoft/MLOS/pull/66#issuecomment-690760863
   python-checks:
     name: Run Python checks
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [windows-2019, ubuntu-20.04]
@@ -142,9 +144,9 @@ jobs:
       run: scripts/run-python-checks.sh
     - name: Run Python unit tests (Windows)
       if: startsWith(matrix.os, 'windows')
-      timeout-minutes: 12
+      timeout-minutes: 75
       run: scripts\run-python-tests.cmd
     - name: Run Python unit tests (Linux)
       if: startsWith(matrix.os, 'ubuntu')
-      timeout-minutes: 12
+      timeout-minutes: 75
       run: scripts/run-python-tests.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
   python-checks:
     name: Run Python checks
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 12
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [windows-2019, ubuntu-20.04]
@@ -142,9 +142,9 @@ jobs:
       run: scripts/run-python-checks.sh
     - name: Run Python unit tests (Windows)
       if: startsWith(matrix.os, 'windows')
-      timeout-minutes: 8
+      timeout-minutes: 12
       run: scripts\run-python-tests.cmd
     - name: Run Python unit tests (Linux)
       if: startsWith(matrix.os, 'ubuntu')
-      timeout-minutes: 8
+      timeout-minutes: 12
       run: scripts/run-python-tests.sh


### PR DESCRIPTION
I'm still seeing a few timeout failures on the unit tests.

This is a quick change to simply increase the timeout for now.