### PR TITLE
Initial work to add gcc support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,9 +227,6 @@ jobs:
             cc: clang-10
           - cxx: g++
             cc: gcc
-        exclude:
-          - UbuntuVersion: 16.04
-            cxx: g++
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,7 @@ jobs:
         #load: true
 
   linux-build-test:
-    name: Ubuntu ${{ matrix.UbuntuVersion }} ${{ matrix.configuration }} build/test C++/C#
+    name: Ubuntu ${{ matrix.UbuntuVersion }} ${{ matrix.configuration }} build/test C++/C# (${{ matrix.cxx }})
     runs-on: ubuntu-latest
     needs: [prep-vars, docker-image-cached-build]
     timeout-minutes: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,7 @@ jobs:
         #load: true
 
   linux-build-test:
-    name: Ubuntu ${{ matrix.UbuntuVersion }} ${{ matrix.configuration }} build/test C++/C# (${{ matrix.cxx }})
+    name: Ubuntu ${{ matrix.UbuntuVersion }} ${{ matrix.configuration }} ${{ matrix.cxx }} build/test C++/C#
     runs-on: ubuntu-latest
     needs: [prep-vars, docker-image-cached-build]
     timeout-minutes: 30
@@ -285,7 +285,7 @@ jobs:
       run: |
         docker exec mlos-${{ matrix.configuration }}-build-ubuntu-${{ matrix.UbuntuVersion }} \
           make dotnet-test
-    - name: Run ${{ matrix.configuration }} cmake build
+    - name: Run ${{ matrix.configuration }} cmake build (CXX=${{ matrix.cxx }})
       timeout-minutes: 5
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,7 +267,6 @@ jobs:
     - name: Start ${{ matrix.configuration }} docker instance for Ubuntu ${{ matrix.UbuntuVersion }}
       shell: bash
       run: |
-        echo $UID
         docker run -it -d -v $PWD:/src/MLOS -u $UID --env CONFIGURATION=${{ matrix.configuration }} \
           --env CC=${{ matrix.cc }} --env CXX=${{ matrix.cxx }} \
           --name mlos-${{ matrix.Configuration }}-build-ubuntu-${{ matrix.UbuntuVersion }} \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,9 @@ jobs:
             cc: clang-10
           - cxx: g++
             cc: gcc
+        exclude:
+          - UbuntuVersion: 16.04
+            cxx: g++
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,6 +221,12 @@ jobs:
       matrix:
         UbuntuVersion: ${{ fromJson(needs.prep-vars.outputs.UbuntuVersionMatrix) }}
         configuration: [Debug, Release]
+        cxx: [clang++-10, g++]
+        include:
+          - cxx: clang++-10
+            cc: clang-10
+          - cxx: g++
+            cc: gcc
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -260,6 +266,7 @@ jobs:
       run: |
         echo $UID
         docker run -it -d -v $PWD:/src/MLOS -u $UID --env CONFIGURATION=${{ matrix.configuration }} \
+          --env CC=${{ matrix.cc }} --env CXX=${{ matrix.cxx }} \
           --name mlos-${{ matrix.Configuration }}-build-ubuntu-${{ matrix.UbuntuVersion }} \
           mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:${{ github.sha }}
     - name: Setup local user in docker Container

--- a/build.linux.sh
+++ b/build.linux.sh
@@ -60,8 +60,15 @@ if [ "$CAKE_VERSION" != "$CAKE_INSTALLED_VERSION" ]; then
     fi
 fi
 
-#export CC=/usr/bin/clang-$CLANG_VERSION
-#export CXX=/usr/bin/clang++-$CLANG_VERSION
+if [ "$CC" == '' ] || [ "$CXX" == '' ]; then
+    echo "Defaulting to CXX=clang++-$CLANG_VERSION"
+    export CC=/usr/bin/clang-$CLANG_VERSION
+    export CXX=/usr/bin/clang++-$CLANG_VERSION
+fi
+
+if [ -z "$(which "$CXX" || true)" ]; then
+    echo "WARNING: CXX=$CXX not found." >&2
+fi
 
 $CXX --version
 

