### PR TITLE
some build pipeline tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,7 +284,9 @@ jobs:
       shell: bash
       run: |
         docker exec mlos-${{ matrix.configuration }}-build-ubuntu-${{ matrix.UbuntuVersion }} \
-          make cmake-build
+          make cmake-build cmake-install
+        docker exec mlos-${{ matrix.configuration }}-build-ubuntu-${{ matrix.UbuntuVersion }} \
+          test -e target/bin/${{ matrix.configuration }}/x86_64/Mlos.UnitTest
     - name: Run ${{ matrix.configuration }} cmake test
       timeout-minutes: 5
       shell: bash
@@ -296,7 +298,7 @@ jobs:
       shell: bash
       run: |
         docker exec mlos-${{ matrix.configuration }}-build-ubuntu-${{ matrix.UbuntuVersion }} \
-          ./build.linux.sh
+          ./build.linux.sh --Configuration=${{ matrix.configuration }}
     - name: Cleanup ${{ matrix.configuration }} docker instance for Ubuntu ${{ matrix.UbuntuVersion }}
       shell: bash
       run: |

--- a/build.cake
+++ b/build.cake
@@ -48,7 +48,7 @@ var OutputDir = Directory("./out/");
 // Output directory for cmake.
 // See Also: Makefile, build/Common.mk
 //
-var CMakeConfiguration = "Release";
+var CMakeConfiguration = Configuration;
 var CMakeBuildDir = Directory($"./out/cmake/{CMakeConfiguration}");
 
 // Docker Test Directory contains the generated dockerfiles and connection string files
@@ -262,6 +262,10 @@ Task("Build-CMake")
         {
             BinaryPath = $"{CMakeBuildDir}",
             Configuration = CMakeConfiguration,
+            Options = new[]
+            {
+                "--jobs", // enable parallel builds using as many processes as CPUs
+            },
             Targets = new[]
             {
                 // Workaround a bug in how CMakeBuildSettings joins the targets


### PR DESCRIPTION
- run build.cake for the right config
- run cmake in parallel inside cake
- run/test the cmake-install target