### PR TITLE
devcontainer nginx port fixups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,10 +7,6 @@
     "dockerComposeFile": "docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [
-        "docs-www:81"
-    ],
     // Prep some host side things for the container build
     "initializeCommand": [".devcontainer/scripts/prep-container-build"],
     // Make sure the container user can read/write to the package caches.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,10 +16,10 @@ services:
     volumes:
       - ../..:/workspaces:cached
 
-    env_file: ../.env
-
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while true; do sleep 1000; done"
+
+    env_file: ../.env
 
   docs-www:
     build:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,26 +16,35 @@ services:
     volumes:
       - ../..:/workspaces:cached
 
+    env_file: ../.env
+
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while true; do sleep 1000; done"
 
+  docs-www:
+    build:
+      context: ./tmp
+      dockerfile: ../../doc/Dockerfile
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+        no_proxy: ${no_proxy}
+        NGINX_PORT: ${NGINX_PORT}
+
     env_file: ../.env
 
-    # Runs app on the same network as the nginx container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:docs-www
+    # Export the port that nginx is listening on for the localhost.
+    # This will map it to a random port to avoid conflicts.
+    # To find which one it's using run `docker ps | grep mlos.*devcontainer-docs-www` and inspect the PORTs column.
+    ports:
+      - "${NGINX_PORT}"
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
-
-  docs-www:
-    image: nginx:latest
     restart: unless-stopped
     volumes:
+      # Our nginx config overrides the default listening port and serving directory.
       - ../doc:/doc
-      - ../doc/nginx-default.conf:/etc/nginx/conf.d/default.conf
-    # Our ngxinx config overrides the default listening port.
-    expose:
-    - 81
+      - ../doc/nginx-default.conf:/etc/nginx/templates/default.conf.template
 
     # Add "forwardPorts": ["81"] to **devcontainer.json** to forward nginx locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -30,15 +30,16 @@ services:
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
         no_proxy: ${no_proxy}
-        NGINX_PORT: ${NGINX_PORT}
-
-    env_file: ../.env
+        # This value is picked up automatically from the .env file in the .devcontainer directory
+        # (where docker-compose is run from).
+        # We prep that file automatically with the prep-container-build script.
+        NGINX_PORT: ${NGINX_PORT:-81}
 
     # Export the port that nginx is listening on for the localhost.
     # This will map it to a random port to avoid conflicts.
     # To find which one it's using run `docker ps | grep mlos.*devcontainer-docs-www` and inspect the PORTs column.
     ports:
-      - "${NGINX_PORT}"
+      - "${NGINX_PORT:-81}"
 
     restart: unless-stopped
     volumes:

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -18,9 +18,10 @@ if [ ! -f .env ]; then
     echo "Creating empty .env file for devcontainer."
     touch .env
 fi
-if ! egrep -q "^NGINX_PORT=[0-9]+$" .env; then
-    sed -i -e '/^NGINX_PORT=/d' .env
-    echo "NGINX_PORT=$(($(shuf -i 0-30000 -n 1) + 80))" >> .env
+# Also prep the random NGINX_PORT for the docker-compose command.
+if ! [ -e .devcontainer/.env ] || ! egrep -q "^NGINX_PORT=[0-9]+$" .devcontainer/.env; then
+    NGINX_PORT=$(($(shuf -i 0-30000 -n 1) + 80))
+    echo "NGINX_PORT=$NGINX_PORT" > .devcontainer/.env
 fi
 
 # Prep some files to use as context for the devcontainer to build from.

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -18,6 +18,10 @@ if [ ! -f .env ]; then
     echo "Creating empty .env file for devcontainer."
     touch .env
 fi
+if ! egrep -q "^NGINX_PORT=[0-9]+$" .env; then
+    sed -i -e '/^NGINX_PORT=/d' .env
+    echo "NGINX_PORT=$(($(shuf -i 0-30000 -n 1) + 80))" >> .env
+fi
 
 # Prep some files to use as context for the devcontainer to build from.
 if [ -d .devcontainer/tmp ]; then

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -46,11 +46,14 @@ cp -v .devcontainer/scripts/common/prep-deps-files.sh .devcontainer/tmp/prep-dep
 # upstream to see if we can use it as a cache.
 # TODO: Ideally we'd only do this when rebuilding the image, but not sure how
 # to detect that form of startup yet.
+# See Also: https://github.com/microsoft/vscode-remote-release/issues/8179
 if [ "${NO_CACHE:-}" != 'true' ]; then
     cacheFrom='mloscore.azurecr.io/mlos-core-devcontainer'
