### PR TITLE
Windows build fixups for recent MSBuild tool versions

### DIFF
--- a/build/Mlos.Cpp.UnitTest.targets
+++ b/build/Mlos.Cpp.UnitTest.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(PkgGoogleTest)\build\native\googletest.targets" />
+  <Import Project="$(PkgGoogleTest)\build\native\googletest.targets" Condition="'$(Linkage-googletest)' == ''" />
   <ItemDefinitionGroup Label="x64 and v141 and Release" Condition="'$(Platform.ToLower())' == 'x64' And ( $(Configuration.ToLower().IndexOf('debug')) == -1 )">
     <Link>
       <AdditionalDependencies>$(PkgGoogleTest)/build/native/lib/x64/v141/Release/googletest_v141.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/source/Examples/SmartCache/SmartCache.vcxproj
+++ b/source/Examples/SmartCache/SmartCache.vcxproj
@@ -40,7 +40,7 @@
     <ClInclude Include="Workloads.h" />
   </ItemGroup>
   <ItemGroup Label="SettingsRegistry">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\SmartCache.SettingsRegistry\SmartCache.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\SmartCache.SettingsRegistry\SmartCache.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\SmartCache\SettingsProvider_gen_base.h" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\SmartCache\SettingsProvider_gen_callbacks.h" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\SmartCache\SettingsProvider_gen_dispatch.h" />

--- a/source/Examples/SmartSharedChannel/SmartSharedChannel.vcxproj
+++ b/source/Examples/SmartSharedChannel/SmartSharedChannel.vcxproj
@@ -12,8 +12,8 @@
     <ProjectReference Include="$(SourceDir)\Mlos.Core\Mlos.Core.vcxproj" />
   </ItemGroup>
   <ItemGroup Label="SettingsRegistry">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\SmartSharedChannel.SettingsRegistry\SmartSharedChannel.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" />
-    <ProjectReference Include="$(SourceDir)\Mlos.UnitTest\Mlos.UnitTest.SettingsRegistry\Mlos.UnitTest.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\SmartSharedChannel.SettingsRegistry\SmartSharedChannel.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="$(SourceDir)\Mlos.UnitTest\Mlos.UnitTest.SettingsRegistry\Mlos.UnitTest.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\SmartSharedChannel\SettingsProvider_gen_base.h" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\SmartSharedChannel\SettingsProvider_gen_callbacks.h" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\SmartSharedChannel\SettingsProvider_gen_dispatch.h" />

--- a/source/Mlos.UnitTest/Mlos.UnitTest.vcxproj
+++ b/source/Mlos.UnitTest/Mlos.UnitTest.vcxproj
@@ -45,7 +45,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup Label="Components">
-    <ProjectReference Include="$(SourceDir)\Mlos.UnitTest\Mlos.UnitTest.SettingsRegistry\Mlos.UnitTest.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="$(SourceDir)\Mlos.UnitTest\Mlos.UnitTest.SettingsRegistry\Mlos.UnitTest.SettingsRegistry.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\Mlos.UnitTest\SettingsProvider_gen_base.h" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\Mlos.UnitTest\SettingsProvider_gen_callbacks.h" />
     <ClInclude Include="$(MlosCodeGenOutputPathRoot)\Mlos.UnitTest\SettingsProvider_gen_dispatch.h" />


### PR DESCRIPTION
Github bumped the version of msbuild tools on Windows runners for our Github Action CI pipeline:
https://github.com/actions/virtual-environments/commit/9a16e36b2847d6e56ba0ff3c0bd275674f1988cc#diff-816219d3c9f30fcc1c40f88ca826c1662bf99eded781c1b419dd2dfb577ae227L216

This exposed a few build authoring issues we had on Windows.  This PR should fix those.