### PR TITLE
Fixups to some docs

### DIFF
--- a/.devcontainer/scripts/README.md
+++ b/.devcontainer/scripts/README.md
@@ -10,9 +10,9 @@ See Also: <https://github.com/microsoft/vscode-remote-release/issues/4568>
 
 ## `mlos_deps.yml` file hack
 
-When building the devcontainer image, we don't want to include the MlosCore source code initially, just its dependencies, so we filter out the MlosCore source code from the `mlos.yml` file when building the image and keep the context to that smaller set of files.
+When building the devcontainer image, we don't want to include the MLOS source code initially, just its dependencies, so we filter out the MLOS source code from the `mlos.yml` file when building the image and keep the context to that smaller set of files.
 
-When the devcontainer starts, we map the source code (and hence the `mlos.yml` file) into the devcontainer and then run `conda env update` to install the rest of the MlosCore dependencies.
+When the devcontainer starts, we map the source code (and hence the `mlos.yml` file) into the devcontainer and then run `conda env update` to install the rest of the MLOS dependencies.
 
 This makes the devcontainer base more cacheable.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MlosCore
+# MLOS
 
 [![MLOS DevContainer](https://github.com/microsoft/MLOS/actions/workflows/devcontainer.yml/badge.svg)](https://github.com/microsoft/MLOS/actions/workflows/devcontainer.yml)
 [![MLOS Linux](https://github.com/microsoft/MLOS/actions/workflows/linux.yml/badge.svg)](https://github.com/microsoft/MLOS/actions/workflows/linux.yml)
@@ -17,7 +17,7 @@ For these design requirements we intend to reuse as much from existing OSS libra
 
 ## Getting Started
 
-The development environment for MlosCore uses `conda` to ease dependency management.
+The development environment for MLOS uses `conda` to ease dependency management.
 
 ### Devcontainer
 
@@ -35,7 +35,7 @@ Simply open the project in VSCode and follow the prompts to build and open the d
 >
 > See <https://github.com/conda-incubator/conda-libmamba-solver#getting-started> for more details.
 
-0. Create the `mlos_core` Conda environment.
+0. Create the `mlos` Conda environment.
 
      ```sh
     conda env create -f conda-envs/mlos.yml
@@ -55,12 +55,20 @@ Simply open the project in VSCode and follow the prompts to build and open the d
 1. Initialize the shell environment.
 
     ```sh
-    conda activate mlos_core
+    conda activate mlos
     ```
 
 2. For an example of using the `mlos_core` optimizer APIs run the [`BayesianOptimization.ipynb`](./mlos_core/notebooks/BayesianOptimization.ipynb) notebook.
 
-3. TODO: Add examples of the `mlos_bench` experiment runner APIs.
+3. For an example of using the `mlos_bench` tool to run an experiment, see the [`mlos_bench` Quickstart README](./mlos_bench/README.md#quickstart).  Here's a quick summary:
+
+    ```sh
+    # get an azure token
+    ./scripts/generate-azure-credentials-config.sh
+
+    # run a simple experiment
+    mlos_bench --config ./mlos_bench/mlos_bench/config/cli/azure-redis-1shot.jsonc
+    ```
 
 ## Distributing
 
@@ -84,6 +92,8 @@ Simply open the project in VSCode and follow the prompts to build and open the d
     # this will install both the optimizer and the experiment runner:
     pip install dist/mlos_bench-0.1.0-py3-none-any.whl
     ```
+
+    > Note exact versions may differ due to automatic versioning.
 
 ## See Also
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -4,7 +4,7 @@ Installation
 Development
 -----------
 
-The development environment for MlosCore uses ``conda`` to ease dependency management.
+The development environment for MLOS uses ``conda`` to ease dependency management.
 
 Devcontainer
 ------------
@@ -26,7 +26,7 @@ Manually
     See `<https://github.com/conda-incubator/conda-libmamba-solver#getting-started>`_ for more details.
 
 
-0. Create the `mlos_core` Conda environment.
+0. Create the `mlos` Conda environment.
 
   .. code-block:: shell
 
@@ -77,3 +77,6 @@ Distributing
     # this will install both the optimizer and the experiment runner:
     pip install dist/mlos_bench-0.1.0-py3-none-any.whl
 
+  .. note::
+
+    Note exact versions may differ due to automatic versioning.


### PR DESCRIPTION
- cleanup `MlosCore` vs `MLOS` naming
- add a link and short description for the `mlos_bench` example
- reference the right conda env (#319)