### PR TITLE
No-op storage implementation

### DIFF
--- a/mlos_bench/config/storage/null.jsonc
+++ b/mlos_bench/config/storage/null.jsonc
@@ -1,0 +1,5 @@
+// No-op storage backend for testing and one-off benchmarks.
+{
+    "class": "mlos_bench.storage.null_storage.NullStorage",
+    "config": {}
+}

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -22,7 +22,7 @@ _LOG = logging.getLogger(__name__)
 
 
 class Storage(metaclass=ABCMeta):
-    # pylint: disable=too-few-public-methods,too-many-instance-attributes
+    # pylint: disable=too-few-public-methods
     """
     An abstract interface between the benchmarking framework
     and storage systems (e.g., SQLite or MLFLow).
@@ -187,10 +187,12 @@ class Storage(metaclass=ABCMeta):
                 the results of the experiment trial run.
             """
 
-    class Trial(metaclass=ABCMeta):
+    class Trial:
         """
         Base interface for storing the results of a single run of the experiment.
         This class is instantiated in the `Storage.Experiment.trial()` method.
+
+        This class is also a complete no-op implementation of the trial storage.
         """
 
         def __init__(self, *,
@@ -239,7 +241,6 @@ class Storage(metaclass=ABCMeta):
             config["trialId"] = self._trial_id
             return config
 
-        @abstractmethod
         def update(self, status: Status,
                    metrics: Optional[Union[Dict[str, float], float]] = None
                    ) -> Optional[Dict[str, float]]:
@@ -266,7 +267,6 @@ class Storage(metaclass=ABCMeta):
                 #     f"Optimization target '{self._opt_target}' is missing from {metrics}")
             return {self._opt_target: metrics} if isinstance(metrics, (float, int)) else metrics
 
-        @abstractmethod
         def update_telemetry(self, status: Status,
                              metrics: Optional[Dict[str, float]] = None) -> None:
             """

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -86,9 +86,16 @@ class Storage(metaclass=ABCMeta):
         This class is instantiated in the `Storage.experiment()` method.
         """
 
-        def __init__(self, tunables: TunableGroups, experiment_id: str, root_env_config: str):
+        def __init__(self, *,
+                     tunables: TunableGroups,
+                     experiment_id: str,
+                     trial_id: int,
+                     root_env_config: str,
+                     opt_target: str):
             self._tunables = tunables.copy()
             self._experiment_id = experiment_id
+            self._trial_id = trial_id
+            self._opt_target = opt_target
             (self._git_repo, self._git_commit, self._root_env_config) = get_git_info(root_env_config)
 
         def __enter__(self) -> 'Storage.Experiment':

--- a/mlos_bench/mlos_bench/storage/no_storage.py
+++ b/mlos_bench/mlos_bench/storage/no_storage.py
@@ -1,0 +1,74 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+No-op implementation of the storage interface.
+"""
+
+import logging
+from typing import Optional, List, Tuple, Dict, Iterator, Any
+
+from mlos_bench.tunables.tunable_groups import TunableGroups
+from mlos_bench.storage.base_storage import Storage
+
+_LOG = logging.getLogger(__name__)
+
+
+class Experiment(Storage.Experiment):
+    """
+    No-op implementation of the storage for an experiment.
+    """
+
+    def __init__(self, *,
+                 tunables: TunableGroups,
+                 experiment_id: str,
+                 trial_id: int,
+                 root_env_config: str,
+                 opt_target: str):
+        super().__init__(tunables, experiment_id, root_env_config)
+        self._trial_id = trial_id
+        self._opt_target = opt_target
+
+    def merge(self, experiment_ids: List[str]) -> None:
+        raise NotImplementedError()
+
+    def load(self, opt_target: Optional[str] = None) -> Tuple[List[dict], List[float]]:
+        return ([], [])
+
+    def pending_trials(self) -> Iterator['Storage.Trial']:
+        return iter([])
+
+    def new_trial(self, tunables: TunableGroups,
+                  config: Optional[Dict[str, Any]] = None) -> 'Storage.Trial':
+        _LOG.info("New Trial: %s", self)
+        return Storage.Trial(
+            tunables=tunables,
+            experiment_id=self._experiment_id,
+            trial_id=self._trial_id,
+            config_id=0,
+            opt_target=self._opt_target,
+            config=config,
+        )
+
+
+class NoStorage(Storage):
+    # pylint: disable=too-few-public-methods
+    """
+    No-op implementation of the storage interface.
+    """
+
+    def experiment(self, *,
+                   experiment_id: str,
+                   trial_id: int,
+                   root_env_config: str,
+                   description: str,
+                   opt_target: str) -> 'Storage.Experiment':
+        _LOG.info("Experiment: %s", self)
+        return Experiment(
+            tunables=self._tunables,
+            experiment_id=experiment_id,
+            trial_id=trial_id,
+            root_env_config=root_env_config,
+            opt_target=opt_target,
+        )

--- a/mlos_bench/mlos_bench/storage/no_storage.py
+++ b/mlos_bench/mlos_bench/storage/no_storage.py
@@ -20,16 +20,6 @@ class Experiment(Storage.Experiment):
     No-op implementation of the storage for an experiment.
     """
 
-    def __init__(self, *,
-                 tunables: TunableGroups,
-                 experiment_id: str,
-                 trial_id: int,
-                 root_env_config: str,
-                 opt_target: str):
-        super().__init__(tunables, experiment_id, root_env_config)
-        self._trial_id = trial_id
-        self._opt_target = opt_target
-
     def merge(self, experiment_ids: List[str]) -> None:
         raise NotImplementedError()
 
@@ -41,8 +31,7 @@ class Experiment(Storage.Experiment):
 
     def new_trial(self, tunables: TunableGroups,
                   config: Optional[Dict[str, Any]] = None) -> 'Storage.Trial':
-        _LOG.info("New Trial: %s", self)
-        return Storage.Trial(
+        trial = Storage.Trial(
             tunables=tunables,
             experiment_id=self._experiment_id,
             trial_id=self._trial_id,
@@ -50,6 +39,9 @@ class Experiment(Storage.Experiment):
             opt_target=self._opt_target,
             config=config,
         )
+        _LOG.info("New Trial: %s", trial)
+        self._trial_id += 1
+        return trial
 
 
 class NoStorage(Storage):
@@ -64,11 +56,12 @@ class NoStorage(Storage):
                    root_env_config: str,
                    description: str,
                    opt_target: str) -> 'Storage.Experiment':
-        _LOG.info("Experiment: %s", self)
-        return Experiment(
+        exp = Experiment(
             tunables=self._tunables,
             experiment_id=experiment_id,
             trial_id=trial_id,
             root_env_config=root_env_config,
             opt_target=opt_target,
         )
+        _LOG.info("Experiment: %s", exp)
+        return exp

--- a/mlos_bench/mlos_bench/storage/null_storage.py
+++ b/mlos_bench/mlos_bench/storage/null_storage.py
@@ -15,7 +15,7 @@ from mlos_bench.storage.base_storage import Storage
 _LOG = logging.getLogger(__name__)
 
 
-class Experiment(Storage.Experiment):
+class NullExperiment(Storage.Experiment):
     """
     No-op implementation of the storage for an experiment.
     """
@@ -35,7 +35,7 @@ class Experiment(Storage.Experiment):
             tunables=tunables,
             experiment_id=self._experiment_id,
             trial_id=self._trial_id,
-            config_id=self._trial_id,  # Make it always unique.
+            config_id=self._trial_id,  # Always unique since there is no storage.
             opt_target=self._opt_target,
             config=config,
         )
@@ -56,12 +56,10 @@ class NullStorage(Storage):
                    root_env_config: str,
                    description: str,
                    opt_target: str) -> 'Storage.Experiment':
