### PR TITLE
Disable old docker package registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ name: CI
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
 on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Manual CI run'
   push:
     branches: [ main ]
   pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         scripts\package.windows.cmd
 
   # Docker build process overview:
-  # - We currently use the docker.pkg.github.com package registry as a staging
+  # - We started using the docker.pkg.github.com package registry as a staging
   # ground to cache the ":latest" version of the build image.
   # - For authentication we use the built-in GITHUB_TOKEN secret to avoid the
   # need to setup special secrets (see forked repo considerations below).
@@ -195,12 +195,6 @@ jobs:
         #  mlos-buildx-${{ matrix.UbuntuVersion }}-
         restore-keys: |
           mlos-buildx-${{ matrix.UbuntuVersion }}-${{ needs.prep-vars.outputs.utc-date }}-${{ needs.prep-vars.outputs.main-sha }}
-    - name: Github Docker Package Registry Login
-      uses: docker/login-action@v1
-      with:
-        registry: docker.pkg.github.com
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Github Docker Container Registry Login
       if: ${{ env.MLOS_GCR_USR != '' }}
       uses: docker/login-action@v1
@@ -217,9 +211,7 @@ jobs:
         # Even if the local cache doesn't have anything, allow using the latest published version.
         cache-from: |
           type=local,src=/tmp/.buildx-cache
-          docker.pkg.github.com/${{ needs.prep-vars.outputs.repository-name-tolower }}/mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:latest
           ghcr.io/${{ needs.prep-vars.outputs.repository-name-tolower }}/mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:latest
-          docker.pkg.github.com/microsoft/mlos/mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:latest
           ghcr.io/microsoft-cisl/mlos/mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:latest
         cache-to: type=local,dest=/tmp/.buildx-cache
         #load: true
@@ -688,24 +680,6 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         #cache-to: type=local,dest=/tmp/.buildx-cache
         load: true
-    # Now we can push the image to the local docker package repository.
-    # Note: Although this works well with the built in GITHUB_TOKEN secret,
-    # it requires a "docker login" to be able to pull (no anonymous pulls).
-    - name: Github Docker Package Registry Login
-      uses: docker/login-action@v1
-      with:
-        registry: docker.pkg.github.com
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Push the docker image to this repo's github docker package registry
-      timeout-minutes: 15
-      shell: bash
-      # We only push to the :latest tag, to avoid needing to cleanup the
-      # registry manually (there's currently no API for that).
-      run: |
-        docker tag mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:${{ github.sha }} \
-          docker.pkg.github.com/${{ needs.prep-vars.outputs.repository-name-tolower }}/mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:latest
-        docker push docker.pkg.github.com/${{ needs.prep-vars.outputs.repository-name-tolower }}/mlos-build-ubuntu-${{ matrix.UbuntuVersion }}:latest
     # Optionally push to the new Github Container Registry service, if the
     # current repo has the appropriate personal access token secrets setup.
     # This service allows anonymous pulls.


### PR DESCRIPTION
Our nightly CI jobs have been failing to push updated docker images recently.

We, along with lots of others, are experiencing an [`unknown blob` error issue](https://github.community/t/random-unknown-blob-error-when-pushing-to-docker-github-package-repository/16725/7) when pushing to the old docker.pkg.github.com package registry.

This registry was superseded by the ghcr.io Github Container Registry service:
https://github.blog/2020-09-01-introducing-github-container-registry/

We aren't using it anymore, so this changeset disables the use of the older registry to get the pipelines publishing to ghcr.io once again.