### PR TITLE
Adding start and end timestamps to the evaluation report

### DIFF
--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluationReport.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluationReport.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
+from datetime import datetime
 import json
 import os
 import pickle
@@ -45,7 +46,10 @@ class OptimizerEvaluationReport:
             optima_over_time: Dict[str, OptimumOverTime] = None,
             pareto_over_time: Dict[int, ParetoFrontier] = None,
             pareto_volume_over_time: Dict[int, Tuple[float, float]] = None,
-            execution_trace: List[Dict[str, object]] = None
+            execution_trace: List[Dict[str, object]] = None,
+            start_time: datetime = None,
+            end_time: datetime = None,
+            suggestion: Point = None
     ):
         self.success = False
         self.exception = None
@@ -66,6 +70,9 @@ class OptimizerEvaluationReport:
         self.execution_trace = execution_trace
         self.pareto_over_time = pareto_over_time if pareto_over_time is not None else dict()
         self.pareto_volume_over_time = pareto_volume_over_time if pareto_volume_over_time is not None else dict()
+        self.start_time = start_time
+        self.end_time = end_time
+        self.suggestion = suggestion
 
     def add_pickled_optimizer(self, iteration: int, pickled_optimizer: bytes):
         assert iteration >= 0
@@ -137,7 +144,9 @@ class OptimizerEvaluationReport:
                 'num_optimization_iterations': self.num_optimization_iterations,
                 'evaluation_frequency': self.evaluation_frequency,
                 'exception': str(self.exception) if self.exception is not None else None,
-                'exception_stack_trace': self.exception_traceback
+                'exception_stack_trace': self.exception_traceback,
+                'start_time': self.start_time.strftime("%d.%m.%Y.%H:%M:%S:%f"),
+                'end_time': self.end_time.strftime("%d.%m.%Y.%H:%M:%S:%f")
             }
             json.dump(execution_info_dict, out_file, indent=2)
 
@@ -204,5 +213,7 @@ class OptimizerEvaluationReport:
                 optimizer_evaluation_report.evaluation_frequency = execution_info_dict['evaluation_frequency']
                 optimizer_evaluation_report.exception = execution_info_dict['exception']
                 optimizer_evaluation_report.exception_traceback = execution_info_dict['exception_stack_trace']
+                optimizer_evaluation_report.start_time = datetime.strptime(execution_info_dict['start_time'], "%d.%m.%Y.%H:%M:%S:%f")
+                optimizer_evaluation_report.end_time = datetime.strptime(execution_info_dict['end_time'], "%d.%m.%Y.%H:%M:%S:%f")
 
         return optimizer_evaluation_report

--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluationReport.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluationReport.py
@@ -48,8 +48,7 @@ class OptimizerEvaluationReport:
             pareto_volume_over_time: Dict[int, Tuple[float, float]] = None,
             execution_trace: List[Dict[str, object]] = None,
             start_time: datetime = None,
-            end_time: datetime = None,
-            suggestion: Point = None
+            end_time: datetime = None
     ):
         self.success = False
         self.exception = None
@@ -72,7 +71,6 @@ class OptimizerEvaluationReport:
         self.pareto_volume_over_time = pareto_volume_over_time if pareto_volume_over_time is not None else dict()
         self.start_time = start_time
         self.end_time = end_time
-        self.suggestion = suggestion
 
     def add_pickled_optimizer(self, iteration: int, pickled_optimizer: bytes):
         assert iteration >= 0

--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluationReport.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluationReport.py
@@ -34,6 +34,8 @@ class OptimizerEvaluationReport:
         * execution trace as captured by the mlos.Tracer
     """
 
+    DATETIME_FORMAT = "%d.%m.%Y.%H:%M:%S:%f"
+
     def __init__(
             self,
             optimizer_configuration: Point = None,
@@ -143,8 +145,8 @@ class OptimizerEvaluationReport:
                 'evaluation_frequency': self.evaluation_frequency,
                 'exception': str(self.exception) if self.exception is not None else None,
                 'exception_stack_trace': self.exception_traceback,
-                'start_time': self.start_time.strftime("%d.%m.%Y.%H:%M:%S:%f"),
-                'end_time': self.end_time.strftime("%d.%m.%Y.%H:%M:%S:%f")
+                'start_time': self.start_time.strftime(self.DATETIME_FORMAT),
+                'end_time': self.end_time.strftime(self.DATETIME_FORMAT)
             }
             json.dump(execution_info_dict, out_file, indent=2)
 
@@ -211,7 +213,7 @@ class OptimizerEvaluationReport:
                 optimizer_evaluation_report.evaluation_frequency = execution_info_dict['evaluation_frequency']
                 optimizer_evaluation_report.exception = execution_info_dict['exception']
                 optimizer_evaluation_report.exception_traceback = execution_info_dict['exception_stack_trace']
-                optimizer_evaluation_report.start_time = datetime.strptime(execution_info_dict['start_time'], "%d.%m.%Y.%H:%M:%S:%f")
-                optimizer_evaluation_report.end_time = datetime.strptime(execution_info_dict['end_time'], "%d.%m.%Y.%H:%M:%S:%f")
+                optimizer_evaluation_report.start_time = datetime.strptime(execution_info_dict['start_time'], OptimizerEvaluationReport.DATETIME_FORMAT)
+                optimizer_evaluation_report.end_time = datetime.strptime(execution_info_dict['end_time'], OptimizerEvaluationReport.DATETIME_FORMAT)
 
         return optimizer_evaluation_report

--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluator.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluator.py
@@ -150,7 +150,6 @@ class OptimizerEvaluator:
         try:
             with traced(scope_name="optimization_loop"):
                 for i in range(self.optimizer_evaluator_config.num_iterations):
-                    print(f"[{i + 1}/{self.optimizer_evaluator_config.num_iterations}]")
                     parameters = self.optimizer.suggest()
                     objectives = self.objective_function.evaluate_point(parameters)
                     self.optimizer.register(parameters.to_dataframe(), objectives.to_dataframe())

--- a/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluator.py
+++ b/source/Mlos.Python/mlos/OptimizerEvaluationTools/OptimizerEvaluator.py
@@ -42,8 +42,7 @@ class OptimizerEvaluator:
             optimizer: OptimizerBase = None,
             optimizer_config: Point = None,
             objective_function: ObjectiveFunctionBase = None,
-            objective_function_config: Point = None,
-            suggestion: Point=None
+            objective_function_config: Point = None
     ):
         assert optimizer_evaluator_config in optimizer_evaluator_config_store.parameter_space
         assert (optimizer is None) != (optimizer_config is None), "A valid optimizer XOR a valid optimizer_config must be supplied."
@@ -55,7 +54,6 @@ class OptimizerEvaluator:
         self.objective_function = None
         self.optimizer_config = None
         self.optimizer = None
-        self.suggestion = suggestion
 
         # Let's get the objective function assigned to self's fields.
         #
@@ -103,8 +101,7 @@ class OptimizerEvaluator:
             optimizer_configuration=self.optimizer_config,
             objective_function_configuration=self.objective_function_config,
             num_optimization_iterations=self.optimizer_evaluator_config.num_iterations,
-            evaluation_frequency=self.optimizer_evaluator_config.evaluation_frequency,
-            suggestion=self.suggestion
+            evaluation_frequency=self.optimizer_evaluator_config.evaluation_frequency
         )
 
         if self.optimizer_evaluator_config.include_execution_trace_in_report:


### PR DESCRIPTION
This really simple change adds a start time and an end time to the optimizer evaluation report, thus allowing us to also know how long the optimization process took.