### PR TITLE
Avoid broken licenseheaders package version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -438,7 +438,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install licenseheaders
+        pip install 'licenseheaders!=0.8.6'
     - name: Run licenseheaders tool and check to see if it caused any changes
       shell: bash
       run: |


### PR DESCRIPTION
Avoids the following error:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.0/x64/bin/licenseheaders", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/site-packages/licenseheaders.py", line 612, in main
    arguments = parse_command_line(sys.argv)
  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/site-packages/licenseheaders.py", line 304, in parse_command_line
    known_extensions = [ftype+":"+",".join(conf["extensions"]) for ftype, conf in typeSettings.items()]
  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/site-packages/licenseheaders.py", line 304, in <listcomp>
    known_extensions = [ftype+":"+",".join(conf["extensions"]) for ftype, conf in typeSettings.items()]
KeyError: 'extensions'
Error: Process completed with exit code 1.
```