### PR TITLE
2020/october/bug fixes

### DIFF
--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/ObjectiveFunctionBase.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/ObjectiveFunctionBase.py
@@ -52,7 +52,7 @@ class ObjectiveFunctionBase(ABC):
     def get_context(self) -> Point:
         """ Returns a context value for this objective function.
 
-        If the context changes on every invokation, this should return the latest one.
+        If the context changes on every invocation, this should return the latest one.
         :return:
         """
         raise NotImplementedError

--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/SyntheticFunctions/ThreeLevelQuadratic.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/SyntheticFunctions/ThreeLevelQuadratic.py
@@ -102,18 +102,18 @@ class ThreeLevelQuadratic(ObjectiveFunctionBase):
 
         lows = dataframe[dataframe['vertex_height'] == "low"]
         if not lows.empty:
-            y_for_lows = lows["low_quadratic_params.x_1"] ** 2 + lows["low_quadratic_params.x_1"] ** 2
+            y_for_lows = lows["low_quadratic_params.x_1"] ** 2 + lows["low_quadratic_params.x_2"] ** 2
             all_ys.append(y_for_lows)
 
         mids = dataframe[dataframe['vertex_height'] == 5]
         if not mids.empty:
-            y_for_mids = mids["medium_quadratic_params.x_1"] ** 2 + mids["medium_quadratic_params.x_1"] ** 2
+            y_for_mids = mids["medium_quadratic_params.x_1"] ** 2 + mids["medium_quadratic_params.x_2"] ** 2
             all_ys.append(y_for_mids)
 
         highs = dataframe[dataframe['vertex_height'] == 15]
 
         if not highs.empty:
-            y_for_highs = highs["high_quadratic_params.x_1"] ** 2 + highs["high_quadratic_params.x_1"] ** 2
+            y_for_highs = highs["high_quadratic_params.x_1"] ** 2 + highs["high_quadratic_params.x_2"] ** 2
             all_ys.append(y_for_highs)
 
         concatenated_ys = pd.concat(all_ys)

--- a/source/Mlos.Python/mlos/Optimizers/BayesianOptimizerFactory.py
+++ b/source/Mlos.Python/mlos/Optimizers/BayesianOptimizerFactory.py
@@ -37,11 +37,12 @@ class BayesianOptimizerFactory:
             self.logger.info(f"Optimizer config not specified. Using default.")
             optimizer_config = bayesian_optimizer_config_store.default
 
-        self.logger.info(f"Creating a bayesian optimizer with config: {optimizer_config}.")
+        self.logger.info(f"Creating a bayesian optimizer with config: {optimizer_config.to_json(indent=2)}.")
 
         return BayesianOptimizer(
             optimization_problem=optimization_problem,
-            optimizer_config=optimizer_config
+            optimizer_config=optimizer_config,
+            logger=self.logger
         )
 
 

--- a/source/Mlos.Python/mlos/Optimizers/OptimizerBase.py
+++ b/source/Mlos.Python/mlos/Optimizers/OptimizerBase.py
@@ -159,7 +159,7 @@ class OptimizerBase(ABC):
                 if objective.minimize:
                     index_of_best = lower_confidence_bounds.idxmin()
                 else:
-                    index_of_best = lower_confidence_bounds.idx_max()
+                    index_of_best = lower_confidence_bounds.idxmax()
                 optimum_value = Point(lower_confidence_bound=lower_confidence_bounds.loc[index_of_best])
             else:
                 raise RuntimeError(f"Unknown optimum definition.")

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/Prediction.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/Prediction.py
@@ -72,7 +72,7 @@ class Prediction:
 
         # validate passed args
         for output_enum in predictor_outputs:
-            assert output_enum in Prediction.LegalColumnNames, \
+            assert output_enum in set(column_name for column_name in Prediction.LegalColumnNames), \
                 f'PredictionSchema Error: Passed PredictionSchema enum "{output_enum}" not in Prediction.PredictionSchema'
         self.predictor_outputs = predictor_outputs
 

--- a/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
@@ -472,5 +472,25 @@ class TestBayesianOptimizer(unittest.TestCase):
             # At the very least we can assert the ordering. Note that the configs corresponding to each of the below confidence bounds can be different, as confidence intervals
             # change width non-linearily both with degrees of freedom, and with prediction variance.
             #
