### PR TITLE
Workaround an issue uncovered by recent versions of sphinx

### DIFF
--- a/source/Mlos.Python/mlos/Spaces/Point.py
+++ b/source/Mlos.Python/mlos/Spaces/Point.py
@@ -58,7 +58,7 @@ class Point:
         try:
             return self[dimension_name]
         except KeyError:
-            return None
+            raise AttributeError(f"This Point does not have a {dimension_name} attribute.")
 
     def __setattr__(self, name, value):
         if name == "dimension_value_dict":

--- a/source/Mlos.Python/mlos/Spaces/Point.py
+++ b/source/Mlos.Python/mlos/Spaces/Point.py
@@ -55,7 +55,10 @@ class Point:
         if dimension_name == "__isabstractmethod__":
             # A sad but necessary way to deal with ABC.
             return False
-        return self[dimension_name]
+        try:
+            return self[dimension_name]
+        except KeyError:
+            return None
 
     def __setattr__(self, name, value):
         if name == "dimension_value_dict":

--- a/website/sphinx/apidoc.sh
+++ b/website/sphinx/apidoc.sh
@@ -22,7 +22,7 @@ $pythonCmd -m pip install -e $MLOS_ROOT/source/Mlos.Python/
 
 # Make sure we have up to date versions of the necessary packages (and their
 # dependencies) rather than falling back to any system provided ones.
-$pythonCmd -m pip install --upgrade sphinx sphinx_rtd_theme numpydoc matplotlib kiwisolver pillow
+$pythonCmd -m pip install --upgrade 'sphinx<3.4.0' sphinx_rtd_theme numpydoc matplotlib kiwisolver pillow
 
 # Make sure that the commands installed by pip are available on the PATH
 export PATH="$PATH:$HOME/.local/bin"

--- a/website/sphinx/apidoc.sh
+++ b/website/sphinx/apidoc.sh
@@ -22,7 +22,7 @@ $pythonCmd -m pip install -e $MLOS_ROOT/source/Mlos.Python/
 
 # Make sure we have up to date versions of the necessary packages (and their
 # dependencies) rather than falling back to any system provided ones.
-$pythonCmd -m pip install --upgrade 'sphinx<3.4.0' sphinx_rtd_theme numpydoc matplotlib kiwisolver pillow
+$pythonCmd -m pip install --upgrade sphinx sphinx_rtd_theme numpydoc matplotlib kiwisolver pillow
 
 # Make sure that the commands installed by pip are available on the PATH
 export PATH="$PATH:$HOME/.local/bin"


### PR DESCRIPTION
With sphinx 3.4.0-3.4.2 (released in late December 2020), sphinx generates
asserts by the Point module due to invalid keys (e.g. `__sphinx_mock__`) in the Point.

```txt
Exception occurred:
  File "/src/MLOS/source/Mlos.Python/mlos/Spaces/Point.py", line 75, in __getitem__
    raise KeyError(f"This Point does not have a value along dimension: {dimension_name}")
KeyError: 'This Point does not have a value along dimension: __sphinx_mock__'
```

Fixes #210 (at least enough that we can submit PRs and run the nightly CI jobs again)