### PR TITLE
Adjusted parameter ranges for many of the Optimizer's components.

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/BayesianOptimizerConfigStore.py
+++ b/source/Mlos.Python/mlos/Optimizers/BayesianOptimizerConfigStore.py
@@ -18,7 +18,7 @@ bayesian_optimizer_config_store = ComponentConfigStore(
                 HomogeneousRandomForestRegressionModel.__name__,
             ]),
             CategoricalDimension(name="experiment_designer_implementation", values=[ExperimentDesigner.__name__]),
-            DiscreteDimension(name="min_samples_required_for_guided_design_of_experiments", min=2, max=10000)
+            DiscreteDimension(name="min_samples_required_for_guided_design_of_experiments", min=2, max=100)
         ]
     ).join(
         subgrid=homogeneous_random_forest_config_store.parameter_space,
@@ -45,4 +45,17 @@ optimizer_config.homogeneous_random_forest_regression_model_config.n_estimators 
 bayesian_optimizer_config_store.add_config_by_name(
     config_name='default_refit_tree_every_time',
     config_point=optimizer_config
+)
+
+# Add a default config with glowworm swarm optimizer
+#
+bayesian_optimizer_config_store.add_config_by_name(
+    config_name="default_with_glow_worm",
+    config_point=Point(
+        surrogate_model_implementation=HomogeneousRandomForestRegressionModel.__name__,
+        experiment_designer_implementation=ExperimentDesigner.__name__,
+        min_samples_required_for_guided_design_of_experiments=10,
+        homogeneous_random_forest_regression_model_config=homogeneous_random_forest_config_store.default,
+        experiment_designer_config=experiment_designer_config_store.get_config_by_name("default_glow_worm_config")
+    )
 )

--- a/source/Mlos.Python/mlos/Optimizers/BayesianOptimizerConvergenceState.py
+++ b/source/Mlos.Python/mlos/Optimizers/BayesianOptimizerConvergenceState.py
@@ -12,4 +12,4 @@ class BayesianOptimizerConvergenceState:
 
     """
     def __init__(self, surrogate_model_fit_state: RegressionModelFitState):
-        self.surrogate_model_fit_state = surrogate_model_fit_state
+        self.surrogate_model_fit_state: RegressionModelFitState = surrogate_model_fit_state

--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/ExperimentDesigner.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/ExperimentDesigner.py
@@ -41,6 +41,18 @@ experiment_designer_config_store = ComponentConfigStore(
     )
 )
 
+experiment_designer_config_store.add_config_by_name(
+    config_name="default_glow_worm_config",
+    config_point=Point(
+        utility_function_implementation=ConfidenceBoundUtilityFunction.__name__,
+        numeric_optimizer_implementation=GlowWormSwarmOptimizer.__name__,
+        confidence_bound_utility_function_config=confidence_bound_utility_function_config_store.default,
+        glow_worm_swarm_optimizer_config=glow_worm_swarm_optimizer_config_store.default,
+        fraction_random_suggestions=0.5
+    ),
+    description="Experiment designer config with glow worm swarm optimizer as a utility function optimizer."
+)
+
 class ExperimentDesigner:
     """ Portion of a BayesianOptimizer concerned with Design of Experiments.
 

--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/GlowWormSwarmOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/GlowWormSwarmOptimizer.py
@@ -20,8 +20,8 @@ glow_worm_swarm_optimizer_config_store = ComponentConfigStore(
         name="glow_worm_swarm_optimizer_config",
         dimensions=[
             DiscreteDimension(name="num_initial_points_multiplier", min=1, max=10),
-            DiscreteDimension(name="num_worms", min=1, max=1000),
-            DiscreteDimension(name="num_iterations", min=1, max=1000), # TODO: consider other stopping criteria too
+            DiscreteDimension(name="num_worms", min=10, max=1000),
+            DiscreteDimension(name="num_iterations", min=1, max=20), # TODO: consider other stopping criteria too
             ContinuousDimension(name="luciferin_decay_constant", min=0, max=1),
             ContinuousDimension(name="luciferin_enhancement_constant", min=0, max=1),
             ContinuousDimension(name="step_size", min=0, max=1),  # TODO: make this adaptive

--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/RandomSearchOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/RandomSearchOptimizer.py
@@ -16,7 +16,7 @@ random_search_optimizer_config_store = ComponentConfigStore(
     parameter_space=SimpleHypergrid(
         name="random_search_optimizer_config",
         dimensions=[
-            DiscreteDimension(name="num_samples_per_iteration", min=1, max=1000)
+            DiscreteDimension(name="num_samples_per_iteration", min=1, max=100000)
         ]
     ),
     default=Point(

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/DecisionTreeConfigStore.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/DecisionTreeConfigStore.py
@@ -39,15 +39,15 @@ decision_tree_config_store = ComponentConfigStore(
             CategoricalDimension(name="criterion", values=[criterion.value for criterion in Criterion]),
             CategoricalDimension(name="splitter", values=[splitter.value for splitter in Splitter]),
             DiscreteDimension(name="max_depth", min=0, max=2**10),
-            DiscreteDimension(name="min_samples_split", min=2, max=2**10),
-            DiscreteDimension(name="min_samples_leaf", min=3, max=2**10),
+            DiscreteDimension(name="min_samples_split", min=2, max=32),
+            DiscreteDimension(name="min_samples_leaf", min=3, max=32),
             ContinuousDimension(name="min_weight_fraction_leaf", min=0.0, max=0.5),
             CategoricalDimension(name="max_features", values=[function.value for function in MaxFeaturesFunc]),
             DiscreteDimension(name="max_leaf_nodes", min=0, max=2**10),
             ContinuousDimension(name="min_impurity_decrease", min=0.0, max=2**10),
             ContinuousDimension(name="ccp_alpha", min=0.0, max=2**10),
-            DiscreteDimension(name="min_samples_to_fit", min=1, max=2 ** 32),
-            DiscreteDimension(name="n_new_samples_before_refit", min=1, max=2**32)
+            DiscreteDimension(name="min_samples_to_fit", min=1, max=32),
+            DiscreteDimension(name="n_new_samples_before_refit", min=1, max=32)
         ]
     ),
     default=Point(

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/HomogeneousRandomForestConfigStore.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/HomogeneousRandomForestConfigStore.py
@@ -10,9 +10,9 @@ homogeneous_random_forest_config_store = ComponentConfigStore(
     parameter_space=SimpleHypergrid(
         name="homogeneous_random_forest_regression_model_config",
         dimensions=[
-            DiscreteDimension(name="n_estimators", min=1, max=10000),
+            DiscreteDimension(name="n_estimators", min=1, max=256),
             ContinuousDimension(name="features_fraction_per_estimator", min=0, max=1, include_min=False, include_max=True),
-            ContinuousDimension(name="samples_fraction_per_estimator", min=0, max=1, include_min=False, include_max=True),
+            ContinuousDimension(name="samples_fraction_per_estimator", min=0.2, max=1, include_min=False, include_max=True),
             CategoricalDimension(name="regressor_implementation", values=[DecisionTreeRegressionModel.__name__]),
             CategoricalDimension(name="bootstrap", values=[True, False])
         ]


### PR DESCRIPTION
Most changes here were informed by repeatedly running the optimizer- I estimate that within the last month it completed somewhere between 10,000 and 30,000 complete optimization runs against synthetic functions including:
- polynomial objective: 2D, degree 2, various domain sizes, various coefficient of variations
- nested polynomial objective: 5 2D, 2nd degree polynomials for a total of 11 parameters (one of which was categorical)
- multilevel quadratic

Each time, the optimizer was run with a different configuration (many of which were chosen at random). What became apparent is that many of the parameters exposed by the optimizer have ranges that are too wide and either turn the entire process into random search (e.g.: min_samples_to_fit = 100000), or make it prohibitively expensive (e.g.: num_trees = 100000). 

This PR narrows those ranges.
