### PR TITLE
Cleaned up stacking polynomial features adapter on one hot encoding adapter

### DIFF
--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionEnhancedRandomForestModel.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionEnhancedRandomForestModel.py
@@ -147,7 +147,7 @@ class RegressionEnhancedRandomForestRegressionModel(RegressionModel):
         # Explode continuous dimensions to polynomial features up to model config specified monomial degree
         # am using include_bias to produce constant term (all 1s) column to simplify one hot encoding logic
         self.polynomial_features_adapter = ContinuousToPolynomialBasisHypergridAdapter(
-            adaptee=self.one_hot_encoder_adapter.target,
+            adaptee=self.one_hot_encoder_adapter, #.target,
             degree=self.model_config.max_basis_function_degree,
             include_bias=True,
             interaction_only=False
@@ -483,8 +483,7 @@ class RegressionEnhancedRandomForestRegressionModel(RegressionModel):
         for missing_column_name in missing_column_names:
             x[missing_column_name] = np.NaN
 
-        x_df = self.one_hot_encoder_adapter.project_dataframe(df=x, in_place=False)
-        x_df = self.polynomial_features_adapter.project_dataframe(df=x_df, in_place=True)
+        x_df = self.polynomial_features_adapter.project_dataframe(df=x, in_place=True)
 
         # impute 0s for NaNs (NaNs can come from hierarchical hypergrids)
         x_df.fillna(value=0, inplace=True)
@@ -493,7 +492,6 @@ class RegressionEnhancedRandomForestRegressionModel(RegressionModel):
         else:
             fit_x = x_df.to_numpy()
             self.polynomial_features_powers_ = self.polynomial_features_adapter.get_polynomial_feature_powers_table()
-        #fit_x = self.scaler_.fit_transform(fit_x)
         self.fit_X_ = fit_x
 
         if what_to_return.upper() == 'fit_x'.upper():

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionEnhancedRandomForestModel.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/RegressionEnhancedRandomForestModel.py
@@ -147,7 +147,7 @@ class RegressionEnhancedRandomForestRegressionModel(RegressionModel):
         # Explode continuous dimensions to polynomial features up to model config specified monomial degree
         # am using include_bias to produce constant term (all 1s) column to simplify one hot encoding logic
         self.polynomial_features_adapter = ContinuousToPolynomialBasisHypergridAdapter(
-            adaptee=self.one_hot_encoder_adapter, #.target,
+            adaptee=self.one_hot_encoder_adapter,
             degree=self.model_config.max_basis_function_degree,
             include_bias=True,
             interaction_only=False

--- a/source/Mlos.Python/mlos/Optimizers/RegressionModels/unit_tests/TestRegressionEnhancedRandomForestModel.py
+++ b/source/Mlos.Python/mlos/Optimizers/RegressionModels/unit_tests/TestRegressionEnhancedRandomForestModel.py
@@ -302,10 +302,12 @@ class TestRegressionEnhancedRandomForestRegressionModel:
         predicted_value_col = Prediction.LegalColumnNames.PREDICTED_VALUE.value
         num_test_x = 50
         x_test_df = objective_function.parameter_space.random_dataframe(num_samples=num_test_x)
+        y_test = objective_function.evaluate_dataframe(x_test_df).to_numpy().reshape(-1)
+
         predictions = rerf.predict(x_test_df)
         pred_df = predictions.get_dataframe()
         predicted_y = pred_df[predicted_value_col].to_numpy()
-        y_test = objective_function.evaluate_dataframe(x_test_df).to_numpy().reshape(-1)
+
         residual_sum_of_squares = ((y_test - predicted_y) ** 2).sum()
         total_sum_of_squares = ((y_test - y_test.mean()) ** 2).sum()
         unexplained_variance = residual_sum_of_squares / total_sum_of_squares

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/CategoricalToOneHotEncodedHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/CategoricalToOneHotEncodedHypergridAdapter.py
@@ -108,6 +108,10 @@ class CategoricalToOneHotEncodedHypergridAdapter(HypergridAdapter):
     def target(self) -> Hypergrid:
         return self._target
 
+    @property
+    def was_encoding_merge_all_categoricals_requested(self):
+        return self._merge_all_categorical_dimensions
+
     def get_original_categorical_column_names(self):
         return self._adaptee_to_target_data_dict.keys()
 

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/CategoricalToOneHotEncodedHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/CategoricalToOneHotEncodedHypergridAdapter.py
@@ -94,6 +94,7 @@ class CategoricalToOneHotEncodedHypergridAdapter(HypergridAdapter):
             self._adaptee_expected_dimension_name_ordering.append(adaptee_dimension.name)
         self._adaptee_contains_categorical_dimensions = len(self._adaptee_dimension_names_to_transform) > 0
 
+        # since sklearn OneHotEncoder doesn't accept strings, convert any categorical dimensions to discrete
         if any(isinstance(dimension, CategoricalDimension) for dimension in self._adaptee.dimensions) or self.has_adaptee_been_flattened:
             self._adaptee = CategoricalToDiscreteHypergridAdapter(adaptee=self._adaptee)
 

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/ContinuousToPolynomialBasisHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/ContinuousToPolynomialBasisHypergridAdapter.py
@@ -94,10 +94,9 @@ class ContinuousToPolynomialBasisHypergridAdapter(HypergridAdapter):
             random_state=self._adaptee.random_state
         )
 
-        # Add all adaptee dimensions to the target
-        # This aligns with this adapter's goal since the linear terms will always be included in the polynomial basis functions
+        # Add non-transformed adaptee dimensions to the target
         for adaptee_dimension in self._adaptee.dimensions:
-            if not adaptee_dimension.name in self._adaptee_dimension_names_to_transform:
+            if adaptee_dimension.name not in self._adaptee_dimension_names_to_transform:
                 self._target.add_dimension(adaptee_dimension.copy())
 
         if not self._adaptee_contains_dimensions_to_transform:

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestCategoricalToOneHotEncodedHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestCategoricalToOneHotEncodedHypergridAdapter.py
@@ -49,13 +49,15 @@ class TestCategoricalToOneHotEncodedHypergridAdapter:
     @pytest.mark.parametrize("drop", ['first', None])
     @pytest.mark.parametrize("merge_all_categorical_dimensions", [True, False])
     def test_projecting_point_from_categorical_to_one_hot_encoding_simple_hypergrid_parameterized(self, drop, merge_all_categorical_dimensions):
-        for adaptee in [self.simple_hypergrid,
-                        self.hierarchical_hypergrid]:
+        for adaptee in [self.simple_hypergrid, self.hierarchical_hypergrid]:
             adapter = CategoricalToOneHotEncodedHypergridAdapter(
                 adaptee=adaptee,
                 drop=drop,
                 merge_all_categorical_dimensions=merge_all_categorical_dimensions
             )
+            test_types_are_not_categorical = [dimension.__class__ != CategoricalDimension for dimension in adapter.dimensions]
+            assert all(test_types_are_not_categorical)
+
             self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(
                 adaptee=adaptee,
                 adapter=adapter,
@@ -66,13 +68,15 @@ class TestCategoricalToOneHotEncodedHypergridAdapter:
     @pytest.mark.parametrize("drop", ['first', None])
     @pytest.mark.parametrize("merge_all_categorical_dimensions", [True, False])
     def test_projecting_dataframe_from_flat_to_one_hot_encoded_hypergrid_parameterized(self, drop, merge_all_categorical_dimensions):
-        for adaptee in [self.simple_hypergrid,
-                        self.hierarchical_hypergrid]:
+        for adaptee in [self.simple_hypergrid, self.hierarchical_hypergrid]:
             adapter = CategoricalToOneHotEncodedHypergridAdapter(
                 adaptee=adaptee,
                 drop=drop,
                 merge_all_categorical_dimensions=merge_all_categorical_dimensions
             )
+            test_types_are_not_categorical = [dimension.__class__ != CategoricalDimension for dimension in adapter.dimensions]
+            assert all(test_types_are_not_categorical)
+
             self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(
                 adapter=adapter,
                 adaptee=adaptee,
@@ -89,11 +93,16 @@ class TestCategoricalToOneHotEncodedHypergridAdapter:
             assert projected_df[column].isin([0, 1]).all()
         unprojected_df = adapter.unproject_dataframe(df=projected_df, in_place=False)
         assert original_df.equals(unprojected_df)
+        assert all([expected_column_name in projected_df.columns.values
+                    for expected_column_name in adapter.get_one_hot_encoded_column_names()])
 
         # Let's make sure that projecting in place works as expected.
         projected_in_place_df = adapter.project_dataframe(original_df, in_place=True)
         assert id(original_df) == id(projected_in_place_df)
         assert projected_in_place_df.equals(projected_df)
+        assert all([expected_column_name in projected_in_place_df.columns.values
+                    for expected_column_name in adapter.get_one_hot_encoded_column_names()])
+
         unprojected_in_place_df = adapter.unproject_dataframe(projected_in_place_df, in_place=True)
         assert id(original_df) == id(unprojected_in_place_df)
         assert unprojected_in_place_df.equals(unprojected_df[unprojected_in_place_df.columns.values])

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestCategoricalToOneHotEncodedHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestCategoricalToOneHotEncodedHypergridAdapter.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 #
 from numbers import Number
-
+import pytest
 
 from mlos.Spaces import SimpleHypergrid, CategoricalDimension, ContinuousDimension, DiscreteDimension, OrdinalDimension
 from mlos.Spaces.HypergridAdapters import CategoricalToOneHotEncodedHypergridAdapter
@@ -45,96 +45,43 @@ class TestCategoricalToOneHotEncodedHypergridAdapter:
             on_external_dimension=CategoricalDimension("categorical_mixed_types", values=[True])
         )
 
-    ## Point project/unproject
-    # Simple Hypergrid tests
-    def test_projecting_point_from_categorical_to_one_hot_encoding_simple_hypergrid(self):
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.simple_hypergrid)
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.simple_hypergrid, adapter=adapter, num_random_points=500)
+    # Point project/unproject
+    @pytest.mark.parametrize("drop", ['first', None])
+    @pytest.mark.parametrize("merge_all_categorical_dimensions", [True, False])
+    def test_projecting_point_from_categorical_to_one_hot_encoding_simple_hypergrid_parameterized(self, drop, merge_all_categorical_dimensions):
+        for adaptee in [self.simple_hypergrid,
+                        self.hierarchical_hypergrid]:
+            adapter = CategoricalToOneHotEncodedHypergridAdapter(
+                adaptee=adaptee,
+                drop=drop,
+                merge_all_categorical_dimensions=merge_all_categorical_dimensions
+            )
+            self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(
+                adaptee=adaptee,
+                adapter=adapter,
+                num_random_points=100
+            )
 
