### PR TITLE
bugfix: correct class name for OneShotOptimizer

### DIFF
--- a/mlos_bench/config/optimizers/one_shot_opt.jsonc
+++ b/mlos_bench/config/optimizers/one_shot_opt.jsonc
@@ -1,6 +1,6 @@
 // Null optimizer that runs a single benchmark with the specified configuration.
 {
-    "class": "mlos_bench.optimizer.NullOptimizer",
+    "class": "mlos_bench.optimizer.OneShotOptimizer",
 
     "config": {
         "minimize": "score",

--- a/mlos_bench/mlos_bench/service/config_persistence.py
+++ b/mlos_bench/mlos_bench/service/config_persistence.py
@@ -45,6 +45,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         """
         super().__init__(config, parent)
         self._config_path = self.config.get("config_path", [])
+        self._config_loader_service = self
 
         # Register methods that we want to expose to the Environment objects.
         self.register([


### PR DESCRIPTION
also, make sure config loader is available even when it's the only service without a parent