### PR TITLE
Fixed a bug that caused intermitted test failures

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/OptimizerBase.py
+++ b/source/Mlos.Python/mlos/Optimizers/OptimizerBase.py
@@ -139,7 +139,7 @@ class OptimizerBase(ABC):
 
             # Drop nulls and zeroes.
             #
-            predictions_df = predictions_df[predictions_df[dof_column_name].notna() & predictions_df[dof_column_name] != 0]
+            predictions_df = predictions_df[predictions_df[dof_column_name].notna() & (predictions_df[dof_column_name] != 0)]
 
             if len(predictions_df.index) == 0:
                 raise ValueError("Insufficient data to compute confidence-bound based optimum.")

--- a/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
@@ -441,7 +441,7 @@ class TestBayesianOptimizer(unittest.TestCase):
             #
             predictions_df = predictions_df[
                 predictions_df[Prediction.LegalColumnNames.PREDICTED_VALUE_DEGREES_OF_FREEDOM.value].notna() &
-                predictions_df[Prediction.LegalColumnNames.PREDICTED_VALUE_DEGREES_OF_FREEDOM.value] != 0
+                (predictions_df[Prediction.LegalColumnNames.PREDICTED_VALUE_DEGREES_OF_FREEDOM.value] != 0)
             ]
 
             if len(predictions_df.index) == 0:


### PR DESCRIPTION
Basically, the absence of parentheses in this expression: 

`predictions_df[dof_column_name].notna() & (predictions_df[dof_column_name] != 0)`

Messed up the order of operations, which resulted in classifying essentially random rows as containing nulls or having insufficient degrees of freedom. Occasionally, a row containing an optimum would be removed and that's when our assert fired.

We need more asserts.