### PR TITLE
Fixup Makefile parallel job support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ MKDIR_BUILD := $(shell test -d build || mkdir build)
 
 # Run make in parallel by default.
 MAKEFLAGS += -j$(shell nproc)
+MAKEFLAGS += -Oline
 
 .PHONY: all
 all: check test dist dist-test doc licenseheaders
@@ -116,13 +117,13 @@ build/pylint.%.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NAME}.
 mypy: conda-env build/mypy.mlos_core.${CONDA_ENV_NAME}.build-stamp build/mypy.mlos_bench.${CONDA_ENV_NAME}.build-stamp
 
 build/mypy.mlos_core.${CONDA_ENV_NAME}.build-stamp: $(MLOS_CORE_PYTHON_FILES)
-build/mypy.mlos_bench.${CONDA_ENV_NAME}.build-stamp: $(MLOS_BENCH_PYTHON_FILES)
+build/mypy.mlos_bench.${CONDA_ENV_NAME}.build-stamp: $(MLOS_BENCH_PYTHON_FILES) build/mypy.mlos_core.${CONDA_ENV_NAME}.build-stamp
 
-.NOTPARALLEL: build/mypy.%.${CONDA_ENV_NAME}.build-stamp
 build/mypy.%.${CONDA_ENV_NAME}.build-stamp: scripts/dmypy-wrapper.sh build/conda-env.${CONDA_ENV_NAME}.build-stamp setup.cfg
 	conda run -n ${CONDA_ENV_NAME} scripts/dmypy-wrapper.sh \
-		$(filter-out scripts/dmypy-wrapper.sh build/conda-env.${CONDA_ENV_NAME}.build-stamp setup.cfg,$+)
+		$(filter-out scripts/dmypy-wrapper.sh build/*.build-stamp setup.cfg,$+)
 	touch $@
+
 
 .PHONY: test
 test: pytest


### PR DESCRIPTION
- update Makefile rules to enable parallel runs again
- group output from each rule together so it's easier to spot errors