-        exp = Experiment(
+        return NullExperiment(
             tunables=self._tunables,
             experiment_id=experiment_id,
             trial_id=trial_id,
             root_env_config=root_env_config,
             opt_target=opt_target,
         )
-        _LOG.info("Experiment: %s", exp)
-        return exp

--- a/mlos_bench/mlos_bench/storage/null_storage.py
+++ b/mlos_bench/mlos_bench/storage/null_storage.py
@@ -35,7 +35,7 @@ class Experiment(Storage.Experiment):
             tunables=tunables,
             experiment_id=self._experiment_id,
             trial_id=self._trial_id,
-            config_id=0,
+            config_id=self._trial_id,  # Make it always unique.
             opt_target=self._opt_target,
             config=config,
         )
@@ -44,7 +44,7 @@ class Experiment(Storage.Experiment):
         return trial
 
 
-class NoStorage(Storage):
+class NullStorage(Storage):
     # pylint: disable=too-few-public-methods
     """
     No-op implementation of the storage interface.

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -35,12 +35,16 @@ class Experiment(Storage.Experiment):
                  root_env_config: str,
                  description: str,
                  opt_target: str):
-        super().__init__(tunables, experiment_id, root_env_config)
+        super().__init__(
+            tunables=tunables,
+            experiment_id=experiment_id,
+            trial_id=trial_id,
+            root_env_config=root_env_config,
+            opt_target=opt_target,
+        )
         self._engine = engine
         self._schema = schema
-        self._trial_id = trial_id
         self._description = description
-        self._opt_target = opt_target
 
     def _setup(self) -> None:
         super()._setup()

--- a/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
@@ -11,8 +11,6 @@ from mlos_bench.environment.status import Status
 from mlos_bench.tunables.tunable_groups import TunableGroups
 from mlos_bench.storage.base_storage import Storage
 
-# pylint: disable=redefined-outer-name
-
 
 def test_exp_load_empty(exp_storage_memory_sql: Storage.Experiment) -> None:
     """

