### PR TITLE
Tweaks to Tunables

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
         "llamatune",
         "matplotlib",
         "mlos",
+        "mwait",
         "ndarray",
         "ndim",
         "nsmallest",

--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -167,7 +167,7 @@ class Environment(metaclass=abc.ABCMeta):
             Free-format dictionary that contains the new environment configuration.
         """
         return tunables.get_param_values(
-            group_names=list(self._tunable_params.get_names()),
+            group_names=list(self._tunable_params.get_covariant_group_names()),
             into_params=self._const_args.copy())
 
     @property

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -119,7 +119,7 @@ class LocalEnv(Environment):
                 with open(os.path.join(temp_dir, self._dump_params_file),
                           "wt", encoding="utf-8") as fh_tunables:
                     # json.dump(self._params, fh_tunables)  # Tunables *and* const_args
-                    json.dump(tunables.get_param_values(self._tunable_params.get_names()),
+                    json.dump(tunables.get_param_values(self._tunable_params.get_covariant_group_names()),
                               fh_tunables)
 
             (return_code, _stdout, stderr) = self._local_exec_service.local_exec(

--- a/mlos_bench/mlos_bench/environments/mock_env.py
+++ b/mlos_bench/mlos_bench/environments/mock_env.py
@@ -97,8 +97,8 @@ class MockEnv(Environment):
         """
         val = None
         if tunable.is_categorical:
-            val = (tunable.categorical_values.index(tunable.categorical_value) /
-                   float(len(tunable.categorical_values) - 1))
+            val = (tunable.categories.index(tunable.categorical_value) /
+                   float(len(tunable.categories) - 1))
         elif tunable.is_numerical:
             val = ((tunable.numerical_value - tunable.range[0]) /
                    float(tunable.range[1] - tunable.range[0]))

--- a/mlos_bench/mlos_bench/optimizers/convert_configspace.py
+++ b/mlos_bench/mlos_bench/optimizers/convert_configspace.py
@@ -44,7 +44,7 @@ def _tunable_to_hyperparameter(
     meta = {"group": group_name, "cost": cost}  # {"lower": "", "upper": "", "scaling": ""}
     if tunable.type == "categorical":
         return CategoricalHyperparameter(
-            tunable.name, choices=tunable.categorical_values,
+            tunable.name, choices=tunable.categories,
             default_value=tunable.value, meta=meta)
     elif tunable.type == "int":
         return UniformIntegerHyperparameter(

--- a/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
@@ -30,7 +30,7 @@ class MockOptimizer(Optimizer):
         super().__init__(tunables, service, config)
         rnd = random.Random(config.get("seed", 42))
         self._random: Dict[str, Callable[[Tunable], TunableValue]] = {
-            "categorical": lambda tunable: rnd.choice(tunable.categorical_values),
+            "categorical": lambda tunable: rnd.choice(tunable.categories),
             "float": lambda tunable: rnd.uniform(*tunable.range),
             "int": lambda tunable: rnd.randint(*tunable.range),
         }

--- a/mlos_bench/mlos_bench/tests/conftest.py
+++ b/mlos_bench/mlos_bench/tests/conftest.py
@@ -9,6 +9,7 @@ Common fixtures for mock TunableGroups and Environment objects.
 import pytest
 
 from mlos_bench.environments.mock_env import MockEnv
+from mlos_bench.tunables.covariant_group import CovariantTunableGroup
 from mlos_bench.tunables.tunable_groups import TunableGroups
 
 # pylint: disable=redefined-outer-name
@@ -70,6 +71,19 @@ def tunable_groups() -> TunableGroups:
     })
     tunables.reset()
     return tunables
+
+
+@pytest.fixture
+def covariant_group(tunable_groups: TunableGroups) -> CovariantTunableGroup:
+    """
+    Text fixture to get a CovariantTunableGroup from tunable_groups.
+
+    Returns
+    -------
+    CovariantTunableGroup
+    """
+    (_, covariant_group) = next(iter(tunable_groups))
+    return covariant_group
 
 
 @pytest.fixture

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_accessors_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_accessors_test.py
@@ -19,7 +19,7 @@ def test_categorical_access_to_numerical_tunable(tunable_int: Tunable) -> None:
     with pytest.raises(ValueError):
         print(tunable_int.categorical_value)
     with pytest.raises(AssertionError):
-        print(tunable_int.categorical_values)
+        print(tunable_int.categories)
 
 
 def test_numerical_access_to_categorical_tunable(tunable_categorical: Tunable) -> None:

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_accessors_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_accessors_test.py
@@ -8,6 +8,7 @@ Unit tests for accessing values to the individual parameters within tunable grou
 
 import pytest
 
+from mlos_bench.tunables.covariant_group import CovariantTunableGroup
 from mlos_bench.tunables.tunable import Tunable
 
 
@@ -29,3 +30,18 @@ def test_numerical_access_to_categorical_tunable(tunable_categorical: Tunable) -
         print(tunable_categorical.numerical_value)
     with pytest.raises(AssertionError):
         print(tunable_categorical.range)