--- a/build.linux.sh
+++ b/build.linux.sh
@@ -55,13 +55,13 @@ if [ "$CAKE_VERSION" != "$CAKE_INSTALLED_VERSION" ]; then
     dotnet tool install Cake.Tool --tool-path "$TOOLS_DIR" --version $CAKE_VERSION
 
     if [ $? -ne 0 ]; then
-        echo "An error occured while installing Cake."
+        echo "An error occurred while installing Cake."
         exit 1
     fi
 fi
 
-export CC=/usr/bin/clang-$CLANG_VERSION
-export CXX=/usr/bin/clang++-$CLANG_VERSION
+#export CC=/usr/bin/clang-$CLANG_VERSION
+#export CXX=/usr/bin/clang++-$CLANG_VERSION
 
 $CXX --version
 

--- a/build/Common.mk
+++ b/build/Common.mk
@@ -19,10 +19,11 @@ MKDIR	:= mkdir -p
 
 # We currently depend on clang due to use of __declspec(selectany) and other
 # attributes in the codegen output.
-ifeq ($(CC),)
+# gcc is now in part supported, but we still prefer clang if available
+ifeq ($(origin CC),default)
     CC  := clang-10
 endif
-ifeq ($(CXX),)
+ifeq ($(origin CXX),default)
     CXX := clang++-10
 endif
 export CC

--- a/build/Common.mk
+++ b/build/Common.mk
@@ -19,8 +19,12 @@ MKDIR	:= mkdir -p
 
 # We currently depend on clang due to use of __declspec(selectany) and other
 # attributes in the codegen output.
-CC	:= clang-10
-CXX	:= clang++-10
+ifeq ($(CC),)
+    CC  := clang-10
+endif
+ifeq ($(CXX),)
+    CXX := clang++-10
+endif
 export CC
 export CXX
 

--- a/build/Mlos.Cpp.cmake
+++ b/build/Mlos.Cpp.cmake
@@ -18,11 +18,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 add_link_options(-Wall -Wextra -Wpedantic -Werror)
 
-# The codegen output currently relies on __declspec(selectany) attributes to
-# instruct the linker to ignore extra definitions resulting from including the
+# The codegen output currently relies on asking the compiler to select one of
+# our equivalent but duplicative definitions that results from including the
 # same header in multiple places.
-# NOTE: This option is only available with clang, not gcc.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdeclspec")
+# For clang, make use of the original __declspec(selectany) attributes that msvc
+# uses.
+# For gcc, we use __attribute__((weak)) to achieve the same.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdeclspec")
+endif()
 
 # When compiling for Debug build, make sure that DEBUG is defined for the compiler.
 # This is to mimic MSVC behavior so that our #ifdefs can remain the same rather
@@ -33,27 +37,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 # TODO: For optimized builds, strip them and keep the symbols separately.
 add_compile_options(-g)
 add_link_options(-g)
-
-# TODO: Search for clang compiler and set the appropriate C/CXX compiler variables.
-#if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-#    # TODO: Add local version of clang to use?
-#    find_program(CLANGCPP
-#        NAMES clang++-10
-#        #PATHS ENV PATH
-#        )
-#    if(CLANGCPP)
-#        message(WARNING "Forcing CXX compiler to ${CLANGCPP}")
-#        set(CMAKE_CXX_COMPILER ${CLANGPP})
-#        set(CMAKE_CXX_COMPILER_ID "Clang")
-#    endif()
-#endif()
-
-# For now we just abort if Clang is not the compiler selected.
-if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-    message(SEND_ERROR
-        "MLOS currently only supports clang (not '${CMAKE_CXX_COMPILER_ID}') for compilation.\n"
-        "Please re-run (c)make with 'CC=clang-10 CXX=clang++-10' set.\n")
-endif()
 
 # https://github.com/google/sanitizers/wiki/AddressSanitizer
 #