-    # Make sure we use an empty config to avoid auth issues for devs with the
-    # registry, which should allow anonymous pulls
-    tmpdir=$(mktemp -d)
-    docker --config="$tmpdir" pull -q "$cacheFrom" >/dev/null || true
-    rmdir "$tmpdir"
+    # Skip pulling for now (see TODO note above)
+    echo "Consider pulling image $cacheFrom for build caching."
+    ## Make sure we use an empty config to avoid auth issues for devs with the
+    ## registry, which should allow anonymous pulls
+    #tmpdir=$(mktemp -d)
+    #docker --config="$tmpdir" pull -q "$cacheFrom" >/dev/null || true
+    #rmdir "$tmpdir"
 fi

--- a/.devcontainer/scripts/prep-container-build.ps1
+++ b/.devcontainer/scripts/prep-container-build.ps1
@@ -14,6 +14,10 @@ if (!(Test-Path .env)) {
     Write-Host "Creating empty .env file for devcontainer."
     New-Item -Type File .env
 }
+if (!(Get-Content .\.env | Select-String '^NGINX_PORT=[0-9]+$')) {
+    $NGINX_PORT = (Get-Random) % 30000 + 80
+    echo "NGINX_PORT=$NGINX_PORT" >> .env
+}
 
 # Prep some files to use as context for the devcontainer to build from.
 if (Test-Path .devcontainer/tmp) {

--- a/.devcontainer/scripts/prep-container-build.ps1
+++ b/.devcontainer/scripts/prep-container-build.ps1
@@ -42,8 +42,10 @@ Copy-Item .devcontainer/scripts/common/prep-deps-files.sh .devcontainer/tmp/prep
 # upstream to see if we can use it as a cache.
 # TODO: Ideally we'd only do this when rebuilding the image, but not sure how
 # to detect that form of startup yet.
+# See Also: https://github.com/microsoft/vscode-remote-release/issues/8179
 if ($env:NO_CACHE -ne 'true') {
     $cacheFrom = 'mloscore.azurecr.io/mlos-core-devcontainer'
-    Write-Host "Pulling cached image $cacheFrom"
-    docker pull $cacheFrom
+    # Skip pulling for now (see TODO note above)
+    Write-Host "Consider pulling image $cacheFrom for build caching."
+    #docker pull $cacheFrom
 }

--- a/.devcontainer/scripts/prep-container-build.ps1
+++ b/.devcontainer/scripts/prep-container-build.ps1
@@ -14,9 +14,9 @@ if (!(Test-Path .env)) {
     Write-Host "Creating empty .env file for devcontainer."
     New-Item -Type File .env
 }
-if (!(Get-Content .\.env | Select-String '^NGINX_PORT=[0-9]+$')) {
-    $NGINX_PORT = (Get-Random) % 30000 + 80
-    echo "NGINX_PORT=$NGINX_PORT" >> .env
+if (!(Test-Path ./.devcontainer/.env) -or !(Get-Content ./.devcontainer/.env | Select-String '^NGINX_PORT=[0-9]+$')) {
+    $NGINX_PORT = (Get-Random) % 30000 + 8
+    Set-Content -Encoding ascii -NoNewline -Path ./.devcontainer/.env -Value "NGINX_PORT=$NGINX_PORT"
 }
 
 # Prep some files to use as context for the devcontainer to build from.

--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ build/linklint-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov
 	@echo "Starting nginx docker container for serving docs."
 	./doc/nginx-docker.sh restart
 	docker port mlos-doc-nginx
-	nginx_port=`docker port mlos-doc-nginx | cut -d/ -f1` \
+	nginx_port=`docker port mlos-doc-nginx | grep 0.0.0.0:8080 | cut -d/ -f1` \
 		&& echo nginx_port=$${nginx_port} \
 		&& set -x \
 		&& docker exec mlos-doc-nginx curl -sSf http://localhost:$${nginx_port}/index.html >/dev/null

--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,7 @@ endif
 build/linklint-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov/index.html build/check-doc.build-stamp
 	@echo "Starting nginx docker container for serving docs."
 	./doc/nginx-docker.sh restart
+	docker port mlos-doc-nginx
 	nginx_port=`docker port mlos-doc-nginx | cut -d/ -f1` \
 		&& echo nginx_port=$${nginx_port} \
 		&& set -x \

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,10 @@ endif
 build/linklint-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov/index.html build/check-doc.build-stamp
 	@echo "Starting nginx docker container for serving docs."
 	./doc/nginx-docker.sh restart
-	nginx_port=`docker port mlos-doc-nginx | cut -d/ -f1` && docker exec mlos-doc-nginx curl -sSf http://localhost:$${nginx_port}/index.html >/dev/null
+	nginx_port=`docker port mlos-doc-nginx | cut -d/ -f1` \
+		&& echo nginx_port=$${nginx_port} \
+		&& set -x \
+		&& docker exec mlos-doc-nginx curl -sSf http://localhost:$${nginx_port}/index.html >/dev/null
 	@echo "Running linklint on the docs."
 	docker exec mlos-doc-nginx linklint -net -redirect -root /doc/build/html/ /@ -error -warn > doc/build/linklint.out 2>&1
 	@if cat doc/build/linklint.out | grep -e ^ERROR -e ^WARN | grep -v 'missing named anchors' | grep -q .; then \

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ endif
 build/linklint-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov/index.html build/check-doc.build-stamp
 	@echo "Starting nginx docker container for serving docs."
 	./doc/nginx-docker.sh restart
-	docker exec mlos-doc-nginx curl -sSf http://localhost:81/index.html >/dev/null
+	nginx_port=`docker port mlos-doc-nginx | cut -d/ -f1` && docker exec mlos-doc-nginx curl -sSf http://localhost:$${nginx_port}/index.html >/dev/null
 	@echo "Running linklint on the docs."
 	docker exec mlos-doc-nginx linklint -net -redirect -root /doc/build/html/ /@ -error -warn > doc/build/linklint.out 2>&1
 	@if cat doc/build/linklint.out | grep -e ^ERROR -e ^WARN | grep -v 'missing named anchors' | grep -q .; then \

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,4 +1,6 @@
 FROM nginx:latest
 RUN apt-get update && apt-get install -y --no-install-recommends linklint curl
 # Our ngxinx config overrides the default listening port.
-EXPOSE 81
+ARG NGINX_PORT=81
+ENV NGINX_PORT=${NGINX_PORT}
+EXPOSE ${NGINX_PORT}

--- a/doc/nginx-default.conf
+++ b/doc/nginx-default.conf
@@ -1,7 +1,6 @@
 # vim: set ft=nginx:
 server {
-    listen       81;
-    listen  [::]:81;
+    listen       ${NGINX_PORT};
     server_name  localhost;
 
     #access_log  /var/log/nginx/host.access.log  main;

--- a/doc/nginx-docker.sh
+++ b/doc/nginx-docker.sh
@@ -6,9 +6,16 @@
 
 # A quick script to start a local webserver for testing the sphinx documentation.
 
+set -eu
+
 scriptpath=$(readlink -f "$0")
 scriptdir=$(dirname "$scriptpath")
 cd "$scriptdir"
+
+if [ -f ../.env ]; then
+    source ../.env
+fi
+NGINX_PORT="${NGINX_PORT:-81}"
 
 # Make it work inside a devcontainer too.
 repo_root=$(readlink -f "$scriptdir/..")
@@ -16,23 +23,29 @@ if [ -n "${LOCAL_WORKSPACE_FOLDER:-}" ]; then
     repo_root="$LOCAL_WORKSPACE_FOLDER"
 fi
 
-if [ "$1" == 'start' ]; then
+cmd="${1:-}"
+
+if [ "$cmd" == 'start' ]; then
     set -x
+    tmpdir=$(mktemp -d)
     docker build --progress=plain -t mlos-doc-nginx \
         --build-arg http_proxy=$http_proxy \
         --build-arg https_proxy=$https_proxy \
         --build-arg no_proxy=$no_proxy \
-        -f Dockerfile /dev/null
+        --build-arg NGINX_PORT=$NGINX_PORT \
+        -f Dockerfile "$tmpdir"
+    rmdir "$tmpdir"
     docker run -d --name mlos-doc-nginx \
-        -v "$repo_root/doc/nginx-default.conf":/etc/nginx/conf.d/default.conf \
+        -v "$repo_root/doc/nginx-default.conf":/etc/nginx/templates/default.conf.template \
         -v "$repo_root/doc":/doc \
-        -p 8080:81 \
+        --env NGINX_PORT=$NGINX_PORT \
+        -p 8080:$NGINX_PORT \
         mlos-doc-nginx
     set +x
-elif [ "$1" == 'stop' ]; then
+elif [ "$cmd" == 'stop' ]; then
     docker stop mlos-doc-nginx || true
     docker rm mlos-doc-nginx || true
-elif [ "$1" == 'restart' ]; then
+elif [ "$cmd" == 'restart' ]; then
     "$scriptpath" 'stop'
     "$scriptpath" 'start'
 else

--- a/doc/nginx-docker.sh
+++ b/doc/nginx-docker.sh
@@ -12,8 +12,8 @@ scriptpath=$(readlink -f "$0")
 scriptdir=$(dirname "$scriptpath")
 cd "$scriptdir"
 
-if [ -f ../.env ]; then
-    source ../.env
+if [ -f ../.devcontainer/.env ]; then
+    source ../.devcontainer/.env
 fi
 NGINX_PORT="${NGINX_PORT:-81}"
 


### PR DESCRIPTION
WSL2 has some weird port mapping behavior that automatically puts container listening ports into the host's network ports as well, leading to port clashes when we run multiple devcontainers at once.

To work around this we make use of nginx container's ability to listen on dynamic ports and docker compose ability to publish container ports to random other host ports.

To make this work we write a small `.env` file in the `.devcontainer/` directory that docker compose automatically picks up during the nginx container build process.

Additionally, we stop pulling upstream container images on each vscode launch for now.
See Also: https://github.com/microsoft/vscode-remote-release/issues/8179