+
+
+def test_covariant_group_repr(covariant_group: CovariantTunableGroup) -> None:
+    """
+    Tests that the covariant group representation works as expected.
+    """
+    assert repr(covariant_group).startswith(f"{covariant_group.name}:")
+
+
+def test_covariant_group_tunables(covariant_group: CovariantTunableGroup) -> None:
+    """
+    Tests that we can access the tunables in the covariant group.
+    """
+    for tunable in covariant_group.get_tunables():
+        assert isinstance(tunable, Tunable)

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_accessors_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_accessors_test.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests for accessing values to the individual parameters within tunable groups.
+"""
+
+import pytest
+
+from mlos_bench.tunables.tunable import Tunable
+
+
+def test_categorical_access_to_numerical_tunable(tunable_int: Tunable) -> None:
+    """
+    Make sure we throw an error on accessing a numerical tunable as a categorical.
+    """
+    with pytest.raises(ValueError):
+        print(tunable_int.categorical_value)
+    with pytest.raises(AssertionError):
+        print(tunable_int.categorical_values)
+
+
+def test_numerical_access_to_categorical_tunable(tunable_categorical: Tunable) -> None:
+    """
+    Make sure we throw an error on accessing a numerical tunable as a categorical.
+    """
+    with pytest.raises(ValueError):
+        print(tunable_categorical.numerical_value)
+    with pytest.raises(AssertionError):
+        print(tunable_categorical.range)

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
@@ -8,7 +8,9 @@ Unit tests for checking tunable comparisons.
 
 import pytest
 
+from mlos_bench.tunables.covariant_group import CovariantTunableGroup
 from mlos_bench.tunables.tunable import Tunable
+from mlos_bench.tunables.tunable_groups import TunableGroups
 
 
 def test_tunable_int_value_lt(tunable_int: Tunable) -> None:
@@ -87,3 +89,13 @@ def test_tunable_lt_different_object(tunable_int: Tunable) -> None:
     assert (tunable_int < "foo") is False
     with pytest.raises(TypeError):
         assert "foo" < tunable_int      # type: ignore[operator]
+
+
+def test_tunable_group_ne_object(tunable_groups: TunableGroups) -> None:
+    """
+    Tests that the __eq__ operator works as expected with other objects.
+    """
+
+    assert tunable_groups != "foo"
+    (tunable, covariant_group) = next(iter(tunable_groups))
+    assert tunable != covariant_group

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
@@ -6,6 +6,8 @@
 Unit tests for checking tunable comparisons.
 """
 
+import pytest
+
 from mlos_bench.tunables.tunable import Tunable
 
 
@@ -76,3 +78,12 @@ def test_tunable_lt_same_name_different_type() -> None:
                           "default": 2
                         })
     assert tunable_cat < tunable_int
+
+
+def test_tunable_lt_different_object(tunable_int: Tunable) -> None:
+    """
+    Tests that the __lt__ operator works as expected.
+    """
+    assert (tunable_int < "foo") is False
+    with pytest.raises(TypeError):
+        assert "foo" < tunable_int      # type: ignore[operator]

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
@@ -95,7 +95,11 @@ def test_tunable_group_ne_object(tunable_groups: TunableGroups) -> None:
     """
     Tests that the __eq__ operator works as expected with other objects.
     """
-
     assert tunable_groups != "foo"