-    def test_projecting_point_from_categorical_to_one_hot_encoding_drop_first_simple_hypergrid(self):
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.simple_hypergrid, drop='first')
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.simple_hypergrid, adapter=adapter, num_random_points=500)
-
-    def test_projecting_point_from_categorical_to_one_hot_encoding_cross_product_simple_hypergrid(self):
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.simple_hypergrid, merge_all_categorical_dimensions=True)
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.simple_hypergrid, adapter=adapter, num_random_points=500)
-
-    def test_projecting_point_from_categorical_to_one_hot_encoding_cross_product_drop_first_simple_hypergrid(self):
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.simple_hypergrid, merge_all_categorical_dimensions=True, drop='first')
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.simple_hypergrid, adapter=adapter, num_random_points=500)
-
-    # Hierarchical Hypergrid tests
-    def test_projecting_point_from_hierarchical_categorical_to_one_hot_encoding_hypergrid(self):
-        hierarchical_adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.hierarchical_hypergrid)
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.hierarchical_hypergrid,
-                                                                                 adapter=hierarchical_adapter,
-                                                                                 num_random_points=500)
-
-    def test_projecting_point_from_hierarchical_categorical_to_one_hot_encoding_drop_first_hypergrid(self):
-        hierarchical_adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.hierarchical_hypergrid, drop='first')
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.hierarchical_hypergrid,
-                                                                                 adapter=hierarchical_adapter,
-                                                                                 num_random_points=500)
-
-    def test_projecting_point_from_hierarchical_categorical_to_one_hot_encoding_cross_product_hypergrid(self):
-        hierarchical_adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.hierarchical_hypergrid, merge_all_categorical_dimensions=True)
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.hierarchical_hypergrid,
-                                                                                 adapter=hierarchical_adapter,
-                                                                                 num_random_points=100)
-
-    def test_projecting_point_from_hierarchical_categorical_to_one_hot_encoding_cross_product_drop_first_hypergrid(self):
-        hierarchical_adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=self.hierarchical_hypergrid,
-                                                                          merge_all_categorical_dimensions=True,
-                                                                          drop='first')
-        self._test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee=self.hierarchical_hypergrid,
-                                                                                 adapter=hierarchical_adapter,
-                                                                                 num_random_points=100)
-
-    ## DataFrame project/unproject tests
-    # Simple Hypergrid tests
-    def test_projecting_dataframe_from_flat_to_one_hot_encoded_hypergrid(self):
-        adaptee = self.simple_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee)
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    def test_projecting_dataframe_from_flat_to_one_hot_encoded_drop_first_hypergrid(self):
-        adaptee = self.simple_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee, drop='first')
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    def test_projecting_dataframe_from_flat_to_one_hot_encoded_cross_product_hypergrid(self):
-        adaptee = self.simple_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee, merge_all_categorical_dimensions=True)
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    def test_projecting_dataframe_from_flat_to_one_hot_encoded_cross_product_drop_first_hypergrid(self):
-        adaptee = self.simple_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee, merge_all_categorical_dimensions=True, drop='first')
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    # Hierarchical Hypergrid tests
-    def test_projecting_dataframe_from_hierarchical_to_one_hot_encoding_hypergrid(self):
-        adaptee = self.hierarchical_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee)
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    def test_projecting_dataframe_from_hierarchical_to_one_hot_encoding_drop_first_hypergrid(self):
-        adaptee = self.hierarchical_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee, drop='first')
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    def test_projecting_dataframe_from_hierarchical_to_one_hot_encoding_cross_product_hypergrid(self):
-        adaptee = self.hierarchical_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee, merge_all_categorical_dimensions=True)
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
-
-    def test_projecting_dataframe_from_hierarchical_to_one_hot_encoding_cross_product_drop_first_hypergrid(self):
-        adaptee = self.hierarchical_hypergrid
-        adapter = CategoricalToOneHotEncodedHypergridAdapter(adaptee=adaptee, merge_all_categorical_dimensions=True, drop='first')
-        self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adapter=adapter, adaptee=adaptee, num_random_points=1000)
+    # DataFrame project/unproject tests
+    @pytest.mark.parametrize("drop", ['first', None])
+    @pytest.mark.parametrize("merge_all_categorical_dimensions", [True, False])
+    def test_projecting_dataframe_from_flat_to_one_hot_encoded_hypergrid_parameterized(self, drop, merge_all_categorical_dimensions):
+        for adaptee in [self.simple_hypergrid,
+                        self.hierarchical_hypergrid]:
+            adapter = CategoricalToOneHotEncodedHypergridAdapter(
+                adaptee=adaptee,
+                drop=drop,
+                merge_all_categorical_dimensions=merge_all_categorical_dimensions
+            )
+            self._test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(
+                adapter=adapter,
+                adaptee=adaptee,
+                num_random_points=1000
+            )
 
     # Helper functions
