### PR TITLE
use "editable" mode when pip installing mlos for unit test pipelines

### DIFF
--- a/build/Mlos.Cpp.UnitTest.cmake
+++ b/build/Mlos.Cpp.UnitTest.cmake
@@ -40,7 +40,7 @@ set_tests_properties(CheckForMlosSharedMemories PROPERTIES
 # Now other test can add "MlosSharedMemoriesChecks" to their
 # "FIXTURES_REQUIRED" property to invoke these scripts before/after themselves.
 add_test(NAME LocalPipInstallMlos
-    COMMAND ${PYTHON3} -m pip install ${MLOS_ROOT}/source/Mlos.Python)
+    COMMAND ${PYTHON3} -m pip install -e ${MLOS_ROOT}/source/Mlos.Python)
 add_test(NAME StartMlosOptimizerService
     COMMAND ${MLOS_ROOT}/build/CMakeHelpers/BackgroundProcessHelper.sh
         start /tmp/mlos_optimizer_microservice.pid /tmp/mlos_optimizer_microservice.log


### PR DESCRIPTION
Minor issue I noticed while working on debugging help for #60.

When run through the cmake unit tests on an otherwise clean environment, we pip install mlos without marking it editable.  This makes live debugging confusing since the edits don't seem to take effect when re-running the microservice.