### PR TITLE
Automatic versioning support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.1.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,11 +1,14 @@
-# Note: the bumpversion tool will automatically rewrite this file and strip the comments.
 [bumpversion]
 current_version = 0.0.4
 commit = True
 tag = True
 
 [bumpversion:file:README.md]
+
 [bumpversion:file:doc/source/installation.rst]
+
 [bumpversion:file:doc/source/conf.py]
+
 [bumpversion:file:mlos_core/_version.py]
+
 [bumpversion:file:mlos_bench/_version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,5 +7,5 @@ tag = True
 [bumpversion:file:README.md]
 [bumpversion:file:doc/source/installation.rst]
 [bumpversion:file:doc/source/conf.py]
-[bumpversion:mlos_core/_version.py]
-[bumpversion:mlos_bench/_version.py]
+[bumpversion:file:mlos_core/_version.py]
+[bumpversion:file:mlos_bench/_version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,5 +6,6 @@ tag = True
 
 [bumpversion:file:README.md]
 [bumpversion:file:doc/source/installation.rst]
+[bumpversion:file:doc/source/conf.py]
 [bumpversion:mlos_core/_version.py]
 [bumpversion:mlos_bench/_version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,10 @@
+# Note: the bumpversion tool will automatically rewrite this file and strip the comments.
+[bumpversion]
+current_version = 0.0.4
+commit = True
+tag = True
+
+[bumpversion:file:README.md]
+[bumpversion:file:doc/source/installation.rst]
+[bumpversion:mlos_core/_version.py]
+[bumpversion:mlos_bench/_version.py]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,7 +59,7 @@ RUN /opt/conda/bin/conda init bash \
 
 # Prepare the mlos_core_deps.yml file in a cross platform way.
 FROM mcr.microsoft.com/devcontainers/miniconda:3 AS deps-prep
-COPY --chown=vscode:conda prep-deps-files.sh mlos_core.yml mlos_core.setup.py mlos_bench.setup.py doc.requirements.txt /tmp/conda-tmp/
+COPY --chown=vscode:conda . /tmp/conda-tmp/
 RUN /tmp/conda-tmp/prep-deps-files.sh \
     && ls -l /tmp/conda-tmp/ # && cat /tmp/conda-tmp/combined.requirements.txt /tmp/conda-tmp/mlos_core_deps.yml
 

--- a/.devcontainer/scripts/common/prep-deps-files.sh
+++ b/.devcontainer/scripts/common/prep-deps-files.sh
@@ -17,10 +17,6 @@ set -x
 scriptdir=$(dirname "$(readlink -f "$0")")
 cd "$scriptdir"
 
-pip install --no-cache-dir setuptools-scm
-
-ls -lR /tmp/conda-tmp/
-
 cat /tmp/conda-tmp/mlos_core.yml \
     | sed 's|#.*||' \
     | egrep -v -e '--editable' -e '^\s*$' \

--- a/.devcontainer/scripts/common/prep-deps-files.sh
+++ b/.devcontainer/scripts/common/prep-deps-files.sh
@@ -17,6 +17,10 @@ set -x
 scriptdir=$(dirname "$(readlink -f "$0")")
 cd "$scriptdir"
 
+pip install --no-cache-dir setuptools-scm
+
+ls -lR /tmp/conda-tmp/
+
 cat /tmp/conda-tmp/mlos_core.yml \
     | sed 's|#.*||' \
     | egrep -v -e '--editable' -e '^\s*$' \
@@ -27,7 +31,7 @@ tmpdir=$(mktemp -d)
 get_python_deps() {
     local pkg="$1"
     touch /tmp/conda-tmp/$pkg.requirements.txt
-    python3 /tmp/conda-tmp/$pkg.setup.py egg_info --egg-base "$tmpdir/"
+    python3 /tmp/conda-tmp/$pkg/setup.py egg_info --egg-base "$tmpdir/"
     cat "$tmpdir/$pkg.egg-info/requires.txt" \
         | grep -v -e '^\[' -e '^\s*$' \
         | grep -v '^mlos-core' \

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -26,7 +26,9 @@ fi
 mkdir -p .devcontainer/tmp/
 cp -v conda-envs/mlos_core.yml .devcontainer/tmp/mlos_core.yml
 for pkg in mlos_core mlos_bench; do
-    cp -v $pkg/setup.py .devcontainer/tmp/$pkg.setup.py
+    mkdir -p .devcontainer/tmp/$pkg
+    cp -v $pkg/setup.py .devcontainer/tmp/$pkg/setup.py
+    cp -v $pkg/_version.py .devcontainer/tmp/$pkg/_version.py
 done
 cp -v doc/requirements.txt .devcontainer/tmp/doc.requirements.txt
 

--- a/.devcontainer/scripts/prep-container-build.ps1
+++ b/.devcontainer/scripts/prep-container-build.ps1
@@ -23,7 +23,9 @@ New-Item -Type Directory .devcontainer/tmp
 
 Copy-Item conda-envs/mlos_core.yml .devcontainer/tmp/mlos_core.yml
 foreach ($pkg in @('mlos_core', 'mlos_bench')) {
-    Copy-Item "$pkg/setup.py" ".devcontainer/tmp/${pkg}.setup.py"
+    New-Item -Type Directory ".devcontainer/tmp/${pkg}"
+    Copy-Item "$pkg/setup.py" ".devcontainer/tmp/${pkg}/setup.py"
+    Copy-Item "$pkg/_version.py" ".devcontainer/tmp/${pkg}/_version.py"
 }
 Copy-Item doc/requirements.txt .devcontainer/tmp/doc.requirements.txt
 

--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,7 @@ build/check-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov/in
 	@cat doc/build/log.txt \
 		| egrep -C1 -e WARNING -e CRITICAL -e ERROR \
 		| egrep -v \
+			-e "warnings.warn\(f'\"{wd.path}\" is shallow and may cause errors'\)" \
 			-e "No such file or directory: '.*.examples'.$$" \
 			-e 'Problems with "include" directive path:' \
 			-e 'duplicate object description' \

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,7 @@ build/pydocstyle.%.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NA
 .PHONY: licenseheaders
 licenseheaders: build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
 
-build/licenseheaders-prereqs.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NAME}.build-stamp
-	conda run -n ${CONDA_ENV_NAME} pip install licenseheaders
-	touch $@
-
-build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: build/licenseheaders-prereqs.${CONDA_ENV_NAME}.build-stamp $(PYTHON_FILES) doc/mit-license.tmpl
+build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: $(PYTHON_FILES) doc/mit-license.tmpl
 	# Note: to avoid makefile dependency loops, we don't touch the setup.py files as that would force the conda-env to be rebuilt.
 	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 -x mlos_bench/setup.py mlos_core/setup.py
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ build/licenseheaders-prereqs.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CO
 	touch $@
 
 build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: build/licenseheaders-prereqs.${CONDA_ENV_NAME}.build-stamp $(PYTHON_FILES) doc/mit-license.tmpl
+	# Note: to avoid makefile dependency loops, we don't touch the setup.py files as that would force the conda-env to be rebuilt.
 	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 -x mlos_bench/setup.py mlos_core/setup.py
 	touch $@
 

--- a/README.md
+++ b/README.md
@@ -74,15 +74,15 @@ Simply open the project in VSCode and follow the prompts to build and open the d
 
     ```sh
     # this will install just the optimizer component with emukit support:
-    pip install dist/mlos_core-0.0.4-py3-none-any.whl[emukit]
+    pip install dist/mlos_core-0.1.0-py3-none-any.whl[emukit]
 
     # this will install just the optimizer component with skopt support:
-    pip install dist/mlos_core-0.0.4-py3-none-any.whl[skopt]
+    pip install dist/mlos_core-0.1.0-py3-none-any.whl[skopt]
     ```
 
     ```sh
     # this will install both the optimizer and the experiment runner:
-    pip install dist/mlos_bench-0.0.4-py3-none-any.whl
+    pip install dist/mlos_bench-0.1.0-py3-none-any.whl
     ```
 
 ## See Also

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/conda-envs/mlos_core-3.10.yml
+++ b/conda-envs/mlos_core-3.10.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - setuptools
+  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -24,6 +25,7 @@ dependencies:
   # See comments in mlos_core.yml.
   #- gcc_linux-64
   - pip:
+    - bump2version
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.10.yml
+++ b/conda-envs/mlos_core-3.10.yml
@@ -26,6 +26,7 @@ dependencies:
   #- gcc_linux-64
   - pip:
     - bump2version
+    - licenseheaders
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.11.yml
+++ b/conda-envs/mlos_core-3.11.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - setuptools
+  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -24,6 +25,7 @@ dependencies:
   # See comments in mlos_core.yml.
   #- gcc_linux-64
   - pip:
+    - bump2version
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.11.yml
+++ b/conda-envs/mlos_core-3.11.yml
@@ -26,6 +26,7 @@ dependencies:
   #- gcc_linux-64
   - pip:
     - bump2version
+    - licenseheaders
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.8.yml
+++ b/conda-envs/mlos_core-3.8.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - setuptools
+  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -24,6 +25,7 @@ dependencies:
   # See comments in mlos_core.yml.
   #- gcc_linux-64
   - pip:
+    - bump2version
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.8.yml
+++ b/conda-envs/mlos_core-3.8.yml
@@ -26,6 +26,7 @@ dependencies:
   #- gcc_linux-64
   - pip:
     - bump2version
+    - licenseheaders
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.9.yml
+++ b/conda-envs/mlos_core-3.9.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - setuptools
+  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -24,6 +25,7 @@ dependencies:
   # See comments in mlos_core.yml.
   #- gcc_linux-64
   - pip:
+    - bump2version
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-3.9.yml
+++ b/conda-envs/mlos_core-3.9.yml
@@ -26,6 +26,7 @@ dependencies:
   #- gcc_linux-64
   - pip:
     - bump2version
+    - licenseheaders
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-windows.yml
+++ b/conda-envs/mlos_core-windows.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - setuptools
+  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -27,6 +28,7 @@ dependencies:
   - vswhere
   - conda-forge::GPy
   - pip:
+    - bump2version
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core-windows.yml
+++ b/conda-envs/mlos_core-windows.yml
@@ -29,6 +29,7 @@ dependencies:
   - conda-forge::GPy
   - pip:
     - bump2version
+    - licenseheaders
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core.yml
+++ b/conda-envs/mlos_core.yml
@@ -15,6 +15,7 @@ dependencies:
   - pytest-xdist
   - pytest-timeout
   - setuptools
+  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -27,6 +28,7 @@ dependencies:
   # NOTE: GPy is currently required by emukit.
   #- gcc_linux-64
   - pip:
+    - bump2version
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/conda-envs/mlos_core.yml
+++ b/conda-envs/mlos_core.yml
@@ -29,6 +29,7 @@ dependencies:
   #- gcc_linux-64
   - pip:
     - bump2version
+    - licenseheaders
     - pytest-local-badge
     - "--editable ../mlos_core[full]"
     - "--editable ../mlos_bench[full]"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,6 +19,8 @@
 import os
 import sys
 
+from logging import warning
+
 import sphinx_rtd_theme
 
 #sys.path.insert(0, os.path.abspath('../..'))
@@ -34,6 +36,14 @@ author = 'GSL'
 
 # The full version, including alpha/beta/rc tags
 release = '0.1.0'
+
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='../..', relative_to=__file__)
+    if version is not None:
+        release = version
+except ImportError:
+    warning("setuptools_scm not found, using version from _version.py")
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,6 +44,8 @@ try:
         release = version
 except ImportError:
     warning("setuptools_scm not found, using version from _version.py")
+except LookupError as e:
+    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,7 @@ copyright = '2022, GSL'
 author = 'GSL'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.4'
+release = '0.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -67,13 +67,13 @@ Distributing
   .. code-block:: shell
 
     # this will install just the optimizer component with emukit support:
-    pip install dist/mlos_core-0.0.4-py3-none-any.whl[emukit]
+    pip install dist/mlos_core-0.1.0-py3-none-any.whl[emukit]
 
     # this will install just the optimizer component with skopt support:
-    pip install dist/mlos_core-0.0.4-py3-none-any.whl[skopt]
+    pip install dist/mlos_core-0.1.0-py3-none-any.whl[skopt]
 
   .. code-block:: shell
 
     # this will install both the optimizer and the experiment runner:
-    pip install dist/mlos_bench-0.0.4-py3-none-any.whl
+    pip install dist/mlos_bench-0.1.0-py3-none-any.whl
 

--- a/mlos_bench/_version.py
+++ b/mlos_bench/_version.py
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Version number for the mlos_core package.
+"""
+
+# NOTE: This should be managed by bumpversion.
+_VERSION = '0.0.4'

--- a/mlos_bench/_version.py
+++ b/mlos_bench/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.0.4'
+_VERSION = '0.1.0'

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -6,16 +6,20 @@
 Setup instructions for the mlos_bench package.
 """
 
+from logging import warning
 from itertools import chain
-from setuptools import setup, find_packages
 
-from setuptools_scm import get_version
+from setuptools import setup, find_packages
 
 from _version import _VERSION    # pylint: disable=import-private-name
 
-version = get_version(root='..', relative_to=__file__)
-if version is not None:
-    _VERSION = version
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+    if version is not None:
+        _VERSION = version
+except ImportError:
+    warning("setuptools_scm not found, using version from _version.py")
 
 extra_requires = {
     # Additional tools for extra functionality.

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -20,6 +20,9 @@ try:
         _VERSION = version
 except ImportError:
     warning("setuptools_scm not found, using version from _version.py")
+except LookupError as e:
+    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
+
 
 extra_requires = {
     # Additional tools for extra functionality.

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -9,7 +9,7 @@ Setup instructions for the mlos_bench package.
 from itertools import chain
 from setuptools import setup, find_packages
 
-_VERSION = '0.0.4'
+from _version import _VERSION    # pylint: disable=import-private-name
 
 extra_requires = {
     # Additional tools for extra functionality.

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -9,7 +9,13 @@ Setup instructions for the mlos_bench package.
 from itertools import chain
 from setuptools import setup, find_packages
 
+from setuptools_scm import get_version
+
 from _version import _VERSION    # pylint: disable=import-private-name
+
+version = get_version(root='..', relative_to=__file__)
+if version is not None:
+    _VERSION = version
 
 extra_requires = {
     # Additional tools for extra functionality.

--- a/mlos_core/_version.py
+++ b/mlos_core/_version.py
@@ -1,0 +1,10 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Version number for the mlos_core package.
+"""
+
+# NOTE: This should be managed by bumpversion.
+_VERSION = '0.0.4'

--- a/mlos_core/_version.py
+++ b/mlos_core/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.0.4'
+_VERSION = '0.1.0'

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -9,7 +9,13 @@ Setup instructions for the mlos_core package.
 from itertools import chain
 from setuptools import setup, find_packages
 
-from _version import _VERSION    # pylint: disable=import-private-name
+from setuptools_scm import get_version
+
+from _version import _VERSION   # pylint: disable=import-private-name
+
+version = get_version(root='..', relative_to=__file__)
+if version is not None:
+    _VERSION = version
 
 extra_requires = {
     'emukit': 'emukit',

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -6,16 +6,21 @@
 Setup instructions for the mlos_core package.
 """
 
+from logging import warning
 from itertools import chain
-from setuptools import setup, find_packages
 
-from setuptools_scm import get_version
+from setuptools import setup, find_packages
 
 from _version import _VERSION   # pylint: disable=import-private-name
 
-version = get_version(root='..', relative_to=__file__)
-if version is not None:
-    _VERSION = version
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__)
+    if version is not None:
+        _VERSION = version
+except ImportError:
+    warning("setuptools_scm not found, using version from _version.py")
+
 
 extra_requires = {
     'emukit': 'emukit',

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -20,6 +20,8 @@ try:
         _VERSION = version
 except ImportError:
     warning("setuptools_scm not found, using version from _version.py")
+except LookupError as e:
+    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
 
 
 extra_requires = {

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -9,7 +9,7 @@ Setup instructions for the mlos_core package.
 from itertools import chain
 from setuptools import setup, find_packages
 
-_VERSION = '0.0.4'
+from _version import _VERSION    # pylint: disable=import-private-name
 
 extra_requires = {
     'emukit': 'emukit',

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -12,9 +12,6 @@ set -eu
 scriptdir=$(dirname "$(readlink -f "$0")")
 cd "$scriptdir/"
 
-CONDA_ENV_NAME=${CONDA_ENV_NAME:-mlos_core}
-conda run -n $CONDA_ENV_NAME pip install bump2version
-
 set -x
 # Example usage: "./update-version.sh --dry-run patch" to bump v0.0.4 -> v0.0.5, for instance.
-conda run -n $CONDA_ENV_NAME bumpversion --verbose $*
+conda run -n ${CONDA_ENV_NAME:-mlos_core} bumpversion --verbose $*

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -4,20 +4,17 @@
 ## Licensed under the MIT License.
 ##
 
+# This script is used to update the git tags, version numbers, etc. in a number of files.
+# See Also: .bumpversion.cfg (which gets rewritten by the tool, and strips comments, so we keep a separate config file for it)
+
 set -eu
 
-NEWVERS=${NEWVERS:-0.0.4}
-
 scriptdir=$(dirname "$(readlink -f "$0")")
-cd "$scriptdir/.."
+cd "$scriptdir/"
 
-sed -i -r -e "s/-[0-9]+\.[0-9]+\.[0-9]+([~]?[a-z0-9]+)?-py/-$NEWVERS-py/" \
-    README.md \
-    doc/source/installation.rst
+CONDA_ENV_NAME=${CONDA_ENV_NAME:-mlos_core}
+conda run -n $CONDA_ENV_NAME pip install bump2version
 
-quotechars='"'
-quotechars+="'"
-
-sed -i -r 's/((_VERSION|release)\s*=\s*['$quotechars'])[0-9]+\.[0-9]+\.[0-9]+([~]?[a-z0-9]+)?(['$quotechars'])/\1'${NEWVERS}'\4/' \
-    mlos_{core,bench}/setup.py \
-    doc/source/conf.py
+set -x
+# Example usage: "./update-version.sh --dry-run patch" to bump v0.0.4 -> v0.0.5, for instance.
+conda run -n $CONDA_ENV_NAME bumpversion --verbose $*

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -10,7 +10,7 @@
 set -eu
 
 scriptdir=$(dirname "$(readlink -f "$0")")
-cd "$scriptdir/"
+cd "$scriptdir/.."
 
 set -x
 # Example usage: "./update-version.sh --dry-run patch" to bump v0.0.4 -> v0.0.5, for instance.

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,13 +39,3 @@ addopts =
 # Moved these to Makefile
 #--cov=mlos_core --cov-report=xml
 testpaths = mlos_core mlos_bench
-
-[bumpversion]
-current_version = 0.0.4
-commit = True
-tag = True
-
-[bumpversion:file:README.md]
-[bumpversion:file:doc/source/installation.rst]
-[bumpversion:mlos_core/_version.py]
-[bumpversion:mlos_bench/_version.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,13 @@ addopts =
 # Moved these to Makefile
 #--cov=mlos_core --cov-report=xml
 testpaths = mlos_core mlos_bench
+
+[bumpversion]
+current_version = 0.0.4
+commit = True
+tag = True
+
+[bumpversion:file:README.md]
+[bumpversion:file:doc/source/installation.rst]
+[bumpversion:mlos_core/_version.py]
+[bumpversion:mlos_bench/_version.py]


### PR DESCRIPTION
- Switch from our manual script to bumpversion for managing manual tags/version changes related to releases.

- Bumps the version to 0.1.0
  Note: Since this is a PR that gets squashed, will have to adjust the tag that points to v0.1.0 after merging

- Adds a programmatic method for adding semver versioning based off of that.
  Mostly useful for local builds.