-    (tunable, covariant_group) = next(iter(tunable_groups))
-    assert tunable != covariant_group
+
+
+def test_covariant_group_ne_object(covariant_group: CovariantTunableGroup) -> None:
+    """
+    Tests that the __eq__ operator works as expected with other objects.
+    """
+    assert covariant_group != "foo"

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
@@ -1,0 +1,78 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests for checking tunable comparisons.
+"""
+
+from mlos_bench.tunables.tunable import Tunable
+
+
+def test_tunable_int_value_lt(tunable_int: Tunable) -> None:
+    """
+    Tests that the __lt__ operator works as expected.
+    """
+    tunable_int_2 = tunable_int.copy()
+    tunable_int_2.numerical_value += 1
+    assert tunable_int.numerical_value < tunable_int_2.numerical_value
+    assert tunable_int < tunable_int_2
+
+
+def test_tunable_int_name_lt(tunable_int: Tunable) -> None:
+    """
+    Tests that the __lt__ operator works as expected.
+    """
+    tunable_int_2 = tunable_int.copy()
+    tunable_int_2._name = "aaa"     # pylint: disable=protected-access
+    assert tunable_int_2 < tunable_int
+
+
+def test_tunable_categorical_value_lt(tunable_categorical: Tunable) -> None:
+    """
+    Tests that the __lt__ operator works as expected.
+    """
+    tunable_categorical_2 = tunable_categorical.copy()
+    new_value = [x for x in tunable_categorical.categorical_values
+                 if x != tunable_categorical.categorical_value and x is not None
+                ][0]
+    assert tunable_categorical.categorical_value is not None
+    tunable_categorical_2.categorical_value = new_value
+    if tunable_categorical.categorical_value < new_value:
+        assert tunable_categorical < tunable_categorical_2
+    elif tunable_categorical.categorical_value > new_value:
+        assert tunable_categorical > tunable_categorical_2
+
+
+def test_tunable_categorical_lt_null() -> None:
+    """
+    Tests that the __lt__ operator works as expected.
+    """
+    tunable_cat = Tunable(name="same-name", config={
+                          "type": "categorical",
+                          "values": ["floof", "fuzz"],
+                          "default": "floof"
+                        })
+    tunable_dog = Tunable(name="same-name", config={
+                          "type": "categorical",
+                          "values": [None, "doggo"],
+                          "default": None
+                        })
+    assert tunable_dog < tunable_cat
+
+
+def test_tunable_lt_same_name_different_type() -> None:
+    """
+    Tests that the __lt__ operator works as expected.
+    """
+    tunable_cat = Tunable(name="same-name", config={
+                          "type": "categorical",
+                          "values": ["floof", "fuzz"],
+                          "default": "floof"
+                        })
+    tunable_int = Tunable(name="same-name", config={
+                          "type": "int",
+                          "range": [1, 3],
+                          "default": 2
+                        })
+    assert tunable_cat < tunable_int

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_comparison_test.py
@@ -37,7 +37,7 @@ def test_tunable_categorical_value_lt(tunable_categorical: Tunable) -> None:
     Tests that the __lt__ operator works as expected.
     """
     tunable_categorical_2 = tunable_categorical.copy()
-    new_value = [x for x in tunable_categorical.categorical_values
+    new_value = [x for x in tunable_categorical.categories
                  if x != tunable_categorical.categorical_value and x is not None
                 ][0]
     assert tunable_categorical.categorical_value is not None

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 #
 """
-Unit tests for assigning values to the individual parameters within tunable groups.
+Unit tests for checking tunable definition rules.
 """
 
 import pytest

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
@@ -6,7 +6,7 @@
 Unit tests for checking tunable definition rules.
 """
 
-import json
+import json5 as json
 import pytest
 
 from mlos_bench.tunables.tunable import Tunable

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests for assigning values to the individual parameters within tunable groups.
+"""
+
+import pytest
+
+from mlos_bench.tunables.tunable import Tunable
+
+def test_categorical_tunable_disallow_repeats() -> None:
+    """
+    Disallow duplicate values in categorical tunables.
+    """
+    with pytest.raises(ValueError):
+        Tunable(name='test', config={
+            "type": "categorical",
+            "values": ["foo", "bar", "foo"],
+            "default": "foo",
+        })

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
@@ -30,13 +30,30 @@ def test_categorical_required_params() -> None:
 
 def test_categorical_wrong_params() -> None:
     """
-    Check that various required definitions are present for categorical tunables.
+    Disallow range param for categorical tunables.
     """
     json_config = """
     {
         "type": "categorical",
         "values": ["foo", "bar", "foo"],
         "range": [0, 1],
+        "default": "foo"
+    }
+    """
+    config = json.loads(json_config)
+    with pytest.raises(ValueError):
+        Tunable(name='test', config=config)
+
+
+def test_categorical_disallow_special_values() -> None:
+    """
+    Disallow special values for categorical values.
+    """
+    json_config = """
+    {
+        "type": "categorical",
+        "values": ["foo", "bar", "foo"],
+        "special": ["baz"],
         "default": "foo"
     }
     """

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
@@ -10,6 +10,7 @@ import pytest
 
 from mlos_bench.tunables.tunable import Tunable
 
+
 def test_categorical_tunable_disallow_repeats() -> None:
     """
     Disallow duplicate values in categorical tunables.

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_definition_test.py
@@ -6,9 +6,43 @@
 Unit tests for checking tunable definition rules.
 """
 
+import json
 import pytest
 
 from mlos_bench.tunables.tunable import Tunable
+
+
+def test_categorical_required_params() -> None:
+    """
+    Check that required parameters are present for categorical tunables.
+    """
+    json_config = """
+    {
+        "type": "categorical",
+        "values_missing": ["foo", "bar", "foo"],
+        "default": "foo"
+    }
+    """
+    config = json.loads(json_config)
+    with pytest.raises(ValueError):
+        Tunable(name='test', config=config)
+
+
+def test_categorical_wrong_params() -> None:
+    """
+    Check that various required definitions are present for categorical tunables.
+    """
+    json_config = """
+    {
+        "type": "categorical",
+        "values": ["foo", "bar", "foo"],
+        "range": [0, 1],
+        "default": "foo"
+    }
+    """
+    config = json.loads(json_config)
+    with pytest.raises(ValueError):
+        Tunable(name='test', config=config)
 
 
 def test_categorical_tunable_disallow_repeats() -> None:
@@ -21,3 +55,110 @@ def test_categorical_tunable_disallow_repeats() -> None:
             "values": ["foo", "bar", "foo"],
             "default": "foo",
         })