-            assert lcb_99_ci_optimum.lower_confidence_bound <= lcb_95_ci_optimum.lower_confidence_bound <= lcb_90_ci_optimum.lower_confidence_bound <= predicted_optimum.predicted_value
-            assert predicted_optimum.predicted_value <= ucb_90_ci_optimum.upper_confidence_bound <= ucb_95_ci_optimum.upper_confidence_bound <= ucb_99_ci_optimum.upper_confidence_bound
+            if not (lcb_99_ci_optimum.lower_confidence_bound <= lcb_95_ci_optimum.lower_confidence_bound <= lcb_90_ci_optimum.lower_confidence_bound <= predicted_optimum.predicted_value):
+                # If the the prediction for predicted_value has too few degrees of freedom, it's impossible to construct a confidence interval for it.
+                # If it was possible, then the inequality above would always hold. If it's not possible, then the inequality above can fail.
+                #
+                optimum_predicted_value_prediction = self.optimizer.predict(feature_values_pandas_frame=predicted_best_config.to_dataframe())
+                optimum_predicted_value_prediction_df = optimum_predicted_value_prediction.get_dataframe()
+                degrees_of_freedom = optimum_predicted_value_prediction_df[Prediction.LegalColumnNames.PREDICTED_VALUE_DEGREES_OF_FREEDOM.value][0]
+                if degrees_of_freedom == 0:
+                    self.assertTrue(lcb_99_ci_optimum.lower_confidence_bound <= lcb_95_ci_optimum.lower_confidence_bound <= lcb_90_ci_optimum.lower_confidence_bound)
+                else:
+                    print(lcb_99_ci_optimum.lower_confidence_bound, lcb_95_ci_optimum.lower_confidence_bound, lcb_90_ci_optimum.lower_confidence_bound, predicted_optimum.predicted_value)
+                    self.assertTrue(False)
+
+            if not (predicted_optimum.predicted_value <= ucb_90_ci_optimum.upper_confidence_bound <= ucb_95_ci_optimum.upper_confidence_bound <= ucb_99_ci_optimum.upper_confidence_bound):
+                optimum_predicted_value_prediction = self.optimizer.predict(feature_values_pandas_frame=predicted_best_config.to_dataframe())
+                optimum_predicted_value_prediction_df = optimum_predicted_value_prediction.get_dataframe()
+                degrees_of_freedom = optimum_predicted_value_prediction_df[Prediction.LegalColumnNames.PREDICTED_VALUE_DEGREES_OF_FREEDOM.value][0]
+                if degrees_of_freedom == 0:
+                    self.assertTrue(ucb_90_ci_optimum.upper_confidence_bound <= ucb_95_ci_optimum.upper_confidence_bound <= ucb_99_ci_optimum.upper_confidence_bound)
+                else:
+                    print(predicted_optimum.predicted_value, ucb_90_ci_optimum.upper_confidence_bound, ucb_95_ci_optimum.upper_confidence_bound, ucb_99_ci_optimum.upper_confidence_bound)
+                    self.assertTrue(False)

--- a/source/Mlos.Python/mlos/Spaces/Point.py
+++ b/source/Mlos.Python/mlos/Spaces/Point.py
@@ -120,7 +120,7 @@ class Point:
     def to_dict(self):
         return_dict = {}
         for param_name, value in self:
-            if isinstance(value, Number) and int(value) == value:
+            if isinstance(value, Number) and int(value) == value and not isinstance(value, bool):
                 value = int(value)
             return_dict[param_name] = value
         return return_dict

--- a/source/Mlos.Python/mlos/Tracer.py
+++ b/source/Mlos.Python/mlos/Tracer.py
@@ -64,7 +64,8 @@ def trace():
 
 
 def add_trace_event(name, phase, category='', timestamp_ns=None, actor_id=None, thread_id=None, arguments=None):
-    if global_values.tracer is not None:
+    tracer = getattr(global_values, 'tracer', None)
+    if tracer is not None:
         global_values.tracer.add_trace_event(
             name,
             phase,

--- a/source/Mlos.Python/mlos/global_values.py
+++ b/source/Mlos.Python/mlos/global_values.py
@@ -47,9 +47,14 @@ def declare_singletons():
     global rpc_handlers  # pylint: disable=global-variable-undefined
     global tracer  # pylint: disable=global-variable-undefined
 
-    ml_model_services_proxy = None
-    rpc_handlers = None
-    tracer = None
+    if 'tracer' not in globals():
+        tracer = None
+
+    if 'ml_model_services_proxy' not in globals():
+        ml_model_services_proxy = None
+
+    if 'rpc_handlers' not in globals():
+        rpc_handlers = None
 
 def serialize_to_bytes_string(obj):
     return codecs.encode(pickle.dumps(obj), "base64").decode()


### PR DESCRIPTION
This fixes a number of bugs and typos:
- ThreeLevelQuadratic: used only x_1 instead both x_1 and x_2
- BayesianFactory was not passing a logger to BayesianOptimizer
- idx_max() -> idxmax()
- checking containment in Enums used to throw a warning
- validating optima in TestBayesianOptimizer would randomly fail
- Point would cast bools to ints (Ed's change probably fixed it already)
- Trying to use an uninitialized Tracer used to cause a crash
- Global singletons could be overwritten
