### PR TITLE
Use explicit codecov token to upload results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -546,6 +546,7 @@ jobs:
       if: ${{ github.repository == 'microsoft/mlos' }}
       uses: codecov/codecov-action@v1
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
         fail_ci_if_error: true


### PR DESCRIPTION
Attempting to fix the following error:

```
->  Pinging Codecov
https://codecov.io/upload/v4?package=github-action-20201130-cc6d3fe&token=secret&branch=main&commit=27c39e71a07b063cc2c59a3eb72609a722d17510&build=397032896&build_url=http%3A%2F%2Fgithub.com%2Fmicrosoft%2FMLOS%2Factions%2Fruns%2F397032896&name=&tag=&slug=microsoft%2FMLOS&service=github-actions&flags=unittests&pr=&job=&cmd_args=Q,f,n,F,Z
HTTP 400

ERROR: Tokenless uploads are only supported for public repositories on GitHub Actions that can be verified through the Actions API.
Please use an upload token if your repository is private and specify it via the -t flag. You can find the token for this repository
at the url below on codecov.io (login required):

Repo token: https://codecov.io/gh/microsoft/MLOS/settings
Documentation: https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token
```

See Also:
https://github.com/microsoft/MLOS/runs/1489105180?check_suite_focus=true