### PR TITLE
reorganize and update conda/python install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,58 +66,10 @@ To achieve this MLOS provides:
 
     Once hooks are created in the target system, iteration on the external agent can be more rapidly developed and deployed.
 
-## Python only installation
+## Python quickstart
+The easiest way to get started with MLOS is to just just the Python package.
+You can find installation instructions in the [Prerequisites: Python Quickstart](./documentation/01-Prerequisites.md#python-quickstart).
 
-Some of the examples require only the installation of the `mlos` Python library.
-These are simplified examples for getting started and do not use the shared memory infrastructure for cross language/process interactions.
-
-First, download the MLOS code using git:
-
-```shell
-git clone https://github.com/microsoft/MLOS.git
-cd MLOS
-```
-
-For this simplified installation, it's recommended to use the [Anaconda python distribution](https://www.anaconda.com/products/individual).
-For a slimmer installation experience, you can also use the [miniconda installer](https://docs.conda.io/en/latest/miniconda.html).
-After installing either anaconda or miniconda, you can create a new environment with all requirements for the examples using
-
-> Note currently MLOS needs Python 3.7, but by default conda packages Python 3.8.
-> For the moment, you may need to search the [installer archives](https://repo.anaconda.com/miniconda/) for a python 3.7 version.
-> e.g. [Miniconda3-py37_4.8.3-Windows-x86_64.exe](https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Windows-x86_64.exe)
-
-```shell
-conda env create -f MLOS/source/Mlos.Notebooks/environment.yml
-```
-
-The environment will be called `mlos_python_environment` and you can activate it as follows:
-
-```shell
-conda activate mlos_python_environment
-```
-
-Use `pip` to install the Python library:
-
-```shell
-pip install MLOS/source/Mlos.Python/
-```
-
-Alternatively, you can also install the package directly without checking out the code:
-
-```shell
-pip install "git+https://github.com/microsoft/MLOS.git#egg=mlos&subdirectory=source/Mlos.Python"
-```
-
-However, this does not include the examples and requires you to set up your environment manually.
-
-After this installation, you can run any of the Python-only example notebooks. To do so you can:
-
-```shell
-python -m ipykernel install --user --name=mlos_environment
-jupyter-notebook --notebook-dir=MLOS/source/Mlos.Notebooks
-```
-
-Jupyter will list a few notebooks. A good place to start is the *BayesianOptimization.ipynb*, which provides an [Introduction to Bayesian Optimization](./source/Mlos.Notebooks/BayesianOptimization.ipynb#mlos-github-tree-view).
 
 ## Full Build (C# and C++ components)
 

--- a/documentation/01-Prerequisites.md
+++ b/documentation/01-Prerequisites.md
@@ -6,9 +6,10 @@ These are one-time setup instructions that should be executed prior to following
 
 - [Prerequisites for building and using MLOS](#prerequisites-for-building-and-using-mlos)
   - [Contents](#contents)
+  - [Cloning the repository](#clone-the-repository)
+  - [Python quickstart](#python-quickstart)
   - [Linux](#linux)
     - [Linux Distribution Requirements](#linux-distribution-requirements)
-    - [Clone the repository](#clone-the-repository)
     - [Option 1: Linux Docker Build Env](#option-1-linux-docker-build-env)
       - [Install Docker](#install-docker)
       - [Build the Docker Image](#build-the-docker-image)
@@ -16,15 +17,59 @@ These are one-time setup instructions that should be executed prior to following
     - [Install Python on Linux](#install-python-on-linux)
       - [Option 1: Docker Python Install](#option-1-docker-python-install)
       - [Option 2: Using Conda](#option-2-using-conda)
-      - [Option 3: Manual Python Install](#option-3-manual-python-install)
   - [Windows](#windows)
-    - [Step 1: Clone the repository](#step-1-clone-the-repository)
-    - [Step 2: Install Python](#step-2-install-python)
-    - [Step 3: Install Docker on Windows](#step-3-install-docker-on-windows)
-    - [Step 4: Install Windows Build Tools](#step-4-install-windows-build-tools)
+    - [Step 1: Install Python](#step-1-install-python)
+    - [Step 2: Install Docker on Windows](#step-2-install-docker-on-windows)
+    - [Step 3: Install Windows Build Tools](#step-3-install-windows-build-tools)
 
 MLOS currently supports 64-bit Intel/AMD platforms, though ARM64 support is under development.
 It supports Windows and Linux environments. Below we provide instructions for each OS.
+
+
+## Clone the repository
+
+Make sure you have [git](https://git-scm.com/) installed and clone the repo:
+
+```shell
+git clone https://github.com/microsoft/MLOS.git
+cd MLOS
+```
+
+## Python quickstart
+
+Some of the examples require only the installation of the `mlos` Python library, which is easy to install on any operating system.
+
+It's recommended to use the [Anaconda python distribution](https://www.anaconda.com/products/individual).
+or the smaller [miniconda installer](https://docs.conda.io/en/latest/miniconda.html).
+After installing either anaconda or miniconda, you can create a new environment with all requirements for the examples using
+
+> Note currently MLOS needs Python 3.7, but by default conda packages Python 3.8.
+> For the moment, you may need to search the [installer archives](https://repo.anaconda.com/miniconda/) for a python 3.7 version.
+> e.g. [Miniconda3-py37_4.8.3-Windows-x86_64.exe](https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Windows-x86_64.exe)
+
+```shell
+conda env create -f MLOS/source/Mlos.Notebooks/environment.yml
+```
+
+The environment will be called `mlos_python_environment` and you can activate it as follows:
+
+```shell
+conda activate mlos_python_environment
+```
+
+Use `pip` to install the Python library:
+
+```shell
+pip install MLOS/source/Mlos.Python/
+```
+
+After this installation, you can run any of the Python-only example notebooks. To do so you can:
+
+```shell
+jupyter-notebook --notebook-dir=MLOS/source/Mlos.Notebooks
+```
+
+Jupyter will list a few notebooks. A good place to start is the *BayesianOptimization.ipynb*, which provides an [Introduction to Bayesian Optimization](./source/Mlos.Notebooks/BayesianOptimization.ipynb#mlos-github-tree-view).
 
 ## Linux
 
@@ -38,20 +83,6 @@ All of them require `git` and, of course, a Linux installation:
 
 > Other distros/versions may work, but are untested.
 
-### Clone the repository
-
-Make sure you have `git` available:
-
-```sh
-apt-get -y install git
-```
-
-Clone the repository:
-
-```sh
-git clone https://github.com/microsoft/MLOS.git
-cd MLOS
-```
 
 ### Option 1: Linux Docker Build Env
 
@@ -121,61 +152,25 @@ If you used the [Docker build image](#docker-build-image) instructions you're do
 
 #### Option 2: Using Conda
 
-TODO
-
-#### Option 3: Manual Python Install
-
-1. Install Python 3.7
-
-    ```sh
-    # We need to add a special apt repository for Python 3.7 support:
-    sudo apt-get -y install \
-        software-properties-common apt-transport-https
-    sudo add-apt-repository -y ppa:deadsnakes/ppa
-    sudo apt-get update
-    sudo apt-get -y install python3.7
-    ```
-
-2. Install MLOS Python dependencies:
-
-    ```sh
-    # Also add some dependencies needed by some of the pip modules
-    sudo apt-get -y install python3-pip python3.7-dev \
-        build-essential libfreetype-dev unixodbc-dev
-    ```
-
-    ```sh
-    python3.7 -m pip install --upgrade pip
-    python3.7 -m pip install setuptools
-
-    python3.7 -m pip install \
-        -r source/Mlos.Python/requirements.txt
-    ```
+Follow the [Python Quickstart](#python-quickstart) above.
 
 ## Windows
 
 MLOS is easiest to use on Windows 10, Version 1903 (March 2019) or newer.
 
-### Step 1: Clone the repository
 
-[Install git](https://git-scm.com/) and clone the repo:
 
-```shell
-git clone https://github.com/microsoft/MLOS.git
-cd MLOS
-```
+### Step 1: Install Python
 
-### Step 2: Install Python
+Follow the [Python Quickstart](#python-quickstart) above.
 
-TODO
-
-### Step 3: Install Docker on Windows
+### Step 2: Install Docker on Windows
 
 Portions of MLOS use Docker. Please follow the instructions on the [Docker Website](https://www.docker.com/products/docker-desktop) to install it. Note that on Windows *Home*, you need a fairly recent Windows version to install Docker (Windows 10 1903 or newer).
 
 On Windows 10 v1903 or newer, we recommend you use the [Windows Subsytem for Linux v2](https://docs.microsoft.com/en-us/windows/wsl/install-win10#update-to-wsl-2) to run the containers. On older Windows 10, you can resort to the [Hyper-V support](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/) of Docker.
 
-### Step 4: Install Windows Build Tools
+### Step 3: Install Windows Build Tools
 
 Download and install Visual Studio 2019 (free) Community Edition:
 

--- a/documentation/01-Prerequisites.md
+++ b/documentation/01-Prerequisites.md
@@ -43,10 +43,6 @@ It's recommended to use the [Anaconda python distribution](https://www.anaconda.
 or the smaller [miniconda installer](https://docs.conda.io/en/latest/miniconda.html).
 After installing either anaconda or miniconda, you can create a new environment with all requirements for the examples using
 
-> Note currently MLOS needs Python 3.7, but by default conda packages Python 3.8.
-> For the moment, you may need to search the [installer archives](https://repo.anaconda.com/miniconda/) for a python 3.7 version.
-> e.g. [Miniconda3-py37_4.8.3-Windows-x86_64.exe](https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Windows-x86_64.exe)
-
 ```shell
 conda env create -f MLOS/source/Mlos.Notebooks/environment.yml
 ```

--- a/scripts/parse-pip-requirements-from-environment-yaml.py
+++ b/scripts/parse-pip-requirements-from-environment-yaml.py
@@ -29,9 +29,6 @@ for item in data["dependencies"]:
             pattern=r'([^=])=([^=])',
             repl='\\1==\\2',
             string=item)
-        if "conda" not in new_item and not new_item.startswith("python"):
-            # skip any conda related packages in pip
-            new_dependencies.append(new_item)
     elif item_type == dict:
         for item_key in item:
             if item_key != "pip":
@@ -42,9 +39,9 @@ for item in data["dependencies"]:
     else:
         raise Exception("Unhandled type: '{item_type}'".format(item_type = item_type))
 
-excluded_dependencies = ['python']
+excluded_dependencies = ['python', 'nb_conda_kernels']
 for item in new_dependencies:
-    if item in excluded_dependencies:
+    dep_name = re.split('[><=]+', item)[0]
++   if dep_name in excluded_dependencies:
         continue
-    else:
-        print(item)
+    print(item)

--- a/scripts/parse-pip-requirements-from-environment-yaml.py
+++ b/scripts/parse-pip-requirements-from-environment-yaml.py
@@ -29,7 +29,9 @@ for item in data["dependencies"]:
             pattern=r'([^=])=([^=])',
             repl='\\1==\\2',
             string=item)
-        new_dependencies.append(new_item)
+        if "conda" not in new_item:
+            # skip any conda related packages in pip
+            new_dependencies.append(new_item)
     elif item_type == dict:
         for item_key in item:
             if item_key != "pip":

--- a/scripts/parse-pip-requirements-from-environment-yaml.py
+++ b/scripts/parse-pip-requirements-from-environment-yaml.py
@@ -42,6 +42,6 @@ for item in data["dependencies"]:
 excluded_dependencies = ['python', 'nb_conda_kernels']
 for item in new_dependencies:
     dep_name = re.split('[><=]+', item)[0]
-+   if dep_name in excluded_dependencies:
+    if dep_name in excluded_dependencies:
         continue
     print(item)

--- a/scripts/parse-pip-requirements-from-environment-yaml.py
+++ b/scripts/parse-pip-requirements-from-environment-yaml.py
@@ -29,7 +29,7 @@ for item in data["dependencies"]:
             pattern=r'([^=])=([^=])',
             repl='\\1==\\2',
             string=item)
-        if "conda" not in new_item:
+        if "conda" not in new_item and not new_item.startswith("python"):
             # skip any conda related packages in pip
             new_dependencies.append(new_item)
     elif item_type == dict:

--- a/source/Mlos.Notebooks/environment.yml
+++ b/source/Mlos.Notebooks/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - nb_conda_kernels
   - matplotlib
   - seaborn
-  - python
+  - python=3.7
   - pip:
     - grpcio-tools==1.30.0
     - bayesian-optimization==1.0.1

--- a/source/Mlos.Notebooks/environment.yml
+++ b/source/Mlos.Notebooks/environment.yml
@@ -12,7 +12,6 @@ dependencies:
   - jupyterlab
   - jupyter
   - ipykernel
-  - nb_conda_kernels
   - matplotlib
   - seaborn
   - python=3.7

--- a/source/Mlos.Notebooks/environment.yml
+++ b/source/Mlos.Notebooks/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyterlab
   - jupyter
   - ipykernel
+  - nb_conda_kernels
   - matplotlib
   - seaborn
   - python=3.7

--- a/source/Mlos.Notebooks/environment.yml
+++ b/source/Mlos.Notebooks/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyterlab
   - jupyter
   - ipykernel
+  - nb_conda_kernels
   - matplotlib
   - seaborn
   - python


### PR DESCRIPTION
cc @bpkroth @markusweimer 

Not sure if I'm undoing some of the work @markusweimer has been doing here before.
I grouped the OS independent steps in the beginning.

I think the "manual python" version is not that useful because it's ubuntu only (not sure if the ppas work for debian?), and there's really no reason to compile your own version of pyodbc, so I removed it.