### PR TITLE
Making glow worm optimizer use the context

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/GlowWormSwarmOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/GlowWormSwarmOptimizer.py
@@ -92,10 +92,16 @@ class GlowWormSwarmOptimizer(UtilityFunctionOptimizer):
         """
         assert context_values_dataframe is None or len(context_values_dataframe.index) == 1
 
+        # TODO: consider remembering great features from previous invocations of the suggest() method.
         parameters_df = self.optimization_problem.parameter_space.random_dataframe(
             num_samples=self.optimizer_config.num_worms * self.optimizer_config.num_initial_points_multiplier
         )
-        features_df = self.optimization_problem.construct_feature_dataframe(parameter_values=parameters_df.copy(deep=False), context_values=context_values_dataframe, product=False)
+
+        features_df = self.optimization_problem.construct_feature_dataframe(
+            parameter_values=parameters_df.copy(deep=False),
+            context_values=context_values_dataframe,
+            product=False
+        )
 
         utility_function_values = self.utility_function(feature_values_pandas_frame=features_df.copy(deep=False))
         num_utility_function_values = len(utility_function_values.index)

--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/GlowWormSwarmOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/GlowWormSwarmOptimizer.py
@@ -90,15 +90,17 @@ class GlowWormSwarmOptimizer(UtilityFunctionOptimizer):
 
 
         """
+        assert context_values_dataframe is None or len(context_values_dataframe.index) == 1
 
