### PR TITLE
Path join tweak

### DIFF
--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -19,6 +19,7 @@ from mlos_bench.environments.base_environment import Environment
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.local_exec_type import SupportsLocalExec
 from mlos_bench.tunables.tunable_groups import TunableGroups
+from mlos_bench.util import path_join
 
 _LOG = logging.getLogger(__name__)
 
@@ -116,7 +117,7 @@ class LocalEnv(Environment):
             _LOG.info("Set up the environment locally: %s at %s", self, temp_dir)
 
             if self._dump_params_file:
-                with open(os.path.join(temp_dir, self._dump_params_file),
+                with open(path_join(temp_dir, self._dump_params_file),
                           "wt", encoding="utf-8") as fh_tunables:
                     # json.dump(self._params, fh_tunables)  # Tunables *and* const_args
                     json.dump(tunables.get_param_values(self._tunable_params.get_covariant_group_names()),

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -22,7 +22,7 @@ from mlos_bench.environments.base_environment import Environment
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.config_loader_type import SupportsConfigLoading
 from mlos_bench.tunables.tunable_groups import TunableGroups
-from mlos_bench.util import instantiate_from_config, BaseTypeVar
+from mlos_bench.util import instantiate_from_config, path_join, BaseTypeVar
 
 if sys.version_info < (3, 10):
     from importlib_resources import files
@@ -94,9 +94,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         _LOG.debug("Resolve path: %s in: %s", file_path, path_list)
         if not os.path.isabs(file_path):
             for path in path_list:
-                full_path = os.path.realpath(os.path.join(path, file_path))
-                if sys.platform == "win32":
-                    full_path = full_path.replace("\\", "/")
+                full_path = path_join(path, file_path, abs_path=True)
                 if os.path.exists(full_path):
                     _LOG.debug("Path resolved: %s", full_path)
                     return full_path

--- a/mlos_bench/mlos_bench/tests/config/__init__.py
+++ b/mlos_bench/mlos_bench/tests/config/__init__.py
@@ -10,6 +10,8 @@ from typing import List
 
 import os
 
+from mlos_bench.util import path_join
+
 
 def locate_config_examples(config_examples_dir: str) -> List[str]:
     """Locates all config examples in the given directory.
@@ -28,5 +30,5 @@ def locate_config_examples(config_examples_dir: str) -> List[str]:
     for root, _, files in os.walk(config_examples_dir):
         for file in files:
             if file.endswith(".json") or file.endswith(".jsonc"):
-                config_examples.append(os.path.join(root, file).replace("\\", "/"))
+                config_examples.append(path_join(root, file))
     return config_examples

--- a/mlos_bench/mlos_bench/tests/config/environments/test_load_environment_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/environments/test_load_environment_config_examples.py
@@ -18,6 +18,7 @@ from mlos_bench.environments.base_environment import Environment
 from mlos_bench.environments.composite_env import CompositeEnv
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.tunables.tunable_groups import TunableGroups
+from mlos_bench.util import path_join
 
 
 _LOG = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ def filter_configs(configs_to_filter: List[str]) -> List[str]:
     return configs_to_filter
 
 
-configs = filter_configs(locate_config_examples(os.path.join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
+configs = filter_configs(locate_config_examples(path_join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
 assert configs
 
 
@@ -83,7 +84,7 @@ def load_environment_config_examples(config_loader_service: ConfigPersistenceSer
     return envs
 
 
-composite_configs = filter_configs(locate_config_examples(os.path.join(
+composite_configs = filter_configs(locate_config_examples(path_join(
     ConfigPersistenceService.BUILTIN_CONFIG_PATH, "environments/composite/")))
 assert composite_configs
 

--- a/mlos_bench/mlos_bench/tests/config/optimizers/test_load_optimizer_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/optimizers/test_load_optimizer_config_examples.py
@@ -17,7 +17,7 @@ from mlos_bench.tests.config import locate_config_examples
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.optimizers.base_optimizer import Optimizer
 from mlos_bench.tunables.tunable_groups import TunableGroups
-from mlos_bench.util import get_class_from_name
+from mlos_bench.util import get_class_from_name, path_join
 
 
 _LOG = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def filter_configs(configs_to_filter: List[str]) -> List[str]:
     return configs_to_filter
 
 
-configs = filter_configs(locate_config_examples(os.path.join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
+configs = filter_configs(locate_config_examples(path_join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
 assert configs
 
 

--- a/mlos_bench/mlos_bench/tests/config/services/test_load_service_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/services/test_load_service_config_examples.py
@@ -16,6 +16,7 @@ import pytest
 from mlos_bench.tests.config import locate_config_examples
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.config_persistence import ConfigPersistenceService
+from mlos_bench.util import path_join
 
 
 _LOG = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ def filter_configs(configs_to_filter: List[str]) -> List[str]:
     return configs_to_filter
 
 
-configs = filter_configs(locate_config_examples(os.path.join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
+configs = filter_configs(locate_config_examples(path_join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
 assert configs
 
 

--- a/mlos_bench/mlos_bench/tests/config/storage/test_load_storage_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/storage/test_load_storage_config_examples.py
@@ -17,7 +17,7 @@ from mlos_bench.tests.config import locate_config_examples
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.storage.base_storage import Storage
 from mlos_bench.tunables.tunable_groups import TunableGroups
-from mlos_bench.util import get_class_from_name
+from mlos_bench.util import get_class_from_name, path_join
 
 
 _LOG = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def filter_configs(configs_to_filter: List[str]) -> List[str]:
     return configs_to_filter
 
 
-configs = filter_configs(locate_config_examples(os.path.join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
+configs = filter_configs(locate_config_examples(path_join(ConfigPersistenceService.BUILTIN_CONFIG_PATH, CONFIG_TYPE)))
 assert configs
 
 

--- a/mlos_bench/mlos_bench/tests/launcher_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from mlos_bench.services.local.local_exec import LocalExecService
 from mlos_bench.services.config_persistence import ConfigPersistenceService
+from mlos_bench.util import path_join
 
 # pylint: disable=redefined-outer-name
 
@@ -20,7 +21,7 @@ def root_path() -> str:
     """
     Root path of mlos_bench project.
     """
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+    return path_join(os.path.dirname(__file__), "../../..", abs_path=True)
 
 
 @pytest.fixture
@@ -43,7 +44,7 @@ def test_launch_main_app(root_path: str,
     """
     with local_exec_service.temp_dir_context() as temp_dir:
 
-        log_path = os.path.join(temp_dir, "mock-1shot.log")
+        log_path = path_join(temp_dir, "mock-1shot.log")
         cmd = "./mlos_bench/mlos_bench/run.py" + \
               " --config mlos_bench/mlos_bench/tests/config/cli/mock-1shot.jsonc" + \
               f" --log_file '{log_path}'"

--- a/mlos_bench/mlos_bench/tests/services/local/local_exec_python_test.py
+++ b/mlos_bench/mlos_bench/tests/services/local/local_exec_python_test.py
@@ -16,6 +16,7 @@ import pytest
 from mlos_bench.tunables.tunable import TunableValue
 from mlos_bench.services.local.local_exec import LocalExecService
 from mlos_bench.services.config_persistence import ConfigPersistenceService
+from mlos_bench.util import path_join
 
 # pylint: disable=redefined-outer-name
 
@@ -43,7 +44,7 @@ def test_run_python_script(local_exec_service: LocalExecService) -> None:
 
     with local_exec_service.temp_dir_context() as temp_dir:
 
-        with open(os.path.join(temp_dir, input_file), "wt", encoding="utf-8") as fh_input:
+        with open(path_join(temp_dir, input_file), "wt", encoding="utf-8") as fh_input:
             json.dump(params, fh_input)
 
         script_path = local_exec_service.config_loader_service.resolve_path(
@@ -57,7 +58,7 @@ def test_run_python_script(local_exec_service: LocalExecService) -> None:
         assert return_code == 0
         # assert stdout.strip() == ""
 
-        with open(os.path.join(temp_dir, output_file), "rt", encoding="utf-8") as fh_output:
+        with open(path_join(temp_dir, output_file), "rt", encoding="utf-8") as fh_output:
             assert [ln.strip() for ln in fh_output.readlines()] == [
                 'echo "40000" > /proc/sys/kernel/sched_migration_cost_ns',
                 'echo "800000" > /proc/sys/kernel/sched_granularity_ns',

--- a/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
+++ b/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
@@ -13,6 +13,7 @@ import pandas
 
 from mlos_bench.services.local.local_exec import LocalExecService
 from mlos_bench.services.config_persistence import ConfigPersistenceService
+from mlos_bench.util import path_join
 
 # pylint: disable=redefined-outer-name
 # -- Ignore pylint complaints about pytest references to
@@ -85,7 +86,7 @@ def test_run_script_read_csv(local_exec_service: LocalExecService) -> None:
         assert stdout.strip() == ""
         assert stderr.strip() == ""
 
-        data = pandas.read_csv(os.path.join(temp_dir, "output.csv"))
+        data = pandas.read_csv(path_join(temp_dir, "output.csv"))
         assert all(data.col1 == [111, 333])
         assert all(data.col2 == [222, 444])
 
@@ -97,7 +98,7 @@ def test_run_script_write_read_txt(local_exec_service: LocalExecService) -> None
     with local_exec_service.temp_dir_context() as temp_dir:
 
         input_file = "input.txt"
-        with open(os.path.join(temp_dir, input_file), "wt", encoding="utf-8") as fh_input:
+        with open(path_join(temp_dir, input_file), "wt", encoding="utf-8") as fh_input:
             fh_input.write("hello\n")
 
         (return_code, stdout, stderr) = local_exec_service.local_exec([
@@ -109,7 +110,7 @@ def test_run_script_write_read_txt(local_exec_service: LocalExecService) -> None
         assert stdout.strip() == ""
         assert stderr.strip() == ""
 
-        with open(os.path.join(temp_dir, input_file), "rt", encoding="utf-8") as fh_input:
+        with open(path_join(temp_dir, input_file), "rt", encoding="utf-8") as fh_input:
             assert fh_input.read().split() == ["hello", "world", "test"]
 
 

--- a/mlos_bench/mlos_bench/util.py
+++ b/mlos_bench/mlos_bench/util.py
@@ -28,6 +28,23 @@ BaseTypeVar = TypeVar("BaseTypeVar", "Environment", "Optimizer", "Service", "Sto
 BaseTypes = Union["Environment", "Optimizer", "Service", "Storage"]
 
 
+def path_join(*args: str) -> str:
+    """
+    Joins the path components and normalizes the path.
+
+    Parameters
+    ----------
+    args : str
+        Path components.
+
+    Returns
+    -------
+    str
+        Joined path.
+    """
+    return os.path.normpath(os.path.join(*args)).replace("\\", "/")
+
+
 def prepare_class_load(config: dict,
                        global_config: Optional[Dict[str, Any]] = None) -> Tuple[str, Dict[str, Any]]:
     """

--- a/mlos_bench/mlos_bench/util.py
+++ b/mlos_bench/mlos_bench/util.py
@@ -28,7 +28,7 @@ BaseTypeVar = TypeVar("BaseTypeVar", "Environment", "Optimizer", "Service", "Sto
 BaseTypes = Union["Environment", "Optimizer", "Service", "Storage"]
 
 
-def path_join(*args: str) -> str:
+def path_join(*args: str, abs_path: bool = False) -> str:
     """
     Joins the path components and normalizes the path.
 
@@ -37,12 +37,18 @@ def path_join(*args: str) -> str:
     args : str
         Path components.
 
+    abs_path : bool
+        If True, the path is converted to be absolute.
+
     Returns
     -------
     str
         Joined path.
     """
-    return os.path.normpath(os.path.join(*args)).replace("\\", "/")
+    path = os.path.join(*args)
+    if abs_path:
+        path = os.path.abspath(path)
+    return os.path.normpath(path).replace("\\", "/")
 
 
 def prepare_class_load(config: dict,


### PR DESCRIPTION
We have various places that need to use `.replace("\\", "/")` after `os.path.join(...)` to canonicalize the paths across platforms.
This consolidates that into a single function.