--- a/mlos_bench/mlos_bench/tests/storage/null_storage_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/null_storage_test.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests for the no-op storage subsystem.
+"""
+import pytest
+
+from mlos_bench.environment.status import Status
+from mlos_bench.tunables.tunable_groups import TunableGroups
+from mlos_bench.storage.base_storage import Storage
+from mlos_bench.storage.null_storage import NullStorage
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def null_experiment(tunable_groups: TunableGroups) -> Storage.Experiment:
+    """
+    Test fixture for mock no-op storage.
+    """
+    storage = NullStorage(
+        tunables=tunable_groups,
+        service=None,
+        config={},
+    )
+    # pylint: disable=unnecessary-dunder-call
+    return storage.experiment(
+        experiment_id="Test-001",
+        trial_id=1,
+        root_env_config="environment.jsonc",
+        description="pytest experiment",
+        opt_target="score",
+    ).__enter__()
+
+
+def test_exp_trial_pending(null_experiment: Storage.Experiment,
+                           tunable_groups: TunableGroups) -> None:
+    """
+    Start two new trials and check that it is *NOT* stored aywhere.
+    """
+    null_experiment.new_trial(tunable_groups)
+    null_experiment.new_trial(tunable_groups)
+    pending = list(null_experiment.pending_trials())
+    assert not pending
+
+
+def test_exp_trial_success(null_experiment: Storage.Experiment,
+                           tunable_groups: TunableGroups) -> None:
+    """
+    Start a trial, finish it successfully, and and check that it is NOT pending.
+    """
+    trial = null_experiment.new_trial(tunable_groups)
+    trial.update(Status.SUCCEEDED, 99.9)
+    pending = list(null_experiment.pending_trials())
+    assert not pending
+
+
+def test_exp_trial_pending_3(null_experiment: Storage.Experiment,
+                             tunable_groups: TunableGroups) -> None:
+    """
+    Start THREE trials, let one succeed, another one fail and keep one not updated.
+    Check that no information is stored anywhere.
+    """
+    score = 99.9
+
+    trial_fail = null_experiment.new_trial(tunable_groups)
+    trial_succ = null_experiment.new_trial(tunable_groups)
+    null_experiment.new_trial(tunable_groups)  # Pending trial
+
+    trial_fail.update(Status.FAILED)
+    trial_succ.update(Status.SUCCEEDED, score)
+
+    pending = list(null_experiment.pending_trials())
+    assert not pending
+
+    (configs, scores) = null_experiment.load()
+    assert len(configs) == 0
+    assert len(scores) == 0

--- a/mlos_bench/mlos_bench/tests/storage/null_storage_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/null_storage_test.py
@@ -35,8 +35,8 @@ def null_experiment(tunable_groups: TunableGroups) -> Storage.Experiment:
     ).__enter__()
 
 
-def test_exp_trial_pending(null_experiment: Storage.Experiment,
-                           tunable_groups: TunableGroups) -> None:
+def test_null_trial_pending(null_experiment: Storage.Experiment,
+                            tunable_groups: TunableGroups) -> None:
     """
     Start two new trials and check that it is *NOT* stored aywhere.
     """
@@ -46,8 +46,8 @@ def test_exp_trial_pending(null_experiment: Storage.Experiment,
     assert not pending
 
 
-def test_exp_trial_success(null_experiment: Storage.Experiment,
-                           tunable_groups: TunableGroups) -> None:
+def test_null_trial_success(null_experiment: Storage.Experiment,
+                            tunable_groups: TunableGroups) -> None:
     """
     Start a trial, finish it successfully, and and check that it is NOT pending.
     """
@@ -57,8 +57,8 @@ def test_exp_trial_success(null_experiment: Storage.Experiment,
     assert not pending
 
 
-def test_exp_trial_pending_3(null_experiment: Storage.Experiment,
-                             tunable_groups: TunableGroups) -> None:
+def test_null_trial_pending_3(null_experiment: Storage.Experiment,
+                              tunable_groups: TunableGroups) -> None:
     """
     Start THREE trials, let one succeed, another one fail and keep one not updated.
     Check that no information is stored anywhere.
@@ -67,7 +67,11 @@ def test_exp_trial_pending_3(null_experiment: Storage.Experiment,
 
     trial_fail = null_experiment.new_trial(tunable_groups)
     trial_succ = null_experiment.new_trial(tunable_groups)
-    null_experiment.new_trial(tunable_groups)  # Pending trial
+    trial_pend = null_experiment.new_trial(tunable_groups)
+
+    assert trial_fail.trial_id == 1
+    assert trial_succ.trial_id == 2
+    assert trial_pend.trial_id == 3
 
     trial_fail.update(Status.FAILED)
     trial_succ.update(Status.SUCCEEDED, score)


### PR DESCRIPTION
We'll need it for testing and one-off benchmarks. It also helps us to streamline the operation of `run_bench.py` and `run_op.py` and probably get the two converged into a single app (run_opt with null optimizer and null storage is effectively run_bench)