### PR TITLE
back out prettier config for json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,7 +60,6 @@
                 "donjayamanne.python-environment-manager",
                 "eamodio.gitlens",
                 "editorconfig.editorconfig",
-                "esbenp.prettier-vscode",
                 "github.copilot",
                 "github.vscode-github-actions",
                 "github.vscode-pull-request-github",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
         "donjayamanne.python-environment-manager",
         "eamodio.gitlens",
         "editorconfig.editorconfig",
-        "esbenp.prettier-vscode",
         "github.copilot",
         "github.vscode-github-actions",
         "github.vscode-pull-request-github",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,9 +89,6 @@
     ],
     "esbonio.sphinx.confDir": "${workspaceFolder}/doc/source",
     "esbonio.sphinx.buildDir": "${workspaceFolder}/doc/build/",
-    "editor.formatOnSave": true,
-    "editor.formatOnSaveMode": "modifications",
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "python.formatting.provider": "none",
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8",


### PR DESCRIPTION
stop using prettier to format json for now - it wraps two line arrays which is annoying for ranges