-    def _test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(self, adaptee, adapter, num_random_points: int):
+    @staticmethod
+    def _test_projecting_dataframe_categorical_to_one_hot_encoding_point_from_adaptee(adaptee, adapter, num_random_points: int):
         original_df = adaptee.random_dataframe(num_samples=num_random_points)
         projected_df = adapter.project_dataframe(df=original_df, in_place=False)
         assert id(original_df) != id(projected_df)
@@ -151,7 +98,8 @@ class TestCategoricalToOneHotEncodedHypergridAdapter:
         assert id(original_df) == id(unprojected_in_place_df)
         assert unprojected_in_place_df.equals(unprojected_df[unprojected_in_place_df.columns.values])
 
-    def _test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(self, adaptee, adapter, num_random_points: int):
+    @staticmethod
+    def _test_projecting_categorical_to_one_hot_encoding_point_from_adaptee(adaptee, adapter, num_random_points: int):
         # First make sure that none of the resulting dimensions are categorical.
         #
         assert not any(isinstance(dimension, CategoricalDimension) for dimension in adapter.dimensions)

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestContinuousToPolynomialBasisHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestContinuousToPolynomialBasisHypergridAdapter.py
@@ -184,13 +184,14 @@ class TestContinuousToPolynomialBasisHypergridAdapter:
     @pytest.mark.parametrize("interaction_only", [True, False])
     @pytest.mark.parametrize("drop", ['first', None])
     @pytest.mark.parametrize("merge_all_categorical_dimensions", [True, False])
