### PR TITLE
Devcontainer port conflict tweaks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [
-        "docs-www:80"
+        "docs-www:81"
     ],
     // Prep some host side things for the container build
     "initializeCommand": [".devcontainer/scripts/prep-container-build"],

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,5 +34,5 @@ services:
       - ../doc:/doc
       - ../doc/nginx-default.conf:/etc/nginx/conf.d/default.conf
 
-    # Add "forwardPorts": ["80"] to **devcontainer.json** to forward nginx locally.
+    # Add "forwardPorts": ["81"] to **devcontainer.json** to forward nginx locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,6 +33,9 @@ services:
     volumes:
       - ../doc:/doc
       - ../doc/nginx-default.conf:/etc/nginx/conf.d/default.conf
+    # Our ngxinx config overrides the default listening port.
+    expose:
+    - 81
 
     # Add "forwardPorts": ["81"] to **devcontainer.json** to forward nginx locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/scripts/README.md
+++ b/.devcontainer/scripts/README.md
@@ -23,3 +23,19 @@ The build pipeline publishes the devcontainer image to the Azure Container Regis
 The secrets for this are stored in the pipeline, but also available in a Key Vault in the MlosCore RG.
 
 One can also use `az acr login` to push an image manually if need be.
+
+### Image cleanup
+
+To save space in the ACR, we purge images older than 7 days.
+
+```sh
+#DRY_RUN_ARGS='--dry-run'
+
+PURGE_CMD="acr purge --filter 'devcontainer-cli:.*' --filter 'mlos-core-devcontainer:.*' --untagged --ago 7d $DRY_RUN_ARGS"
+
+# Setup a daily task:
+az acr task create --name dailyPurgeTask --cmd "$PURGE_CMD" --registry mloscore --schedule "0 1 * * *" --context /dev/null
+
+# Or, run it manually.
+az acr run --cmd "$PURGE_CMD" --registry mloscore --context /dev/null
+```

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ licenseheaders: build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
 
 build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: $(PYTHON_FILES) doc/mit-license.tmpl
 	# Note: to avoid makefile dependency loops, we don't touch the setup.py files as that would force the conda-env to be rebuilt.
-	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 -x mlos_bench/setup.py mlos_core/setup.py
+	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 .sql -x mlos_bench/setup.py mlos_core/setup.py
 	touch $@
 
 .PHONY: cspell

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ licenseheaders: build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
 
 build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: $(PYTHON_FILES) doc/mit-license.tmpl
 	# Note: to avoid makefile dependency loops, we don't touch the setup.py files as that would force the conda-env to be rebuilt.
-	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 .sql -x mlos_bench/setup.py mlos_core/setup.py
+	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 -x mlos_bench/setup.py mlos_core/setup.py
 	touch $@
 
 .PHONY: cspell

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ endif
 build/linklint-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov/index.html build/check-doc.build-stamp
 	@echo "Starting nginx docker container for serving docs."
 	./doc/nginx-docker.sh restart
-	docker exec mlos-doc-nginx curl -sSf http://localhost/index.html >/dev/null
+	docker exec mlos-doc-nginx curl -sSf http://localhost:81/index.html >/dev/null
 	@echo "Running linklint on the docs."
 	docker exec mlos-doc-nginx linklint -net -redirect -root /doc/build/html/ /@ -error -warn > doc/build/linklint.out 2>&1
 	@if cat doc/build/linklint.out | grep -e ^ERROR -e ^WARN | grep -v 'missing named anchors' | grep -q .; then \

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,2 +1,4 @@
 FROM nginx:latest
 RUN apt-get update && apt-get install -y --no-install-recommends linklint curl
+# Our ngxinx config overrides the default listening port.
+EXPOSE 81

--- a/doc/nginx-default.conf
+++ b/doc/nginx-default.conf
@@ -1,7 +1,7 @@
 # vim: set ft=nginx:
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       81;
+    listen  [::]:81;
     server_name  localhost;
 
     #access_log  /var/log/nginx/host.access.log  main;

--- a/doc/nginx-docker.sh
+++ b/doc/nginx-docker.sh
@@ -26,7 +26,7 @@ if [ "$1" == 'start' ]; then
     docker run -d --name mlos-doc-nginx \
         -v "$repo_root/doc/nginx-default.conf":/etc/nginx/conf.d/default.conf \
         -v "$repo_root/doc":/doc \
-        -p 8080:80 \
+        -p 8080:81 \
         mlos-doc-nginx
     set +x
 elif [ "$1" == 'stop' ]; then

--- a/mlos_bench/db/osat.sql
+++ b/mlos_bench/db/osat.sql
@@ -1,3 +1,7 @@
+--
+-- Copyright (c) Microsoft Corporation.
+-- Licensed under the MIT License.
+--
 
 DROP TABLE IF EXISTS benchmark CASCADE;
 DROP TABLE IF EXISTS benchmark_status CASCADE;

--- a/mlos_bench/db/osat.sql
+++ b/mlos_bench/db/osat.sql
@@ -1,7 +1,3 @@
---
--- Copyright (c) Microsoft Corporation.
--- Licensed under the MIT License.
---
 
 DROP TABLE IF EXISTS benchmark CASCADE;
 DROP TABLE IF EXISTS benchmark_status CASCADE;


### PR DESCRIPTION
Windows (or other platforms) may listen on port 80 and cause conflicts when WSL2 tries to forward ports for both sides so that `localhost` resolution behaves as expected despite the VM technically being a separate host.
When this happens the devcontainer can fail to start due to in ability for nginx docs container to listen on port 80.
To workaround this we simply tell it to listen on port 81 instead.  The devcontainer forwards the port to a different one on the host anyways.

Additionally, we document some commands for cleaning up stale container images in the ACR service to avoid excessive storage usage.