### PR TITLE
Workaround upstream conda release issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,8 +34,13 @@ USER vscode
 
 # Use the mamba solver (necessary for some quality of life speedups due to
 # required packages to support Windows)
+# FIXME: Simplify this conda solver install rule once the new mamba is released.
+# See Also: https://github.com/conda/conda-libmamba-solver/issues/169#issuecomment-1490509810
 RUN umask 0002 \
-    && /opt/conda/bin/conda install -v -y -n base conda-libmamba-solver \
+    && ( \
+        /opt/conda/bin/conda install -v -y -n base 'conda-libmamba-solver>=23.3.0' \
+        || /opt/conda/bin/conda install -v -y -n base 'conda-forge::conda-libmamba-solver=23.3.0' \
+    ) \
     && /opt/conda/bin/conda config --set solver libmamba
 
 # Update the base. This helps save space by making sure the same version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,7 +62,7 @@
                 "trond-snekvik.simple-rst",
                 "DavidAnson.vscode-markdownlint", // Linter for markdown files
                 "huntertran.auto-markdown-toc", // Auto-generated Markdown Table of Contents
-                "cschleiden.vscode-github-actions", // GitHub Actions integration
+                "github.vscode-github-actions", // GitHub Actions integration
                 "ms-azuretools.vscode-docker",
                 "waderyan.gitblame", // Enhances git blame experience
                 "donjayamanne.githistory", // Enhanced git history experience

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,7 +11,7 @@
         "trond-snekvik.simple-rst",
         "DavidAnson.vscode-markdownlint", // Linter for markdown files
         "huntertran.auto-markdown-toc", // Auto-generated Markdown Table of Contents
-        "cschleiden.vscode-github-actions", // GitHub Actions integration
+        "github.vscode-github-actions", // GitHub Actions integration
         "ms-azuretools.vscode-docker",
         "waderyan.gitblame", // Enhances git blame experience
         "donjayamanne.githistory", // Enhanced git history experience


### PR DESCRIPTION
Attempts to workaround some upstream release version mismatch issues for now so we can build the devcontainer in the pipelines.

See Also: <https://github.com/conda/conda-libmamba-solver/issues/169#issuecomment-1490509810>