### PR TITLE
bugfix: enforce the data types for bulk_register inputs

### DIFF
--- a/mlos_bench/mlos_bench/tests/optimizers/opt_bulk_register_test.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/opt_bulk_register_test.py
@@ -52,6 +52,18 @@ def mock_configs() -> List[dict]:
 
 
 @pytest.fixture
+def mock_configs_str(mock_configs) -> List[dict]:
+    """
+    Same as `mock_config` above, but with all values converted to strings.
+    (This can happen when we retrieve the data from storage).
+    """
+    return [
+        {key: str(val) for (key, val) in config.items()}
+        for config in mock_configs
+    ]
+
+
+@pytest.fixture
 def mock_scores() -> List[Optional[float]]:
     """
     Mock benchmark results from earlier experiments.
@@ -109,6 +121,14 @@ def test_update_mock_min(mock_opt: MockOptimizer, mock_configs: List[dict],
     _test_opt_update_min(mock_opt, mock_configs, mock_scores, mock_status)
 
 
+def test_update_mock_min_str(mock_opt: MockOptimizer, mock_configs_str: List[dict],
+                             mock_scores: List[float], mock_status: List[Status]) -> None:
+    """
+    Test the bulk update of the mock optimizer with all-strings data.
+    """
+    _test_opt_update_min(mock_opt, mock_configs_str, mock_scores, mock_status)
+
+
 def test_update_mock_max(mock_opt_max: MockOptimizer, mock_configs: List[dict],
                          mock_scores: List[float], mock_status: List[Status]) -> None:
     """
@@ -147,3 +167,12 @@ def test_update_scikit_et(scikit_et_opt: MlosCoreOptimizer, mock_configs: List[d
     Test the bulk update of the scikit-optimize ET optimizer.
     """
     _test_opt_update_min(scikit_et_opt, mock_configs, mock_scores, mock_status)
+
+
+def test_update_scikit_gp_str(
+        scikit_gp_opt: MlosCoreOptimizer, mock_configs_str: List[dict],
+        mock_scores: List[float], mock_status: List[Status]) -> None:
+    """
+    Test the bulk update of the optimizer with all-string data.
+    """
+    _test_opt_update_min(scikit_gp_opt, mock_configs_str, mock_scores, mock_status)

--- a/mlos_bench/mlos_bench/tests/optimizers/opt_bulk_register_test.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/opt_bulk_register_test.py
@@ -52,7 +52,7 @@ def mock_configs() -> List[dict]:
 
 
 @pytest.fixture
-def mock_configs_str(mock_configs) -> List[dict]:
+def mock_configs_str(mock_configs: List[dict]) -> List[dict]:
     """
     Same as `mock_config` above, but with all values converted to strings.
     (This can happen when we retrieve the data from storage).

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -9,7 +9,7 @@ import copy
 import collections
 import logging
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TypedDict, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, TypedDict, Union
 
 _LOG = logging.getLogger(__name__)
 
@@ -48,6 +48,13 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         "float": float,
         # Don't string convert None (json null) to "None"
         "categorical": lambda s: None if s is None else str(s),
+    }
+
+    # Actual storage type
+    _DTYPE: Dict[str, Type] = {
+        "int": int,
+        "float": float,
+        "categorical": str,
     }
 
     def __init__(self, name: str, config: TunableDict):
@@ -308,6 +315,20 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
             Data type of the tunable - one of {'int', 'float', 'categorical'}.
         """
         return self._type
+
+    @property
+    def dtype(self) -> Type:
+        """
+        Get the actual Python data type of the tunable.
+
+        This is useful for bulk conversions of the input data.
+
+        Returns
+        -------
+        dtype : type
+            Data type of the tunable - one of {int, float, str}.
+        """
+        return self._DTYPE[self._type]
 
     @property
     def is_categorical(self) -> bool:

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -198,8 +198,8 @@ class Tunable:  # pylint: disable=too-many-instance-attributes
         # (e.g., scikit-optimize) and for data restored from certain storage
         # systems (where values can be strings).
         try:
-            if self.is_categorical and value in self._values:
-                coerced_value = value
+            if self.is_categorical and value is None:
+                coerced_value = None
             else:
                 coerced_value = self._DTYPE[self._type](value)
         except Exception:


### PR DESCRIPTION
That bugfix allows us to resume the experiments when using mlos_core optimizers. now we can run, e.g., 
```bash
mlos_bench --config .\mlos_bench\mlos_bench\config\cli\azure-redis-skopt.jsonc
```
multiple times and collect the results from all runs in SQLite3 DB.