### PR TITLE
Small feature additions to tracer and to logger

### DIFF
--- a/source/Mlos.Python/mlos/Logger.py
+++ b/source/Mlos.Python/mlos/Logger.py
@@ -23,22 +23,21 @@ class BufferingHandler(logging.StreamHandler):
 
     def emit(self, record):
         if self.level <= record.levelno:
-            event = {
-                'timestamp': record.asctime,
-                'level': record.levelname,
-                'filename': record.filename,
-                'line': record.lineno,
-                'function': record.funcName,
-                'message': record.message.replace("'", '"'),
-                'exception_text': record.exc_text.replace("'", '"') if record.exc_text is not None else None
-            }
-            self.buffered_log_records.append(event)
+            self.buffered_log_records.append(record)
 
     def get_records(self, clear_buffer=False):
         records = self.buffered_log_records
         if clear_buffer:
-            self.buffered_log_records = []
+            self.clear()
         return records
+
+    def clear(self):
+        self.buffered_log_records = []
+
+    def dump_to_file(self, output_file_path):
+        with open(output_file_path, 'a+') as out_file:
+            for record in self.buffered_log_records:
+                out_file.write(self.format(record=record))
 
 
 def create_logger(logger_name, create_console_handler=True, create_file_handler=False, create_buffering_handler=False, logging_level=logging.INFO):

--- a/source/Mlos.Python/mlos/Tracer.py
+++ b/source/Mlos.Python/mlos/Tracer.py
@@ -5,6 +5,7 @@
 from contextlib import contextmanager
 from functools import wraps
 import json
+import os
 import time
 from threading import current_thread
 from typing import Dict
@@ -66,7 +67,7 @@ def trace():
 def add_trace_event(name, phase, category='', timestamp_ns=None, actor_id=None, thread_id=None, arguments=None):
     tracer = getattr(global_values, 'tracer', None)
     if tracer is not None:
-        global_values.tracer.add_trace_event(
+        tracer.add_trace_event(
             name,
             phase,
             timestamp_ns=timestamp_ns,
@@ -80,14 +81,15 @@ def add_trace_event(name, phase, category='', timestamp_ns=None, actor_id=None, 
 @contextmanager
 def traced(scope_name):
     start_timestamp_ns = int(time.time() * 1000000)
-    add_trace_event(name=scope_name, phase="B", timestamp_ns=start_timestamp_ns)
+    thread_id = current_thread().ident
+    add_trace_event(name=scope_name, phase="B", timestamp_ns=start_timestamp_ns, thread_id=thread_id)
 
     yield
 
     end_timestamp_ns = int(time.time() * 1000000)
     while end_timestamp_ns <= start_timestamp_ns:
         end_timestamp_ns += 100
-    add_trace_event(name=scope_name, phase="E", timestamp_ns=end_timestamp_ns)
+    add_trace_event(name=scope_name, phase="E", timestamp_ns=end_timestamp_ns, thread_id=thread_id)
 
 
 class Tracer:
@@ -95,14 +97,27 @@ class Tracer:
 
     """
 
-    def __init__(self, actor_id, thread_id):
+    def __init__(self, actor_id=None, thread_id=None):
+        pid = os.getpid()
+
+        if actor_id is None:
+            actor_id = pid
+        else:
+            actor_id = f"{actor_id}.{pid}"
         self.actor_id = actor_id
+
+        if thread_id is None:
+            thread_id = current_thread().ident
         self.thread_id = thread_id
         self._trace_events = []
 
     @property
     def trace_events(self):
         return self._trace_events
+
+    @trace_events.setter
+    def trace_events(self, value):
+        self._trace_events = value
 
     @staticmethod
     def reformat_events(events):


### PR DESCRIPTION
Really small features that I've had to add to Tracer and to Logger. Basically, when after each optimization run, I want to have an EvaluationReport that contains the tracer events, and all the log records (along with goodness of fit metrics over time etc.). I also want to be able to pickle/unpickle them and to dump them to files. 

Furthermore, the evaluation uses multiprocessing, so capturing the PID in the Traces helps disambiguate events from different runs and render them pretty.

Tracer:
* we capture thread id and PID with traced events

Logger:
* we save the record as is, instead of turning it into a dictionary. This is a minor perf improvement, but it also allows us to use the formatter specified by the user when dumping records to file.
* we can dump traces to file now. 