### PR TITLE
Made Opitimizer Serializable

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
@@ -4,6 +4,7 @@
 #
 import math
 import os
+import pickle
 import random
 import unittest
 import warnings
@@ -402,6 +403,13 @@ class TestBayesianOptimizer(unittest.TestCase):
                 best_config_point, best_objective = bayesian_optimizer.optimum(optimum_definition=OptimumDefinition.BEST_OBSERVATION)
                 print(f"[Restart:  {restart_num}/{num_restarts}] Optimum config: {best_config_point}, optimum objective: {best_objective}")
                 self.validate_optima(optimizer=bayesian_optimizer)
+
+            # Test if pickling works
+            #
+            pickled_optimizer = pickle.dumps(local_optimizer)
+            unpickled_optimizer = pickle.loads(pickled_optimizer)
+            for _ in range(10):
+                self.assertTrue(unpickled_optimizer.suggest() == local_optimizer.suggest())
 
     @trace()
     def test_bayesian_optimizer_default_copies_parameters(self):

--- a/source/Mlos.Python/mlos/Spaces/Point.py
+++ b/source/Mlos.Python/mlos/Spaces/Point.py
@@ -107,6 +107,13 @@ class Point:
     def __str__(self):
         return str(self.to_json(indent=2))
 
+    def __getstate__(self):
+        return self.to_json()
+
+    def __setstate__(self, state):
+        temp_point = self.from_json(state)
+        self.dimension_value_dict = temp_point.dimension_value_dict
+
     def to_json(self, indent=None):
         if indent is not None:
             return json.dumps(self.to_dict(), indent=indent)

--- a/source/Mlos.Python/mlos/Spaces/unit_tests/TestHierarchicalHypergrid2.py
+++ b/source/Mlos.Python/mlos/Spaces/unit_tests/TestHierarchicalHypergrid2.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-import random
+import pickle
 import unittest
 
 from mlos.Spaces import CategoricalDimension, Dimension, DiscreteDimension, OrdinalDimension, Point, SimpleHypergrid
@@ -182,5 +182,10 @@ class TestHierarchicalHypergrid2(unittest.TestCase):
                 on_external_dimension=CategoricalDimension(name='cache_implementation_name', values=['associative_cache'])
             )
 
-
+    def test_pickling(self):
+        for _ in range(100):
+            random_point = self.cache_param_space.random()
+            pickled = pickle.dumps(random_point)
+            unpickled = pickle.loads(pickled)
+            self.assertTrue(unpickled == random_point)
 


### PR DESCRIPTION
Implementing __getstate__ and __setstate__ on Point makes all instances of Point serializable and by extension the entire optimizer.
