### PR TITLE
increase longhaul job step timeout beyond default

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,7 +116,7 @@ jobs:
         docker exec -u root mlos-build-ubuntu-${{ matrix.UbuntuVersion }} \
           /src/MLOS/scripts/setup-container-user.sh github-action-runner $(id -u) $(id -g)
     - name: Run python long haul tests (Ubuntu ${{ matrix.UbuntuVersion}})
-      timeout-minutes: 710
+      timeout-minutes: 700
       run: |
         docker exec --workdir /src/MLOS/source/Mlos.Python mlos-build-ubuntu-${{ matrix.UbuntuVersion }} \
           python3.7 -m unittest discover -p LongHaulTest*.py --verbose

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,7 +116,7 @@ jobs:
         docker exec -u root mlos-build-ubuntu-${{ matrix.UbuntuVersion }} \
           /src/MLOS/scripts/setup-container-user.sh github-action-runner $(id -u) $(id -g)
     - name: Run python long haul tests (Ubuntu ${{ matrix.UbuntuVersion}})
-      timeout-minutes: 700
+      timeout-minutes: 710
       run: |
         docker exec --workdir /src/MLOS/source/Mlos.Python mlos-build-ubuntu-${{ matrix.UbuntuVersion }} \
           python3.7 -m unittest discover -p LongHaulTest*.py --verbose

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,6 +116,7 @@ jobs:
         docker exec -u root mlos-build-ubuntu-${{ matrix.UbuntuVersion }} \
           /src/MLOS/scripts/setup-container-user.sh github-action-runner $(id -u) $(id -g)
     - name: Run python long haul tests (Ubuntu ${{ matrix.UbuntuVersion}})
+      timeout-minutes: 700
       run: |
         docker exec --workdir /src/MLOS/source/Mlos.Python mlos-build-ubuntu-${{ matrix.UbuntuVersion }} \
           python3.7 -m unittest discover -p LongHaulTest*.py --verbose


### PR DESCRIPTION
previously we only set the overall job timeout beyond the default of 360 minutes
(6 hours)

with this change we also explicitly set the timeout for the longhaul execution
step in the job (in case that was also defaulting to 360)

still not sure if this will fix things, but worth a try

closes #113