-        # TODO: consider remembering great features from previous invocations of the suggest() method.
-        feature_values_dataframe = self.optimization_problem.parameter_space.random_dataframe(
+        parameters_df = self.optimization_problem.parameter_space.random_dataframe(
             num_samples=self.optimizer_config.num_worms * self.optimizer_config.num_initial_points_multiplier
         )
-        utility_function_values = self.utility_function(feature_values_pandas_frame=feature_values_dataframe.copy(deep=False))
+        features_df = self.optimization_problem.construct_feature_dataframe(parameter_values=parameters_df.copy(deep=False), context_values=context_values_dataframe, product=False)
+
+        utility_function_values = self.utility_function(feature_values_pandas_frame=features_df.copy(deep=False))
         num_utility_function_values = len(utility_function_values.index)
         if num_utility_function_values == 0:
-            config_to_suggest = Point.from_dataframe(feature_values_dataframe.iloc[[0]])
+            config_to_suggest = Point.from_dataframe(parameters_df.iloc[[0]])
             self.logger.debug(f"Suggesting: {str(config_to_suggest)} at random.")
             return config_to_suggest
 
@@ -107,8 +109,8 @@ class GlowWormSwarmOptimizer(UtilityFunctionOptimizer):
         top_utility_values = utility_function_values.nlargest(n=self.optimizer_config.num_worms, columns=['utility'])
 
         # TODO: could it be in place?
-        features_for_top_utility = self.parameter_adapter.project_dataframe(feature_values_dataframe.loc[top_utility_values.index], in_place=False)
-        worms = pd.concat([features_for_top_utility, top_utility_values], axis=1)
+        params_for_top_utility = self.parameter_adapter.project_dataframe(parameters_df.loc[top_utility_values.index], in_place=False)
+        worms = pd.concat([params_for_top_utility, top_utility_values], axis=1)
         # Let's reset the index to make keeping track down the road easier.
         #
         worms.index = pd.Index(range(len(worms.index)))
@@ -121,7 +123,7 @@ class GlowWormSwarmOptimizer(UtilityFunctionOptimizer):
         for _ in range(self.optimizer_config.num_iterations):
             worms = self.run_iteration(worms=worms)
             # TODO: keep track of the max configs over iterations
-            worms = self.compute_utility(worms)
+            worms = self.compute_utility(worms, context_values_dataframe)
             worms['luciferin'] = (1 - self.optimizer_config.luciferin_decay_constant) * worms['luciferin'] + \
                                  self.optimizer_config.luciferin_enhancement_constant * worms['utility']
 
@@ -135,7 +137,7 @@ class GlowWormSwarmOptimizer(UtilityFunctionOptimizer):
         return self.parameter_adapter.unproject_point(config_to_suggest)
 
     @trace()
-    def compute_utility(self, worms):
+    def compute_utility(self, worms, context_values_df):
         """ Computes utility function values for each worm.
 
         Since some worm positions will produce a NaN, we need to keep producing new utility values for those.
@@ -143,8 +145,9 @@ class GlowWormSwarmOptimizer(UtilityFunctionOptimizer):
         :param worms:
         :return:
         """
-        unprojected_features = self.parameter_adapter.unproject_dataframe(worms[self.dimension_names], in_place=False)
-        utility_function_values = self.utility_function(unprojected_features.copy(deep=False))
+        unprojected_params_df = self.parameter_adapter.unproject_dataframe(worms[self.dimension_names], in_place=False)
+        features_df = self.optimization_problem.construct_feature_dataframe(unprojected_params_df, context_values_df, product=False)
+        utility_function_values = self.utility_function(features_df.copy(deep=False))
         worms['utility'] = utility_function_values
         index_of_nans = worms.index.difference(utility_function_values.index)
         # TODO: A better solution would be to give them random valid configs, and let them live.

--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/RandomSearchOptimizer.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/RandomSearchOptimizer.py
@@ -43,7 +43,7 @@ class RandomSearchOptimizer(UtilityFunctionOptimizer):
         UtilityFunctionOptimizer.__init__(self, optimizer_config, optimization_problem, utility_function, logger)
 
     @trace()
-    def suggest(self, context_values_dataframe: pd.DataFrame = None):  # pylint: disable=unused-argument
+    def suggest(self, context_values_dataframe: pd.DataFrame = None):
         """ Returns the next best configuration to try.
 
         It does so by generating num_samples_per_iteration random configurations,

--- a/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/unit_tests/TestUtilityFunctionOptimizers.py
+++ b/source/Mlos.Python/mlos/Optimizers/ExperimentDesigner/UtilityFunctionOptimizers/unit_tests/TestUtilityFunctionOptimizers.py
@@ -48,8 +48,17 @@ class TestUtilityFunctionOptimizers:
         cls.input_space = objective_function.parameter_space
         cls.output_space = objective_function.output_space
 
-        cls.input_values_dataframe = objective_function.parameter_space.random_dataframe(num_samples=2500)
-        cls.output_values_dataframe = objective_function.evaluate_dataframe(cls.input_values_dataframe)
+        cls.optimization_problem = OptimizationProblem(
+            parameter_space=cls.input_space,
+            objective_space=cls.output_space,
+            objectives=[Objective(name='y', minimize=True)]
+        )
+
+
+
+        cls.parameter_values_df = cls.optimization_problem.parameter_space.random_dataframe(num_samples=2500)
+        cls.feature_values_df = cls.optimization_problem.construct_feature_dataframe(parameter_values=cls.parameter_values_df, context_values=None, product=False)
+        cls.output_values_df = objective_function.evaluate_dataframe(cls.parameter_values_df)
 
         cls.model_config = homogeneous_random_forest_config_store.default
 
@@ -57,20 +66,14 @@ class TestUtilityFunctionOptimizers:
 
         cls.model = MultiObjectiveHomogeneousRandomForest(
             model_config=cls.model_config,
-            input_space=cls.input_space,
-            output_space=cls.output_space
+            input_space=cls.optimization_problem.feature_space,
+            output_space=cls.optimization_problem.objective_space
         )
-        cls.model.fit(cls.input_values_dataframe, cls.output_values_dataframe, iteration_number=len(cls.input_values_dataframe.index))
+        cls.model.fit(cls.feature_values_df, cls.output_values_df, iteration_number=len(cls.feature_values_df.index))
 
         cls.utility_function_config = Point(
             utility_function_name="upper_confidence_bound_on_improvement",
             alpha=0.05
-        )
-
-        cls.optimization_problem = OptimizationProblem(
-            parameter_space=cls.input_space,
-            objective_space=cls.output_space,
-            objectives=[Objective(name='y', minimize=True)]
         )
 
         cls.utility_function = ConfidenceBoundUtilityFunction(
@@ -112,7 +115,7 @@ class TestUtilityFunctionOptimizers:
         for _ in range(5):
             suggested_params = glow_worm_swarm_optimizer.suggest()
             print(suggested_params.to_json())
-            assert suggested_params in self.input_space
+            assert suggested_params in self.input_space, f"{suggested_params.to_json(indent=2)} not in {self.input_space}"
 
     @trace()
     def test_glow_worm_on_three_level_quadratic(self):


### PR DESCRIPTION
I was working on Random Near Incumbent Optimizer and I noticed that GlowWormSwarmOptimizer was doing something really wrong with the context features. I don't really understand how/if it ever worked with context.

So this is a quick fix, where we have the worms keep track of the parameter values (not feature values) and only constructing the features dataframe when calling the utility function. This way, the glow worm swarm optimizer can suggest optimal parameters for a given context, instead of suggesting optimal parameters and context. I really don't know how it ever worked. I suspect it was never able to compute the utility value, and always bailed on the first 'if' producing a de-facto random suggestion. 