+
+
+@pytest.mark.parametrize("tunable_type", ["int", "float"])
+def test_numerical_tunable_disallow_null_default(tunable_type: str) -> None:
+    """
+    Disallow null values as default for numerical tunables.
+    """
+    with pytest.raises(ValueError):
+        Tunable(name=f'test_{tunable_type}', config={
+            "type": tunable_type,
+            "range": [0, 10],
+            "default": None,
+        })
+
+
+@pytest.mark.parametrize("tunable_type", ["int", "float"])
+def test_numerical_tunable_disallow_out_of_range(tunable_type: str) -> None:
+    """
+    Disallow out of range values as default for numerical tunables.
+    """
+    with pytest.raises(ValueError):
+        Tunable(name=f'test_{tunable_type}', config={
+            "type": tunable_type,
+            "range": [0, 10],
+            "default": 11,
+        })
+
+
+@pytest.mark.parametrize("tunable_type", ["int", "float"])
+def test_numerical_tunable_wrong_params(tunable_type: str) -> None:
+    """
+    Disallow values param for numerical tunables.
+    """
+    with pytest.raises(ValueError):
+        Tunable(name=f'test_{tunable_type}', config={
+            "type": tunable_type,
+            "range": [0, 10],
+            "values": ["foo", "bar"],
+            "default": 0,
+        })
+
+
+@pytest.mark.parametrize("tunable_type", ["int", "float"])
+def test_numerical_tunable_required_params(tunable_type: str) -> None:
+    """
+    Disallow null values param for numerical tunables.
+    """
+    json_config = f"""
+    {{
+        "type": "{tunable_type}",
+        "range_missing": [0, 10],
+        "default": 0
+    }}
+    """
+    config = json.loads(json_config)
+    with pytest.raises(ValueError):
+        Tunable(name=f'test_{tunable_type}', config=config)
+
+
+@pytest.mark.parametrize("tunable_type", ["int", "float"])
+def test_numerical_tunable_invalid_range(tunable_type: str) -> None:
+    """
+    Disallow invalid range param for numerical tunables.
+    """
+    json_config = f"""
+    {{
+        "type": "{tunable_type}",
+        "range": [0, 10, 7],
+        "default": 0
+    }}
+    """
+    config = json.loads(json_config)
+    with pytest.raises(AssertionError):
+        Tunable(name=f'test_{tunable_type}', config=config)
+
+
+@pytest.mark.parametrize("tunable_type", ["int", "float"])
+def test_numerical_tunable_reversed_range(tunable_type: str) -> None:
+    """
+    Disallow reverse range param for numerical tunables.
+    """
+    json_config = f"""
+    {{
+        "type": "{tunable_type}",
+        "range": [10, 0],
+        "default": 0
+    }}
+    """
+    config = json.loads(json_config)
+    with pytest.raises(ValueError):
+        Tunable(name=f'test_{tunable_type}', config=config)
+
+
+def test_bad_type() -> None:
+    """
+    Disallow bad types.
+    """
+    json_config = """
+    {
+        "type": "foo",
+        "range": [0, 10],
+        "default": 0
+    }
+    """
+    config = json.loads(json_config)
+    with pytest.raises(ValueError):
+        Tunable(name='test_bad_type', config=config)

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_group_indexing_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_group_indexing_test.py
@@ -23,6 +23,9 @@ def test_tunable_group_indexing(tunable_groups: TunableGroups, tunable_categoric
     (tunable_categorical, covariant_group) = tunable_groups.get_tunable(tunable_categorical.name)
     assert tunable_groups.get_tunable(tunable_categorical)[0] == tunable_categorical
 
+    assert tunable_categorical in covariant_group
+    assert tunable_categorical.name in covariant_group
+
     # Check that we can lookup that tunable by name or tunable object in the covariant group.
     assert covariant_group.get_tunable(tunable_categorical) == tunable_categorical
     assert covariant_group.get_tunable(tunable_categorical.name) == tunable_categorical

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_group_indexing_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_group_indexing_test.py
@@ -40,7 +40,7 @@ def test_tunable_group_indexing(tunable_groups: TunableGroups, tunable_categoric
     assert covariant_group[tunable_categorical.name] == tunable_categorical.value
 
     # Check that we can assign a new value by index.
-    new_value = [x for x in tunable_categorical.categorical_values if x != tunable_categorical.value][0]
+    new_value = [x for x in tunable_categorical.categories if x != tunable_categorical.value][0]
     tunable_groups[tunable_categorical] = new_value
     assert tunable_groups[tunable_categorical] == new_value
     assert tunable_groups[tunable_categorical.name] == new_value

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_group_indexing_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_group_indexing_test.py
@@ -1,0 +1,55 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Tests for checking the indexing rules for tunable groups.
+"""
+
+from mlos_bench.tunables.tunable import Tunable
+from mlos_bench.tunables.tunable_groups import TunableGroups
+
+
+def test_tunable_group_indexing(tunable_groups: TunableGroups, tunable_categorical: Tunable) -> None:
+    """
+    Check that various types of indexing work for the tunable group.
+    """
+    # Check that the "in" operator works.
+    assert tunable_categorical in tunable_groups
+    assert tunable_categorical.name in tunable_groups
+
+    # NOTE: we reassign the tunable_categorical here since they come from
+    # different fixtures so are technically different objects.
+    (tunable_categorical, covariant_group) = tunable_groups.get_tunable(tunable_categorical.name)
+    assert tunable_groups.get_tunable(tunable_categorical)[0] == tunable_categorical
+
+    # Check that we can lookup that tunable by name or tunable object in the covariant group.
+    assert covariant_group.get_tunable(tunable_categorical) == tunable_categorical
+    assert covariant_group.get_tunable(tunable_categorical.name) == tunable_categorical
+
+    # Reset the value on the tunable using the tunable.
+    tunable_categorical.value = tunable_categorical.default
+
+    # Check that we can index by name or tunable object.
+    assert tunable_groups[tunable_categorical] == tunable_categorical.value
+    assert tunable_groups[tunable_categorical.name] == tunable_categorical.value
+    assert covariant_group[tunable_categorical] == tunable_categorical.value
+    assert covariant_group[tunable_categorical.name] == tunable_categorical.value
+
+    # Check that we can assign a new value by index.
+    new_value = [x for x in tunable_categorical.categorical_values if x != tunable_categorical.value][0]
+    tunable_groups[tunable_categorical] = new_value
+    assert tunable_groups[tunable_categorical] == new_value
+    assert tunable_groups[tunable_categorical.name] == new_value
+    assert covariant_group[tunable_categorical] == new_value
+    assert covariant_group[tunable_categorical.name] == new_value
+    assert tunable_categorical.value == new_value
+    assert tunable_categorical.value != tunable_categorical.default
+
+    # Check that we can assign a new value by name.
+    tunable_groups[tunable_categorical] = tunable_categorical.default
+    assert tunable_categorical.value == tunable_categorical.default
+    assert tunable_groups[tunable_categorical] == tunable_categorical.value
+    assert tunable_groups[tunable_categorical.name] == tunable_categorical.value
+    assert covariant_group[tunable_categorical] == tunable_categorical.value
+    assert covariant_group[tunable_categorical.name] == tunable_categorical.value

--- a/mlos_bench/mlos_bench/tests/tunables/tunable_to_configspace_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunable_to_configspace_test.py
@@ -54,7 +54,7 @@ def _cmp_tunable_hyperparameter_categorical(
     Check if categorical Tunable and ConfigSpace Hyperparameter actually match.
     """
     assert isinstance(cs_param, CategoricalHyperparameter)
-    assert set(cs_param.choices) == set(tunable.categorical_values)
+    assert set(cs_param.choices) == set(tunable.categories)
     assert cs_param.default_value == tunable.value
 
 

--- a/mlos_bench/mlos_bench/tests/tunables/tunables_assign_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunables_assign_test.py
@@ -6,7 +6,7 @@
 Unit tests for assigning values to the individual parameters within tunable groups.
 """
 
-import json
+import json5 as json
 import pytest
 
 from mlos_bench.tunables.tunable import Tunable

--- a/mlos_bench/mlos_bench/tests/tunables/tunables_assign_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunables_assign_test.py
@@ -6,6 +6,7 @@
 Unit tests for assigning values to the individual parameters within tunable groups.
 """
 
+import json
 import pytest
 
 from mlos_bench.tunables.tunable import Tunable
@@ -95,3 +96,44 @@ def test_tunable_assign_float_to_int_fail(tunable_int: Tunable) -> None:
     """
     with pytest.raises(ValueError):
         tunable_int.value = 10.1
+
+
+def test_tunable_assign_null_to_categorical() -> None:
+    """
+    Checks that we can use null/None in categorical tunables.
+    """
+    json_config = """
+    {
+        "name": "categorical_test",
+        "type": "categorical",
+        "values": ["foo", null],
+        "default": "foo"
+    }
+    """
+    config = json.loads(json_config)
+    categorical_tunable = Tunable(name='categorical_test', config=config)
+    assert categorical_tunable
+    assert categorical_tunable.categorical_value == "foo"
+    categorical_tunable.value = None
+    assert categorical_tunable.value is None
+    assert categorical_tunable.value != 'None'
+
+
+def test_tunable_assign_null_to_int(tunable_int: Tunable) -> None:
+    """
+    Checks that we can't use null/None in integer tunables.
+    """
+    with pytest.raises(TypeError):
+        tunable_int.value = None
+    with pytest.raises(TypeError):
+        tunable_int.numerical_value = None    # type: ignore[assignment]
+
+
+def test_tunable_assign_null_to_float(tunable_float: Tunable) -> None:
+    """
+    Checks that we can't use null/None in float tunables.
+    """
+    with pytest.raises(TypeError):
+        tunable_float.value = None
+    with pytest.raises(TypeError):
+        tunable_float.numerical_value = None    # type: ignore[assignment]

--- a/mlos_bench/mlos_bench/tests/tunables/tunables_assign_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunables_assign_test.py
@@ -66,6 +66,30 @@ def test_tunables_assign_coerce_str_invalid(tunable_groups: TunableGroups) -> No
         tunable_groups.assign({"kernel_sched_migration_cost_ns": "1.1"})
 
 
+def test_tunable_assign_str_to_numerical(tunable_int: Tunable) -> None:
+    """
+    Check str to int coercion.
+    """
+    with pytest.raises(ValueError):
+        tunable_int.numerical_value = "foo" # type: ignore[assignment]
+
+
+def test_tunable_assign_int_to_numerical_value(tunable_int: Tunable) -> None:
+    """
+    Check numerical value assignment.
+    """
+    tunable_int.numerical_value = 10.0
+    assert tunable_int.numerical_value == 10
+
+
+def test_tunable_assign_float_to_numerical_value(tunable_float: Tunable) -> None:
+    """
+    Check numerical value assignment.
+    """
+    tunable_float.numerical_value = 0.1
+    assert tunable_float.numerical_value == 0.1
+
+
 def test_tunable_assign_str_to_int(tunable_int: Tunable) -> None:
     """
     Check str to int coercion.

--- a/mlos_bench/mlos_bench/tests/tunables/tunables_copy_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunables_copy_test.py
@@ -16,7 +16,7 @@ def test_copy_tunable_int(tunable_int: Tunable) -> None:
     """
     tunable_copy = tunable_int.copy()
     assert tunable_int == tunable_copy
-    tunable_copy.value = tunable_copy.numerical_value + 200
+    tunable_copy.numerical_value += 200
     assert tunable_int != tunable_copy
 
 

--- a/mlos_bench/mlos_bench/tests/tunables/tunables_copy_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunables_copy_test.py
@@ -42,7 +42,7 @@ def test_copy_covariant_group(covariant_group: CovariantTunableGroup) -> None:
     tunable = next(iter(covariant_group.get_tunables()))
     new_value: TunableValue
     if tunable.is_categorical:
-        new_value = [x for x in tunable.categorical_values if x != tunable.categorical_value][0]
+        new_value = [x for x in tunable.categories if x != tunable.categorical_value][0]
     elif tunable.is_numerical:
         new_value = tunable.numerical_value + 1
     covariant_group_copy[tunable] = new_value

--- a/mlos_bench/mlos_bench/tests/tunables/tunables_copy_test.py
+++ b/mlos_bench/mlos_bench/tests/tunables/tunables_copy_test.py
@@ -6,7 +6,8 @@
 Unit tests for deep copy of tunable objects and groups.
 """
 
-from mlos_bench.tunables.tunable import Tunable
+from mlos_bench.tunables.covariant_group import CovariantTunableGroup
+from mlos_bench.tunables.tunable import Tunable, TunableValue
 from mlos_bench.tunables.tunable_groups import TunableGroups
 
 
@@ -30,3 +31,21 @@ def test_copy_tunable_groups(tunable_groups: TunableGroups) -> None:
     assert tunable_groups_copy.is_updated()
     assert not tunable_groups.is_updated()
     assert tunable_groups != tunable_groups_copy
+
+
+def test_copy_covariant_group(covariant_group: CovariantTunableGroup) -> None:
+    """
+    Check if deep copy works for TunableGroups object.
+    """
+    covariant_group_copy = covariant_group.copy()
+    assert covariant_group == covariant_group_copy
+    tunable = next(iter(covariant_group.get_tunables()))
+    new_value: TunableValue
+    if tunable.is_categorical:
+        new_value = [x for x in tunable.categorical_values if x != tunable.categorical_value][0]
+    elif tunable.is_numerical:
+        new_value = tunable.numerical_value + 1
+    covariant_group_copy[tunable] = new_value
+    assert covariant_group_copy.is_updated()
+    assert not covariant_group.is_updated()
+    assert covariant_group != covariant_group_copy

--- a/mlos_bench/mlos_bench/tunables/covariant_group.py
+++ b/mlos_bench/mlos_bench/tunables/covariant_group.py
@@ -7,7 +7,7 @@ Tunable parameter definition.
 """
 import copy
 
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Union
 
 from mlos_bench.tunables.tunable import Tunable, TunableValue
 
@@ -132,9 +132,13 @@ class CovariantTunableGroup:
         """
         return self._tunables.keys()
 
-    def get_values(self) -> Dict[str, TunableValue]:
+    def get_tunable_values_dict(self) -> Dict[str, TunableValue]:
         """
-        Get current values of all tunables in the group.
+        Get current values of all tunables in the group as a dict.
+
+        Returns
+        -------
+        tunables : Dict[str, TunableValue]
         """
         return {name: tunable.value for (name, tunable) in self._tunables.items()}
 
@@ -150,27 +154,43 @@ class CovariantTunableGroup:
         """
         return f"{self._name}: {self._tunables}"
 
-    def get_tunable(self, name: str) -> Tunable:
+    def get_tunable(self, tunable: Union[str, Tunable]) -> Tunable:
         """
         Access the entire Tunable in a group (not just its value).
         Throw KeyError if the tunable is not in the group.
 
         Parameters
         ----------
-        name : str
+        tunable : str
             Name of the tunable parameter.
 
         Returns
         -------
-        tunable : Tunable
+        Tunable
             An instance of the Tunable parameter.
         """
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
         return self._tunables[name]
 
-    def __getitem__(self, name: str) -> TunableValue:
-        return self.get_tunable(name).value
+    def get_tunables(self) -> Iterable[Tunable]:
+        """Gets the set of tunables for this CovariantTunableGroup.
 
-    def __setitem__(self, name: str, value: TunableValue) -> TunableValue:
+        Returns
+        -------
+        Iterable[Tunable]
+        """
+        return self._tunables.values()
+
+    def __contains__(self, tunable: Union[str, Tunable]) -> bool:
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
+        return name in self._tunables
+
+    def __getitem__(self, tunable: Union[str, Tunable]) -> TunableValue:
+        return self.get_tunable(tunable).value
+
+    def __setitem__(self, tunable: Union[str, Tunable], tunable_value: Union[TunableValue, Tunable]) -> TunableValue:
         self._is_updated = True
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
+        value: TunableValue = tunable_value.value if isinstance(tunable_value, Tunable) else tunable_value
         self._tunables[name].value = value
         return value

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -232,7 +232,8 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
             return value in self._values
         elif self.is_numerical and self._range:
             if isinstance(value, (int, float)):
-                return bool(self._range[0] <= value <= self._range[1]) or value == self._default
+                # TODO: allow special values outside of range?
+                return bool(self._range[0] <= value <= self._range[1]) # or value == self._default
             else:
                 raise ValueError(f"Invalid value type for tunable {self}: {value}={type(value)}")
         else:

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -191,7 +191,7 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         # (e.g., scikit-optimize) and for data restored from certain storage
         # systems (where values can be strings).
         try:
-            if self.is_categorical and value is None and None in self.categorical_values:
+            if self.is_categorical and value is None and None in self.categories:
                 # Don't string convert None (json null)
                 coerced_value = None
             else:
@@ -343,7 +343,7 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         return self._range
 
     @property
-    def categorical_values(self) -> List[Optional[str]]:
+    def categories(self) -> List[Optional[str]]:
         """
         Get the list of all possible values of a categorical tunable.
         Return None if the tunable is not categorical.

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -9,7 +9,6 @@ import copy
 import collections
 import logging
 
-from types import NoneType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypedDict, Union
 
 _LOG = logging.getLogger(__name__)
@@ -256,7 +255,7 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         Set the current value of the tunable.
         """
         assert self.is_categorical
-        assert isinstance(new_value, (str, NoneType))
+        assert isinstance(new_value, (str, type(None)))
         self.value = new_value
         return self.value
 

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -80,10 +80,14 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
             if self._special is not None:
                 raise ValueError("Special values must be None for the categorical type")
         elif self.is_numerical:
+            if self._values is not None:
+                raise ValueError("Values must be None for the numerical type")
             if not self._range or len(self._range) != 2 or self._range[0] >= self._range[1]:
                 raise ValueError(f"Invalid range: {self._range}")
         else:
             raise ValueError(f"Invalid parameter type: {self._type}")
+        if not self.is_valid(self.default):
+            raise ValueError(f"Invalid default value: {self.default}")
 
     def __repr__(self) -> str:
         """
@@ -227,8 +231,10 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         if self.is_categorical and self._values:
             return value in self._values
         elif self.is_numerical and self._range:
-            assert isinstance(value, (int, float))
-            return bool(self._range[0] <= value <= self._range[1]) or value == self._default
+            if isinstance(value, (int, float)):
+                return bool(self._range[0] <= value <= self._range[1]) or value == self._default
+            else:
+                raise ValueError(f"Invalid value type for tunable {self}: {value}={type(value)}")
         else:
             raise ValueError(f"Invalid parameter type: {self._type}")
 

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -9,6 +9,7 @@ import copy
 import collections
 import logging
 
+from types import NoneType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypedDict, Union
 
 _LOG = logging.getLogger(__name__)
@@ -255,7 +256,7 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         Set the current value of the tunable.
         """
         assert self.is_categorical
-        assert new_value is None or isinstance(new_value, str)
+        assert isinstance(new_value, (str, NoneType))
         self.value = new_value
         return self.value
 

--- a/mlos_bench/mlos_bench/tunables/tunable_groups.py
+++ b/mlos_bench/mlos_bench/tunables/tunable_groups.py
@@ -7,7 +7,7 @@ TunableGroups definition.
 """
 import copy
 
-from typing import Dict, Generator, Iterable, Mapping, Optional, Tuple
+from typing import Dict, Generator, Iterable, Mapping, Optional, Tuple, Union
 
 from mlos_bench.tunables.tunable import Tunable, TunableValue
 from mlos_bench.tunables.covariant_group import CovariantTunableGroup
@@ -108,18 +108,29 @@ class TunableGroups:
             for group in sorted(self._tunable_groups.values(), key=lambda g: (-g.cost, g.name))
             for tunable in sorted(group._tunables.values())) + " }"
 
-    def __getitem__(self, name: str) -> TunableValue:
+    def __contains__(self, tunable: Union[str, Tunable]) -> bool:
+        """
+        Checks if the given name/tunable is in this tunable group.
+        """
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
+        return name in self._index
+
+    def __getitem__(self, tunable: Union[str, Tunable]) -> TunableValue:
         """
         Get the current value of a single tunable parameter.
         """
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
         return self._index[name][name]
 
-    def __setitem__(self, name: str, value: TunableValue) -> None:
+    def __setitem__(self, tunable: Union[str, Tunable], tunable_value: Union[TunableValue, Tunable]) -> TunableValue:
         """
         Update the current value of a single tunable parameter.
         """
         # Use double index to make sure we set the is_updated flag of the group
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
+        value: TunableValue = tunable_value.value if isinstance(tunable_value, Tunable) else tunable_value
         self._index[name][name] = value
+        return self._index[name][name]
 
     def __iter__(self) -> Generator[Tuple[Tunable, CovariantTunableGroup], None, None]:
         """
@@ -151,7 +162,7 @@ class TunableGroups:
         group = self._index[name]
         return (group.get_tunable(name), group)
 
-    def get_names(self) -> Iterable[str]:
+    def get_covariant_group_names(self) -> Iterable[str]:
         """
         Get the names of all covariance groups in the collection.
 
@@ -202,11 +213,11 @@ class TunableGroups:
             Flat dict of all parameters and their values from given covariance groups.
         """
         if group_names is None:
-            group_names = self.get_names()
+            group_names = self.get_covariant_group_names()
         if into_params is None:
             into_params = {}
         for name in group_names:
-            into_params.update(self._tunable_groups[name].get_values())
+            into_params.update(self._tunable_groups[name].get_tunable_values_dict())
         return into_params
 
     def is_updated(self, group_names: Optional[Iterable[str]] = None) -> bool:
@@ -224,7 +235,7 @@ class TunableGroups:
             True if any of the specified tunable groups has been updated, False otherwise.
         """
         return any(self._tunable_groups[name].is_updated()
-                   for name in (group_names or self.get_names()))
+                   for name in (group_names or self.get_covariant_group_names()))
 
     def reset(self, group_names: Optional[Iterable[str]] = None) -> "TunableGroups":
         """
@@ -240,7 +251,7 @@ class TunableGroups:
         self : TunableGroups
             Self-reference for chaining.
         """
