### PR TITLE
Fixups for libstdc++-10 support

### DIFF
--- a/source/Examples/SmartCache/Main.cpp
+++ b/source/Examples/SmartCache/Main.cpp
@@ -54,8 +54,8 @@ void ThrowIfFail(HRESULT hr)
 int
 __cdecl
 main(
-    __in int argc,
-    __in char* argv[])
+    _In_ int argc,
+    _In_ char* argv[])
 {
     UNUSED(argc);
     UNUSED(argv);

--- a/source/Examples/SmartSharedChannel/Main.cpp
+++ b/source/Examples/SmartSharedChannel/Main.cpp
@@ -51,8 +51,8 @@ void CheckHR(HRESULT hr)
 int
 __cdecl
 main(
-    __in int argc,
-    __in char* argv[])
+    _In_ int argc,
+    _In_ char* argv[])
 {
     UNUSED(argc);
     UNUSED(argv);

--- a/source/Mlos.Core/Mlos.Core.h
+++ b/source/Mlos.Core/Mlos.Core.h
@@ -56,7 +56,6 @@ constexpr int32_t INVALID_FD_VALUE = -1;
 
 #define _Check_return_
 #define _Out_
-#define __in
 #define _In_
 #define _In_z_
 

--- a/source/Mlos.Core/Mlos.Core.h
+++ b/source/Mlos.Core/Mlos.Core.h
@@ -24,6 +24,7 @@
 #include <functional>
 #include <type_traits>
 #include <string.h>
+#include <cwchar>
 
 // Undefine MIN MAX macros.
 //

--- a/source/Mlos.UnitTest/Main.cpp
+++ b/source/Mlos.UnitTest/Main.cpp
@@ -35,8 +35,8 @@ using ::testing::UnitTest;
 int
 __cdecl
 main(
-    __in int argc,
-    __in char* argv[])
+    _In_ int argc,
+    _In_ char* argv[])
 {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Recently we discovered the following error in CI for Linux builds:

```txt
Scanning dependencies of target Mlos.Core
make[3]: Leaving directory '/home/runner/work/MLOS/MLOS/out/cmake/Debug'
make[3]: Entering directory '/home/runner/work/MLOS/MLOS/out/cmake/Debug'
[ 20%] Building CXX object source/Mlos.Core/CMakeFiles/Mlos.Core.dir/ArenaAllocator.cpp.o
In file included from /home/runner/work/MLOS/MLOS/source/Mlos.Core/ArenaAllocator.cpp:16:
In file included from /home/runner/work/MLOS/MLOS/source/Mlos.Core/Mlos.Core.h:90:
In file included from /home/runner/work/MLOS/MLOS/source/Mlos.Core/PropertyProxy.h:18:
In file included from /home/runner/work/MLOS/MLOS/source/Mlos.Core/ObjectSerialization.h:19:
/home/runner/work/MLOS/MLOS/source/Mlos.Core/StringTypes.h:89:38: error: use of undeclared identifier 'wcslen'
        Length = string != nullptr ? wcslen(string) : 0;
                                     ^
/home/runner/work/MLOS/MLOS/source/Mlos.Core/StringTypes.h:105:61: error: use of undeclared identifier 'wcsncmp'
    return lhs.Length == rhs.Length && (lhs.Length == 0 || (wcsncmp(lhs.Data, rhs.Data, lhs.Length) == 0));
                                                            ^
2 errors generated.
```

Not entirely sure how this snuck in since I can't find anything on the C++ side which has changed recently and tests were passing a few days ago, but here we are.

It seems that we weren't including the wide character string functions in the standard libs previously.  This small change should fix that.