### PR TITLE
Removed RegressionModelConfig class

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionEnhancedRandomForestModel.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionEnhancedRandomForestModel.py
@@ -12,16 +12,15 @@ from sklearn.metrics import r2_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.preprocessing import PolynomialFeatures
 
-from mlos.Spaces import Hypergrid, SimpleHypergrid, \
-    ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
-from mlos.Tracer import trace
 from mlos.Logger import create_logger
-
-from mlos.Optimizers.RegressionModels.RegressionModel import RegressionModel, RegressionModelConfig
+from mlos.Optimizers.RegressionModels.RegressionModel import RegressionModel
 from mlos.Optimizers.RegressionModels.Prediction import Prediction
 from mlos.Optimizers.RegressionModels.SklearnLassoRegressionModelConfig import SklearnLassoRegressionModelConfig
 from mlos.Optimizers.RegressionModels.SklearnRidgeRegressionModelConfig import SklearnRidgeRegressionModelConfig
 from mlos.Optimizers.RegressionModels.SklearnRandomForestRegressionModelConfig import SklearnRandomForestRegressionModelConfig
+from mlos.Spaces import Hypergrid, SimpleHypergrid, ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
+from mlos.Spaces.Configs.DefaultConfigMeta import DefaultConfigMeta
+from mlos.Tracer import trace
 
 # sklearn injects many warnings, so from
 #   https://stackoverflow.com/questions/32612180/eliminating-warnings-from-scikit-learn
@@ -45,7 +44,7 @@ class RegressionEnhancedRandomForestRegressionModelPrediction(Prediction):
         super().__init__(objective_name=objective_name, predictor_outputs=RegressionEnhancedRandomForestRegressionModelPrediction.OUTPUT_FIELDS)
 
 
-class RegressionEnhancedRandomForestRegressionModelConfig(RegressionModelConfig):
+class RegressionEnhancedRandomForestRegressionModelConfig(metaclass=DefaultConfigMeta):
     """A configuration object for RERF model.
 
     Class responsible for validating its objects are valid hyper parameters for the sklearn classes:

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionModel.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionModel.py
@@ -12,7 +12,6 @@ from mlos.Optimizers.RegressionModels.GoodnessOfFitMetrics import GoodnessOfFitM
 from mlos.Optimizers.RegressionModels.Prediction import Prediction
 from mlos.Optimizers.RegressionModels.RegressionModelFitState import RegressionModelFitState
 from mlos.Spaces import Hypergrid
-from mlos.Spaces.Configs.DefaultConfigMeta import DefaultConfigMeta
 from mlos.Tracer import trace
 
 
@@ -139,18 +138,3 @@ class RegressionModel(ABC):
         )
         self.fit_state.set_gof_metrics(data_set_type, gof_metrics)
         return gof_metrics
-
-class RegressionModelConfig(ABC, metaclass=DefaultConfigMeta):
-    """ An abstract class for all regression models config to implement.
-
-    """
-
-    @classmethod
-    @abstractmethod
-    def contains(cls, config):
-        """
-
-        :param config:
-        :return:
-        """
-        raise NotImplementedError

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/SklearnLassoRegressionModelConfig.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/SklearnLassoRegressionModelConfig.py
@@ -4,13 +4,10 @@
 #
 from enum import Enum
 
-from mlos.Spaces import SimpleHypergrid, \
-    ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
+from mlos.Spaces import SimpleHypergrid, ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
+from mlos.Spaces.Configs.DefaultConfigMeta import DefaultConfigMeta
 
-from .RegressionModel import RegressionModelConfig
-
-
-class SklearnLassoRegressionModelConfig(RegressionModelConfig):
+class SklearnLassoRegressionModelConfig(metaclass=DefaultConfigMeta):
     class Selection(Enum):
         """
         Parameter to sklearn lasso regressor controlling how model coefficients are selected for update.

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/SklearnRandomForestRegressionModelConfig.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/SklearnRandomForestRegressionModelConfig.py
@@ -4,12 +4,10 @@
 #
 from enum import Enum
 
-from mlos.Spaces import SimpleHypergrid, \
-    ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
+from mlos.Spaces import SimpleHypergrid, ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
+from mlos.Spaces.Configs.DefaultConfigMeta import DefaultConfigMeta
 
-from .RegressionModel import RegressionModelConfig
-
-class SklearnRandomForestRegressionModelConfig(RegressionModelConfig):
+class SklearnRandomForestRegressionModelConfig(metaclass=DefaultConfigMeta):
     class MaxFeatures(Enum):
         """
         The number of features to consider when looking for the best split

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/SklearnRidgeRegressionModelConfig.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/SklearnRidgeRegressionModelConfig.py
@@ -4,13 +4,11 @@
 #
 from enum import Enum
 
-from mlos.Spaces import SimpleHypergrid, \
-    ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
-
-from .RegressionModel import RegressionModelConfig
+from mlos.Spaces import SimpleHypergrid, ContinuousDimension, DiscreteDimension, CategoricalDimension, Point
+from mlos.Spaces.Configs.DefaultConfigMeta import DefaultConfigMeta
 
 
-class SklearnRidgeRegressionModelConfig(RegressionModelConfig):
+class SklearnRidgeRegressionModelConfig(metaclass=DefaultConfigMeta):
     class Solver(Enum):
         """
         From https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Ridge.html:


### PR DESCRIPTION
RegressionModelConfig was a mistake. It's now gone. 

Remaining work: Remove DefaultConfigMeta #145 altogether also. I didn't want to do it now because I don't want to mess with RERF code too much, as Ed is editing it too. 