-        for name in (group_names or self.get_names()):
+        for name in (group_names or self.get_covariant_group_names()):
             self._tunable_groups[name].reset()
         return self
 

--- a/mlos_bench/mlos_bench/tunables/tunable_groups.py
+++ b/mlos_bench/mlos_bench/tunables/tunable_groups.py
@@ -144,14 +144,14 @@ class TunableGroups:
         """
         return ((group.get_tunable(name), group) for (name, group) in self._index.items())
 
-    def get_tunable(self, name: str) -> Tuple[Tunable, CovariantTunableGroup]:
+    def get_tunable(self, tunable: Union[str, Tunable]) -> Tuple[Tunable, CovariantTunableGroup]:
         """
         Access the entire Tunable (not just its value) and its covariant group.
         Throw KeyError if the tunable is not found.
 
         Parameters
         ----------
-        name : str
+        tunable : Union[str, Tunable]
             Name of the tunable parameter.
 
         Returns
@@ -159,6 +159,7 @@ class TunableGroups:
         (tunable, group) : (Tunable, CovariantTunableGroup)
             A 2-tuple of an instance of the Tunable parameter and covariant group it belongs to.
         """
+        name: str = tunable.name if isinstance(tunable, Tunable) else tunable
         group = self._index[name]
         return (group.get_tunable(name), group)
 


### PR DESCRIPTION
More work being split out from #313 

- Handle `null` (in json, `None` in python) values for categoricals.
- Disallow duplicate values in categoricals.
- Provide type aware setters (compromise to a much much larger type aware rework for `Tunables` that isn't super beneficial).
- Slight method renaming for clarity.
- For convenience, allow accessing the `TunableGroups` by `Tunable`, not just it's name.
- Add `__contains__` method to `TunableGroups` so we can do `if tunable in tunable_group` checks
- Add a few more tests for `Tunable`, `TunableGroups`, and `CovariantTunableGroup` definitions.
  Coverage should be about 90% overall now, and 99+% on those files.