--- a/build/Mlos.Cpp.cmake
+++ b/build/Mlos.Cpp.cmake
@@ -21,8 +21,7 @@ add_link_options(-Wall -Wextra -Wpedantic -Werror)
 # The codegen output currently relies on asking the compiler to select one of
 # our equivalent but duplicative definitions that results from including the
 # same header in multiple places.
-# For clang, make use of the original __declspec(selectany) attributes that msvc
-# uses.
+# For clang, make use of the original __declspec(selectany) attributes that msvc uses.
 # For gcc, we use __attribute__((weak)) to achieve the same.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdeclspec")

--- a/build/Mlos.Cpp.cmake
+++ b/build/Mlos.Cpp.cmake
@@ -18,15 +18,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 add_link_options(-Wall -Wextra -Wpedantic -Werror)
 
-# The codegen output currently relies on asking the compiler to select one of
-# our equivalent but duplicative definitions that results from including the
-# same header in multiple places.
-# For clang, make use of the original __declspec(selectany) attributes that msvc uses.
-# For gcc, we use __attribute__((weak)) to achieve the same.
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdeclspec")
-endif()
-
 # When compiling for Debug build, make sure that DEBUG is defined for the compiler.
 # This is to mimic MSVC behavior so that our #ifdefs can remain the same rather
 # than having to switch to using NDEBUG.

--- a/build/Mlos.Cpp.cmake
+++ b/build/Mlos.Cpp.cmake
@@ -55,19 +55,6 @@ if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
         "Please re-run (c)make with 'CC=clang-10 CXX=clang++-10' set.\n")
 endif()
 
-# TODO: This just finds the program, but doesn't actually enable it as a
-# target.  To use clang-tidy, we will need to provide a .clang-format config
-# and probably reformat some code again.
-find_program(CLANG_TIDY NAMES clang-tidy clang-tidy-6.0)
-if(CLANG_TIDY)
-    add_custom_target(
-        clang-tidy
-        COMMAND ${CLANG_TIDY}
-        ${SOURCE_FILES}
-        --
-        -I ${CMAKE_SOURCE_DIR}/include)
-endif()
-
 # https://github.com/google/sanitizers/wiki/AddressSanitizer
 #
 option(ADDRESS_SANITIZER "Enable Clang AddressSanitizer" OFF)

--- a/source/Examples/SmartCache/Main.cpp
+++ b/source/Examples/SmartCache/Main.cpp
@@ -52,7 +52,6 @@ void ThrowIfFail(HRESULT hr)
 }
 
 int
-MLOS_CDECL_ATTR
 main(
     _In_ int argc,
     _In_ char* argv[])

--- a/source/Examples/SmartCache/Main.cpp
+++ b/source/Examples/SmartCache/Main.cpp
@@ -52,7 +52,7 @@ void ThrowIfFail(HRESULT hr)
 }
 
 int
-__cdecl
+MLOS_CDECL_ATTR
 main(
     _In_ int argc,
     _In_ char* argv[])

