### PR TITLE
Fixup comment word wrap settings for vscode vim

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,8 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
+# Note: this is not currently supported by all editors or their editorconfig plugins.
+max_line_length = 132
 
 # Makefiles need tab indentation
 [{Makefile,*.mk}]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,6 @@
         132
     ],
     // Control how the vim reflow key combo wraps text for comments.
-    // Set it just below the line length limit to account for an off-by-one error in the vscodevim plugin.
-    "vim.textwidth": 131
+    // Set it to something less than the code length but not too short.
+    "vim.textwidth": 100
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,12 @@
     "cmake.generator": "Unix Makefiles",
     "cmake.preferredGenerators": [
         "Unix Makefiles"
-    ]
+    ],
+    // Show a vertical line at our code standard's line length limit.
+    "editor.rulers": [
+        132
+    ],
+    // Control how the vim reflow key combo wraps text for comments.
+    // Set it just below the line length limit to account for an off-by-one error in the vscodevim plugin.
+    "vim.textwidth": 131
 }


### PR DESCRIPTION
Tweaks to vscode plugins to reflow comments at a width that matches the rest of the code style.

Noticed by @grlap 