### PR TITLE
Avoid some broken cmake package versions in Docker image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ docker-image:
 	    --build-arg=http_proxy=${http_proxy} \
 	    -t mlos-build-ubuntu-$(UbuntuVersion)
 	@ echo Finished building mlos-build-ubuntu-$(UbuntuVersion) image.
-	@ echo Run "docker run -v $$PWD:/src/MLOS --name mlos-build mlos-build-ubuntu-$(UbuntuVersion)" to start an instance.
+	@ echo "Run 'docker run -v $$PWD:/src/MLOS --name mlos-build mlos-build-ubuntu-$(UbuntuVersion)' to start an instance."
 
 # Cleanup the outputs produced by cmake.
 .PHONY: cmake-distclean

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ endif
 .PHONY: docker-image
 docker-image:
 	docker pull ghcr.io/microsoft-cisl/mlos/mlos-build-ubuntu-$(UbuntuVersion):latest
-	docker build . --target $(MlosBuildImageTarget) \
+	docker build . $(DOCKER_BUILD_ARGS) --target $(MlosBuildImageTarget) \
 	    --build-arg=MlosBuildBaseArg=$(MlosBuildBaseArg) \
 	    --build-arg=UbuntuVersion=$(UbuntuVersion) \
 	    --build-arg=http_proxy=${http_proxy} \

--- a/scripts/install.cmake.sh
+++ b/scripts/install.cmake.sh
@@ -10,6 +10,17 @@ set -eu
 if ! [ -x /usr/bin/cmake ] || [ "${1:-}" == '--force-upgrade' ]; then
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
     set -x
+
+    sudo tee /etc/apt/preferences.d/avoid-broken-cmake-repo-package-versions <<'APT_PREFERENCES'
+Package: cmake
+Pin: version 3.19.0-0kitware1ubuntu20.04.1
+Pin-Priority: -1
+
+Package: cmake-data
+Pin: version 3.19.0-0kitware1ubuntu20.04.1
+Pin-Priority: -1
+APT_PREFERENCES
+
     sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ `lsb_release -c -s` main"
     sudo apt-get update
     sudo apt-get --no-install-recommends -y install cmake


### PR DESCRIPTION
At the moment the cmake apt repo we rely on has published newer cmake packages that specify a dependency that doesn't exist.  This breaks a clean cmake install (as we do during docker image build).

For the moment, we're adding that version to a rejectlist to workaround the issue.