--- a/source/Examples/SmartSharedChannel/Main.cpp
+++ b/source/Examples/SmartSharedChannel/Main.cpp
@@ -72,7 +72,6 @@ void AssertFailed(
 // NOTES:
 //
 int
-MLOS_CDECL_ATTR
 main(
     _In_ int argc,
     _In_ char* argv[])

--- a/source/Examples/SmartSharedChannel/Main.cpp
+++ b/source/Examples/SmartSharedChannel/Main.cpp
@@ -72,7 +72,7 @@ void AssertFailed(
 // NOTES:
 //
 int
-__cdecl
+MLOS_CDECL_ATTR
 main(
     _In_ int argc,
     _In_ char* argv[])

--- a/source/Mlos.Core/Mlos.Core.h
+++ b/source/Mlos.Core/Mlos.Core.h
@@ -75,12 +75,11 @@ constexpr int32_t INVALID_FD_VALUE = -1;
 #define MLOS_UNUSED_ARG(x) (void)x
 
 #ifdef _MSC_VER
-#define MLOS_SELECTANY_LINKER_ATTR __declspec(selectany)
+#define MLOS_SELECTANY_ATTR __declspec(selectany)
 #elif __clang__
-// Note: this requires compiling with -fdeclspec.
-#define MLOS_SELECTANY_LINKER_ATTR __declspec(selectany)
+#define MLOS_SELECTANY_ATTR __attribute__((weak))
 #elif __GNUC__
-#define MLOS_SELECTANY_LINKER_ATTR __attribute__((weak))
+#define MLOS_SELECTANY_ATTR __attribute__((weak))
 #else
 #warning Unhandled compiler.
 #endif

--- a/source/Mlos.Core/Mlos.Core.h
+++ b/source/Mlos.Core/Mlos.Core.h
@@ -74,6 +74,21 @@ constexpr int32_t INVALID_FD_VALUE = -1;
 #define MLOS_RETAIL_ASSERT(result) { if (!result) Mlos::Core::MlosPlatform::TerminateProcess(); }
 #define MLOS_UNUSED_ARG(x) (void)x
 
+#ifdef _MSC_VER
+#define MLOS_SELECTANY_LINKER_ATTR __declspec(selectany)
+#define MLOS_CDECL_ATTR __cdecl
+#elif __clang__
+// Note: this requires compiling with -fdeclspec.
+#define MLOS_SELECTANY_LINKER_ATTR __declspec(selectany)
+#define MLOS_CDECL_ATTR __cdecl
+#elif __GNUC__
+#define MLOS_SELECTANY_LINKER_ATTR __attribute__((weak))
+// cdecl is unnecessary (and emits a warning) when compiling for x86-64, which is currently the only platform we support
+#define MLOS_CDECL_ATTR /* __attribute__((cdecl))__ */
+#else
+#warning Unhandled compiler.
+#endif
+
 #include "MlosPlatform.h"
 
 #include "BytePtr.h"

--- a/source/Mlos.Core/Mlos.Core.h
+++ b/source/Mlos.Core/Mlos.Core.h
@@ -76,15 +76,11 @@ constexpr int32_t INVALID_FD_VALUE = -1;
 
 #ifdef _MSC_VER
 #define MLOS_SELECTANY_LINKER_ATTR __declspec(selectany)
-#define MLOS_CDECL_ATTR __cdecl
 #elif __clang__
 // Note: this requires compiling with -fdeclspec.
 #define MLOS_SELECTANY_LINKER_ATTR __declspec(selectany)
-#define MLOS_CDECL_ATTR __cdecl
 #elif __GNUC__
 #define MLOS_SELECTANY_LINKER_ATTR __attribute__((weak))
-// cdecl is unnecessary (and emits a warning) when compiling for x86-64, which is currently the only platform we support
-#define MLOS_CDECL_ATTR /* __attribute__((cdecl))__ */
 #else
 #warning Unhandled compiler.
 #endif

--- a/source/Mlos.Core/ObjectDeserializationCallback.h
+++ b/source/Mlos.Core/ObjectDeserializationCallback.h
@@ -53,12 +53,12 @@ public:
     {
         DispatchTable<N + N1> result = {};
 
-        for (size_t i = 0; i < N; ++i)
+        for (size_t i = 0; i != N; ++i)
         {
             result[i] = (*this)[i];
         }
 
-        for (size_t i = 0; i < N1; ++i)
+        for (size_t i = 0; i != N1; ++i)
         {
             result[i + N] = arr[i];
         }

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeHandlerCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeHandlerCodeWriter.cs
@@ -49,7 +49,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
 
             // Define a global dispatch table.
             //
-            WriteLine("__declspec(selectany) ::Mlos::Core::DispatchEntry DispatchTable[] = ");
+            WriteLine("MLOS_SELECTANY_LINKER_ATTR ::Mlos::Core::DispatchEntry DispatchTable[] = ");
             WriteLine("{");
 
             IndentationLevel++;

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeHandlerCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeHandlerCodeWriter.cs
@@ -49,7 +49,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
 
             // Define a global dispatch table.
             //
-            WriteLine("MLOS_SELECTANY_LINKER_ATTR ::Mlos::Core::DispatchEntry DispatchTable[] = ");
+            WriteLine("MLOS_SELECTANY_ATTR ::Mlos::Core::DispatchEntry DispatchTable[] = ");
             WriteLine("{");
 
             IndentationLevel++;

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeRuntimeCallbackCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeRuntimeCallbackCodeWriter.cs
@@ -82,7 +82,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
             //
             string cppTypeNameAsField = $"{sourceType.Name}_Callback";
 
-            WriteLine($"__declspec(selectany) std::function<void ({cppProxyTypeFullName}&&)> {cppTypeNameAsField} = nullptr;");
+            WriteLine($"MLOS_SELECTANY_LINKER_ATTR std::function<void ({cppProxyTypeFullName}&&)> {cppTypeNameAsField} = nullptr;");
             WriteLine();
         }
 

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeRuntimeCallbackCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectDeserializeRuntimeCallbackCodeWriter.cs
@@ -82,7 +82,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
             //
             string cppTypeNameAsField = $"{sourceType.Name}_Callback";
 
-            WriteLine($"MLOS_SELECTANY_LINKER_ATTR std::function<void ({cppProxyTypeFullName}&&)> {cppTypeNameAsField} = nullptr;");
+            WriteLine($"MLOS_SELECTANY_ATTR std::function<void ({cppProxyTypeFullName}&&)> {cppTypeNameAsField} = nullptr;");
             WriteLine();
         }
 

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectGetVariableDataSizeCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectGetVariableDataSizeCodeWriter.cs
@@ -43,7 +43,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
         public override void WriteEndFile()
         {
             IndentationLevel--;
-            WriteLine("};");
+            WriteLine("}");
             WriteLine();
         }
 

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectSerializationVariableDataCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppObjectSerializationVariableDataCodeWriter.cs
@@ -50,7 +50,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
         public override void WriteEndFile()
         {
             IndentationLevel--;
-            WriteLine("};");
+            WriteLine("}");
             WriteLine();
         }
 
@@ -99,7 +99,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
             WriteLine("return totalDataSize;");
             IndentationLevel--;
 
-            WriteLine("};");
+            WriteLine("}");
             WriteLine();
         }
 

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppProxyVerifyVariableDataCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppProxyVerifyVariableDataCodeWriter.cs
@@ -40,7 +40,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
         public override void WriteEndFile()
         {
             IndentationLevel--;
-            WriteLine("};");
+            WriteLine("}");
             WriteLine();
         }
 

