### PR TITLE
Registering multiple objectives

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/BayesianOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/BayesianOptimizer.py
@@ -48,7 +48,7 @@ class BayesianOptimizer(OptimizerBase):
         OptimizerBase.__init__(self, optimization_problem)
 
         # Since the optimization_problem.objective_space can now be multi-dimensional (as a milestone towards multi-objective
-        # optimization), we have to prepare a smaller search space for the surrogate model.
+        # optimization), we have to prepare a smaller objective space for the surrogate model.
         # TODO: create multiple models each predicting a different objective. Also consider multi-objective models.
         #
         assert not optimization_problem.objective_space.is_hierarchical(), "Not supported."

--- a/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
@@ -441,8 +441,32 @@ class TestBayesianOptimizer:
 
             optimizer.register(input.to_dataframe(), output.to_dataframe())
 
-        prediction = optimizer.predict(feature_values_pandas_frame=input.to_dataframe())
-        print(prediction.get_dataframe())
+        num_predictions = 100
+        prediction = optimizer.predict(feature_values_pandas_frame=input_space.random_dataframe(num_predictions))
+        prediction_df = prediction.get_dataframe()
+        assert len(prediction_df.index) == num_predictions
+
+        # Let's test invalid observations.
+        #
+        input = input_space.random()
+        input_df = input.to_dataframe()
+
+        # We should only remember the valid dimensions.
+        #
+        output_with_extra_dimension = Point(y_1=input.x_1, y_2=input.x_2, invalid_dimension=42)
+        output_with_extra_dimension_df = output_with_extra_dimension.to_dataframe()
+        optimizer.register(input_df, output_with_extra_dimension_df)
+
+        # Let's make sure that the invalid_dimension was not remembered.
+        #
+        all_inputs_df, all_outputs_df = optimizer.get_all_observations()
+        assert all(column.value for column in all_inputs_df.columns in {'y_1', 'y_2'})
+
+
+
+
+
+
 
     def validate_optima(self, optimizer: OptimizerBase):
         should_raise_for_predicted_value = False

--- a/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/unit_tests/TestBayesianOptimizer.py
@@ -488,13 +488,6 @@ class TestBayesianOptimizer:
             optimizer.register(input_df, only_invalid_outputs_df)
 
 
-
-
-
-
-
-
-
     def validate_optima(self, optimizer: OptimizerBase):
         should_raise_for_predicted_value = False
         should_raise_for_confidence_bounds = False


### PR DESCRIPTION
This PR is a first step towards multi-objective optimization.

It's really simple: the user can now define an objective space that's multi-dimensional. Subsequently the user can register observations that contain values for one or more of those objectives. 

Still, only one objective is optimized. Effectively, all those extra objectives are remembered, but ignored.