-    def test_stacking_polynomial_feature_on_one_hot_encoding_parameterized(self,
-                                                                           degree,
-                                                                           include_bias,
-                                                                           interaction_only,
-                                                                           drop,
-                                                                           merge_all_categorical_dimensions
-                                                                           ):
+    def test_stacking_polynomial_feature_on_one_hot_encoding_parameterized(
+        self,
+        degree,
+        include_bias,
+        interaction_only,
+        drop,
+        merge_all_categorical_dimensions
+    ):
         # The RegressionEnhancedRandomForestRegressionModel stacks polynomial feature adapter on one hot encoding adapter.
         # When the RERF code was changed to use these adapters, there was some concern about how the stacking was done.
         # This test tries to replicate the result of using the expected stacking pattern.

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestContinuousToPolynomialBasisHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestContinuousToPolynomialBasisHypergridAdapter.py
@@ -190,7 +190,7 @@ class TestContinuousToPolynomialBasisHypergridAdapter:
             drop='first'
         )
         self.polynomial_features_adapter = ContinuousToPolynomialBasisHypergridAdapter(
-            adaptee=self.one_hot_encoder_adapter.target,
+            adaptee=self.one_hot_encoder_adapter,  # .target,
             degree=2,
             include_bias=True,
             interaction_only=False

--- a/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestContinuousToPolynomialBasisHypergridAdapter.py
+++ b/source/Mlos.Python/mlos/Spaces/HypergridAdapters/unit_tests/TestContinuousToPolynomialBasisHypergridAdapter.py
@@ -179,30 +179,41 @@ class TestContinuousToPolynomialBasisHypergridAdapter:
                 print('observed: ', observed_values)
             assert sum_diffs < epsilon
 
-    def test_stacking_polynomial_feature_on_one_hot_encoding(self):
+    @pytest.mark.parametrize("degree", [2, 3, 5])
+    @pytest.mark.parametrize("include_bias", [True, False])
+    @pytest.mark.parametrize("interaction_only", [True, False])
+    @pytest.mark.parametrize("drop", ['first', None])
+    @pytest.mark.parametrize("merge_all_categorical_dimensions", [True, False])
+    def test_stacking_polynomial_feature_on_one_hot_encoding_parameterized(self,
+                                                                           degree,
+                                                                           include_bias,
+                                                                           interaction_only,
+                                                                           drop,
+                                                                           merge_all_categorical_dimensions
+                                                                           ):
         # The RegressionEnhancedRandomForestRegressionModel stacks polynomial feature adapter on one hot encoding adapter.
         # When the RERF code was changed to use these adapters, there was some concern about how the stacking was done.
         # This test tries to replicate the result of using the expected stacking pattern.
+        for adaptee in [self.simple_hypergrid,
+                        self.unbalanced_hierarchical_hypergrid,
+                        self.balanced_hierarchical_hypergrid]:
+            print(f'running test for adaptee: {adaptee.name}')
 
-        self.one_hot_encoder_adapter = CategoricalToOneHotEncodedHypergridAdapter(
-            adaptee=self.balanced_hierarchical_hypergrid,
-            merge_all_categorical_dimensions=True,
-            drop='first'
-        )
-        self.polynomial_features_adapter = ContinuousToPolynomialBasisHypergridAdapter(
-            adaptee=self.one_hot_encoder_adapter,  # .target,
-            degree=2,
-            include_bias=True,
-            interaction_only=False
-        )
+            one_hot_encoder_adapter = CategoricalToOneHotEncodedHypergridAdapter(
+                adaptee=adaptee,
+                merge_all_categorical_dimensions=merge_all_categorical_dimensions,
+                drop=drop
+            )
 
-        original_df = self.balanced_hierarchical_hypergrid.random_dataframe(num_samples=10)
-        print(original_df.columns.values, len(original_df.columns.values))
+            polynomial_features_adapter = ContinuousToPolynomialBasisHypergridAdapter(
+                adaptee=one_hot_encoder_adapter,
+                degree=degree,
+                include_bias=include_bias,
+                interaction_only=interaction_only
+            )
 
-        ohe_projected_df = self.one_hot_encoder_adapter.project_dataframe(df=original_df, in_place=False)
-        print(ohe_projected_df.columns.values, len(ohe_projected_df.columns.values))
-        assert len(ohe_projected_df.columns.values) == 9
+        original_df = adaptee.random_dataframe(num_samples=10)
+        projected_df = polynomial_features_adapter.project_dataframe(df=original_df, in_place=True)
 
-        both_projected_df = self.polynomial_features_adapter.project_dataframe(df=ohe_projected_df, in_place=True)
-        print(both_projected_df.columns.values, len(both_projected_df.columns.values))
-        assert len(both_projected_df.columns.values) == 31
+        # test values are as expected
+        self._test_polynomial_feature_values_are_as_expected(polynomial_features_adapter, projected_df)


### PR DESCRIPTION
The initial RERF rewrite using the (then new) hypergrid adapters `CategoricalToOneHotEncodedHypergridAdapter` and `ContinuousToPolynomialBasisHypergridAdapter` incorrectly performed the transform operations.  This PR corrects this mistake in the RERF `.transform_x()` method.

Also:
1. Added new unit tests for stacking `CategoricalToOneHotEncodedHypergridAdapter` and `ContinuousToPolynomialBasisHypergridAdapter`.
2. Parameterized unit tests in `CategoricalToOneHotEncodedHypergridAdapter` to simplify code.
3. Added comment to  `CategoricalToOneHotEncodedHypergridAdapter` explaining why the `CategoricalToDiscreteHypergridAdapter` is used.