--- a/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppTypeReflectionTableCodeWriter.cs
+++ b/source/Mlos.SettingsSystem.CodeGen/CodeWriters/CppObjectExchangeCodeWriters/CppTypeReflectionTableCodeWriter.cs
@@ -84,7 +84,7 @@ namespace Mlos.SettingsSystem.CodeGen.CodeWriters.CppObjectExchangeCodeWriters
             // Write a class name using std::array.
             // std::array<5, char> = { 'C', 'l', 'a', 's', 's', '\0' };
             //
-            WriteLine($"std::array<char, {nameLength}> TypeName_{cppClassName} =  {{ {string.Join(",", cppClassName.Select(r => $"'{r}'"))}, '\\0' }};");
+            WriteLine($"std::array<char, {nameLength}> TypeName_{cppClassName} {{{{ {string.Join(",", cppClassName.Select(r => $"'{r}'"))}, '\\0' }}}};");
 
             metadataOffset += nameLength + sizeof(uint);
 

--- a/source/Mlos.UnitTest/Main.cpp
+++ b/source/Mlos.UnitTest/Main.cpp
@@ -29,7 +29,6 @@ using ::testing::TestPartResult;
 using ::testing::UnitTest;
 
 int
-MLOS_CDECL_ATTR
 main(
     _In_ int argc,
     _In_ char* argv[])

