### PR TITLE
rename test class to start with Test so pytest finds them

### DIFF
--- a/source/Mlos.Python/mlos/Spaces/unit_tests/TestSortedBinaryTree.py
+++ b/source/Mlos.Python/mlos/Spaces/unit_tests/TestSortedBinaryTree.py
@@ -9,7 +9,7 @@ from mlos.Spaces.Dimensions.SortedBinaryTree import SortedBinaryTree, Stack
 NUM_KEYS = 10000
 RANGE = 100 * NUM_KEYS
 
-class StackTest:
+class TestStack:
 
     def test_stack(self):
         stack = Stack()
@@ -26,7 +26,7 @@ class StackTest:
             assert True
 
 
-class SortedBinaryTreeTest:
+class TestSortedBinaryTree:
 
     def setup_method(self, method):
         self.random_sorted_binary_tree = SortedBinaryTree()


### PR DESCRIPTION
Fixes #178.

It's unclear to me whether unittest ran these. But they pass ;)