--- a/source/Mlos.UnitTest/Main.cpp
+++ b/source/Mlos.UnitTest/Main.cpp
@@ -29,7 +29,7 @@ using ::testing::TestPartResult;
 using ::testing::UnitTest;
 
 int
-__cdecl
+MLOS_CDECL_ATTR
 main(
     _In_ int argc,
     _In_ char* argv[])

--- a/source/Mlos.UnitTest/SharedChannelTests.cpp
+++ b/source/Mlos.UnitTest/SharedChannelTests.cpp
@@ -26,7 +26,7 @@ public:
     }
 
 private:
-    std::array<byte, T> array {{ 0 }};
+    std::array<byte, T> array { { 0 } };
 };
 
 namespace SharedChannelTests

--- a/source/Mlos.UnitTest/SharedChannelTests.cpp
+++ b/source/Mlos.UnitTest/SharedChannelTests.cpp
@@ -222,8 +222,8 @@ TEST(SharedChannel, VerifySendingReceivingArrayStruct)
     //
     ObjectDeserializationCallback::Mlos::UnitTest::Line_Callback = [line](Proxy::Mlos::UnitTest::Line&& recvLine)
         {
-            EXPECT_EQ(recvLine.Points()[0].X(), 3.0);
-            EXPECT_EQ(recvLine.Points()[0].Y(), 5);
+            EXPECT_EQ(recvLine.Points()[0].X(), line.Points[0].X);
+            EXPECT_EQ(recvLine.Points()[0].Y(), line.Points[0].Y);
             EXPECT_EQ(recvLine.Points()[1].X(), 7);
             EXPECT_EQ(recvLine.Points()[1].Y(), 9);
             EXPECT_EQ(recvLine.Height()[0], 1.3f);
@@ -368,6 +368,7 @@ TEST(SharedChannel, StressSendReceive)
     bool result =
         resultFromWriter1.get() &&
         resultFromWriter2.get();
+    MLOS_UNUSED_ARG(result);
 
     sharedChannel.SendMessage(Mlos::Core::TerminateReaderThreadRequestMessage());
 

--- a/source/Mlos.UnitTest/SharedChannelTests.cpp
+++ b/source/Mlos.UnitTest/SharedChannelTests.cpp
@@ -29,7 +29,7 @@ private:
     std::array<byte, T> array = { 0 };
 };
 
-namespace
+namespace SharedChannelTests
 {
 #ifndef DEBUG
 // Verify buffer size.
@@ -212,7 +212,7 @@ TEST(SharedChannel, VerifySendingReceivingArrayStruct)
     ChannelSynchronization sync = {};
     TestSharedChannel sharedChannel(sync, buffer, 128);
 
-    Mlos::UnitTest::Line line;
+    Mlos::UnitTest::Line line = {};
     line.Points[0] = { 3, 5 };
     line.Points[1] = { 7, 9 };
     line.Height = { 1.3f, 3.9f };
@@ -376,5 +376,7 @@ TEST(SharedChannel, StressSendReceive)
     result =
         resultFromReader1.get() &&
         resultFromReader2.get();
+
+    EXPECT_EQ(result, true);
 }
 }

--- a/source/Mlos.UnitTest/SharedChannelTests.cpp
+++ b/source/Mlos.UnitTest/SharedChannelTests.cpp
@@ -26,7 +26,7 @@ public:
     }
 
 private:
-    std::array<byte, T> array = { 0 };
+    std::array<byte, T> array {{ 0 }};
 };
 
 namespace SharedChannelTests


### PR DESCRIPTION
Initial work to enable gcc support #23 

Started as a hack to workaround cmake's FetchContent not appearing to pass the CMAKE_COMPILER_ID through when building with CXX=clang++-10

This also fixes a few minor issues that gcc complained about.

- [x] Enable CI pipeline tests