### PR TITLE
Use keyword arguments in all mlos_core optimizers and space adapters

### DIFF
--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -35,7 +35,8 @@ class MlosCoreOptimizer(Optimizer):
         space = tunable_groups_to_configspace(tunables)
         _LOG.debug("ConfigSpace: %s", space)
 
-        opt_type = getattr(OptimizerType, self._config.pop('optimizer_type', DEFAULT_OPTIMIZER_TYPE.name))
+        opt_type = getattr(OptimizerType, self._config.pop(
+            'optimizer_type', DEFAULT_OPTIMIZER_TYPE.name))
 
         space_adapter_type = self._config.pop('space_adapter_type', None)
         space_adapter_config = self._config.pop('space_adapter_config', {})
@@ -44,9 +45,12 @@ class MlosCoreOptimizer(Optimizer):
             space_adapter_type = getattr(SpaceAdapterType, space_adapter_type)
 
         self._opt: BaseOptimizer = OptimizerFactory.create(
-            space, opt_type, optimizer_kwargs=self._config,
+            parameter_space=space,
+            optimizer_type=opt_type,
+            optimizer_kwargs=self._config,
             space_adapter_type=space_adapter_type,
-            space_adapter_kwargs=space_adapter_config)
+            space_adapter_kwargs=space_adapter_config
+        )
 
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
                       status: Optional[Sequence[Status]] = None) -> bool:

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -196,7 +196,6 @@ class Storage(metaclass=ABCMeta):
         def __init__(self, *,
                      tunables: TunableGroups, experiment_id: str, trial_id: int,
                      config_id: int, opt_target: str, config: Optional[Dict[str, Any]] = None):
-            # pylint: disable=too-many-arguments
             self._tunables = tunables
             self._experiment_id = experiment_id
             self._trial_id = trial_id

--- a/mlos_core/mlos_core/optimizers/__init__.py
+++ b/mlos_core/mlos_core/optimizers/__init__.py
@@ -63,43 +63,53 @@ DEFAULT_OPTIMIZER_TYPE = OptimizerType.SKOPT
 class OptimizerFactory:
     """Simple factory class for creating BaseOptimizer-derived objects"""
 
-    # pylint: disable=too-few-public-methods,consider-alternative-union-syntax
+    # pylint: disable=too-few-public-methods
 
     @staticmethod
-    def create(
-        parameter_space: ConfigSpace.ConfigurationSpace,
-        optimizer_type: OptimizerType = DEFAULT_OPTIMIZER_TYPE,
-        optimizer_kwargs: Optional[dict] = None,
-        space_adapter_type: SpaceAdapterType = SpaceAdapterType.IDENTITY,
-        space_adapter_kwargs: Optional[dict] = None,
-    ) -> ConcreteOptimizer:
-        """Creates a new optimizer instance, given the parameter space, optimizer type and potential optimizer options.
+    def create(*,
+               parameter_space: ConfigSpace.ConfigurationSpace,
+               optimizer_type: OptimizerType = DEFAULT_OPTIMIZER_TYPE,
+               optimizer_kwargs: Optional[dict] = None,
+               space_adapter_type: SpaceAdapterType = SpaceAdapterType.IDENTITY,
+               space_adapter_kwargs: Optional[dict] = None) -> ConcreteOptimizer:
+        """
+        Create a new optimizer instance, given the parameter space, optimizer type,
+        and potential optimizer options.
 
         Parameters
         ----------
         parameter_space : ConfigSpace.ConfigurationSpace
             Input configuration space.
-
         optimizer_type : OptimizerType
             Optimizer class as defined by Enum.
-
         optimizer_kwargs : Optional[dict]
             Optional arguments passed in Optimizer class constructor.
-
         space_adapter_type : Optional[SpaceAdapterType]
             Space adapter class to be used alongside the optimizer.
-
         space_adapter_kwargs : Optional[dict]
             Optional arguments passed in SpaceAdapter class constructor.
 
         Returns
         -------
-        Instance of concrete optimizer (e.g., RandomOptimizer, EmukitOptimizer, SkoptOptimizer, etc.) class.
+        optimizer : ConcreteOptimizer
+            Instance of concrete optimizer class
+            (e.g., RandomOptimizer, EmukitOptimizer, SkoptOptimizer, etc.).
         """
         if space_adapter_kwargs is None:
             space_adapter_kwargs = {}
         if optimizer_kwargs is None:
             optimizer_kwargs = {}
-        space_adapter = SpaceAdapterFactory.create(parameter_space, space_adapter_type, space_adapter_kwargs=space_adapter_kwargs)
-        optimizer: ConcreteOptimizer = optimizer_type.value(parameter_space, space_adapter=space_adapter, **optimizer_kwargs)
+
+        space_adapter = SpaceAdapterFactory.create(
+            parameter_space=parameter_space,
+            space_adapter_type=space_adapter_type,
+            space_adapter_kwargs=space_adapter_kwargs,
+        )
+
+        optimizer: ConcreteOptimizer = optimizer_type.value(
+            parameter_space=parameter_space,
+            space_adapter=space_adapter,
+            **optimizer_kwargs
+        )
+
         return optimizer

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/emukit_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/emukit_optimizer.py
@@ -31,11 +31,18 @@ class EmukitOptimizer(BaseBayesianOptimizer):
         The space adapter class to employ for parameter space transformations.
     """
 
-    def __init__(self, parameter_space: ConfigSpace.ConfigurationSpace,
+    def __init__(self, *,
+                 parameter_space: ConfigSpace.ConfigurationSpace,
                  space_adapter: Optional[BaseSpaceAdapter] = None):
-        super().__init__(parameter_space, space_adapter)
+
+        super().__init__(
+            parameter_space=parameter_space,
+            space_adapter=space_adapter,
+        )
+
+        # pylint: disable=import-outside-toplevel
+        from emukit.examples.gp_bayesian_optimization.single_objective_bayesian_optimization import GPBayesianOptimization
         self.emukit_parameter_space = configspace_to_emukit_space(self.optimizer_parameter_space)
-        from emukit.examples.gp_bayesian_optimization.single_objective_bayesian_optimization import GPBayesianOptimization  # noqa pylint: disable=import-outside-toplevel
         self.gpbo: GPBayesianOptimization
 
     def _register(self, configurations: pd.DataFrame, scores: pd.Series,

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/skopt_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/skopt_optimizer.py
@@ -28,14 +28,16 @@ class SkoptOptimizer(BaseBayesianOptimizer):
         The parameter space to optimize.
     """
 
-    def __init__(
-        self,
-        parameter_space: ConfigSpace.ConfigurationSpace,
-        space_adapter: Optional[BaseSpaceAdapter] = None,
-        base_estimator: str = 'gp',
-        seed: Optional[int] = None,
-    ):
-        super().__init__(parameter_space, space_adapter)
+    def __init__(self, *,
+                 parameter_space: ConfigSpace.ConfigurationSpace,
+                 space_adapter: Optional[BaseSpaceAdapter] = None,
+                 base_estimator: str = 'gp',
+                 seed: Optional[int] = None):
+
+        super().__init__(
+            parameter_space=parameter_space,
+            space_adapter=space_adapter,
+        )
 
         from skopt import Optimizer as Optimizer_Skopt  # pylint: disable=import-outside-toplevel
         self.base_optimizer = Optimizer_Skopt(

--- a/mlos_core/mlos_core/optimizers/flaml_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/flaml_optimizer.py
@@ -40,13 +40,15 @@ class FlamlOptimizer(BaseOptimizer):
         More info: https://microsoft.github.io/FLAML/docs/FAQ#about-low_cost_partial_config-in-tune
     """
 
-    def __init__(
-        self,
-        parameter_space: ConfigSpace.ConfigurationSpace,
-        space_adapter: Optional[BaseSpaceAdapter] = None,
-        low_cost_partial_config: Optional[dict] = None,
-    ):
-        super().__init__(parameter_space, space_adapter)
+    def __init__(self, *,
+                 parameter_space: ConfigSpace.ConfigurationSpace,
+                 space_adapter: Optional[BaseSpaceAdapter] = None,
+                 low_cost_partial_config: Optional[dict] = None):
+
+        super().__init__(
+            parameter_space=parameter_space,
+            space_adapter=space_adapter,
+        )
 
         self.flaml_parameter_space: dict = configspace_to_flaml_space(self.optimizer_parameter_space)
         self.low_cost_partial_config = low_cost_partial_config

--- a/mlos_core/mlos_core/optimizers/flaml_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/flaml_optimizer.py
@@ -74,7 +74,8 @@ class FlamlOptimizer(BaseOptimizer):
         if context is not None:
             raise NotImplementedError()
         for (_, config), score in zip(configurations.iterrows(), scores):
-            cs_config: ConfigSpace.Configuration = ConfigSpace.Configuration(self.optimizer_parameter_space, values=config.to_dict())  # noqa: E501
+            cs_config: ConfigSpace.Configuration = ConfigSpace.Configuration(
+                self.optimizer_parameter_space, values=config.to_dict())
             if cs_config in self.evaluated_samples:
                 warn(f"Configuration {config} was already registered", UserWarning)
 

--- a/mlos_core/mlos_core/optimizers/optimizer.py
+++ b/mlos_core/mlos_core/optimizers/optimizer.py
@@ -26,7 +26,9 @@ class BaseOptimizer(metaclass=ABCMeta):
     Optimizer abstract base class defining the basic interface.
     """
 
-    def __init__(self, parameter_space: ConfigSpace.ConfigurationSpace, space_adapter: Optional[BaseSpaceAdapter] = None):
+    def __init__(self, *,
+                 parameter_space: ConfigSpace.ConfigurationSpace,
+                 space_adapter: Optional[BaseSpaceAdapter] = None):
         """
         Create a new instance of the base optimizer.
 

--- a/mlos_core/mlos_core/optimizers/optimizer.py
+++ b/mlos_core/mlos_core/optimizers/optimizer.py
@@ -18,8 +18,6 @@ import pandas as pd
 from mlos_core import config_to_dataframe
 from mlos_core.spaces.adapters.adapter import BaseSpaceAdapter
 
-# pylint: disable=consider-alternative-union-syntax
-
 
 class BaseOptimizer(metaclass=ABCMeta):
     """

--- a/mlos_core/mlos_core/spaces/adapters/__init__.py
+++ b/mlos_core/mlos_core/spaces/adapters/__init__.py
@@ -44,7 +44,7 @@ ConcreteSpaceAdapter = TypeVar(
 class SpaceAdapterFactory:
     """Simple factory class for creating BaseSpaceAdapter-derived objects"""
 
-    # pylint: disable=too-few-public-methods,consider-alternative-union-syntax
+    # pylint: disable=too-few-public-methods
 
     @staticmethod
     def create(*,

--- a/mlos_core/mlos_core/spaces/adapters/__init__.py
+++ b/mlos_core/mlos_core/spaces/adapters/__init__.py
@@ -47,31 +47,36 @@ class SpaceAdapterFactory:
     # pylint: disable=too-few-public-methods,consider-alternative-union-syntax
 
     @staticmethod
-    def create(
-        parameter_space: ConfigSpace.ConfigurationSpace,
-        space_adapter_type: SpaceAdapterType = SpaceAdapterType.IDENTITY,
-        space_adapter_kwargs: Optional[dict] = None,
-    ) -> ConcreteSpaceAdapter:
-        """Creates a new space adapter instance, given the parameter space and potential space adapter options.
+    def create(*,
+               parameter_space: ConfigSpace.ConfigurationSpace,
+               space_adapter_type: SpaceAdapterType = SpaceAdapterType.IDENTITY,
+               space_adapter_kwargs: Optional[dict] = None) -> ConcreteSpaceAdapter:
+        """
+        Create a new space adapter instance, given the parameter space and potential
+        space adapter options.
 
         Parameters
         ----------
         parameter_space : ConfigSpace.ConfigurationSpace
             Input configuration space.
-
         space_adapter_type : Optional[SpaceAdapterType]
             Space adapter class to be used alongside the optimizer.
-
         space_adapter_kwargs : Optional[dict]
             Optional arguments passed in SpaceAdapter class constructor.
 
         Returns
         -------
-        Instance of concrete optimizer (e.g., None, LlamaTuneAdapter, etc.)
+        space_adapter : ConcreteSpaceAdapter
+            Instance of concrete space adapter (e.g., None, LlamaTuneAdapter, etc.)
         """
         if space_adapter_type is None:
             space_adapter_type = SpaceAdapterType.IDENTITY
         if space_adapter_kwargs is None:
             space_adapter_kwargs = {}
-        space_adapter: ConcreteSpaceAdapter = space_adapter_type.value(parameter_space, **space_adapter_kwargs)
+
+        space_adapter: ConcreteSpaceAdapter = space_adapter_type.value(
+            parameter_space=parameter_space,
+            **space_adapter_kwargs
+        )
+
         return space_adapter

--- a/mlos_core/mlos_core/spaces/adapters/__init__.py
+++ b/mlos_core/mlos_core/spaces/adapters/__init__.py
@@ -75,7 +75,7 @@ class SpaceAdapterFactory:
             space_adapter_kwargs = {}
 
         space_adapter: ConcreteSpaceAdapter = space_adapter_type.value(
-            parameter_space=parameter_space,
+            orig_parameter_space=parameter_space,
             **space_adapter_kwargs
         )
 

--- a/mlos_core/mlos_core/spaces/adapters/adapter.py
+++ b/mlos_core/mlos_core/spaces/adapters/adapter.py
@@ -21,7 +21,7 @@ class BaseSpaceAdapter(metaclass=ABCMeta):
         The original parameter space to explore.
     """
 
-    def __init__(self, orig_parameter_space: ConfigSpace.ConfigurationSpace):
+    def __init__(self, *, orig_parameter_space: ConfigSpace.ConfigurationSpace):
         self._orig_parameter_space: ConfigSpace.ConfigurationSpace = orig_parameter_space
         self._random_state = orig_parameter_space.random
 

--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -31,32 +31,28 @@ class LlamaTuneAdapter(BaseSpaceAdapter):   # pylint: disable=too-many-instance-
     DEFAULT_MAX_UNIQUE_VALUES_PER_PARAM = 10000
     """Default number of (max) unique values of each parameter, when space discretization is used"""
 
-    def __init__(   # pylint: disable=too-many-arguments
-        self,
-        orig_config_space: ConfigSpace.ConfigurationSpace,
-        num_low_dims: int = DEFAULT_NUM_LOW_DIMS,
-        special_param_values: Optional[dict] = None,
-        max_unique_values_per_param: Optional[int] = DEFAULT_MAX_UNIQUE_VALUES_PER_PARAM,
-        use_approximate_reverse_mapping: bool = False,
-    ) -> None:
-        """Create a space adapter that employs LlamaTune's techniques.
+    def __init__(self, *,
+                 orig_config_space: ConfigSpace.ConfigurationSpace,
+                 num_low_dims: int = DEFAULT_NUM_LOW_DIMS,
+                 special_param_values: Optional[dict] = None,
+                 max_unique_values_per_param: Optional[int] = DEFAULT_MAX_UNIQUE_VALUES_PER_PARAM,
+                 use_approximate_reverse_mapping: bool = False):
+        """
+        Create a space adapter that employs LlamaTune's techniques.
 
         Parameters
         ----------
         parameter_space : ConfigSpace.ConfigurationSpace
             The original (user-provided) parameter space to optimize.
-
         num_low_dims: int
             Number of dimensions used in the low-dimensional parameter search space.
-
         special_param_values_dict: Optional[dict]
             Dictionary of special
-
         max_unique_values_per_param: Optional[int]:
             Number of unique values per parameter. Used to discretize the parameter space.
             If `None` space discretization is disabled.
         """
-        super().__init__(orig_config_space)
+        super().__init__(orig_parameter_space=orig_config_space)
 
         if num_low_dims >= len(orig_config_space):
             raise ValueError("Number of target config space dimensions should be less than those of original config space.")

--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -32,7 +32,7 @@ class LlamaTuneAdapter(BaseSpaceAdapter):   # pylint: disable=too-many-instance-
     """Default number of (max) unique values of each parameter, when space discretization is used"""
 
     def __init__(self, *,
-                 orig_config_space: ConfigSpace.ConfigurationSpace,
+                 orig_parameter_space: ConfigSpace.ConfigurationSpace,
                  num_low_dims: int = DEFAULT_NUM_LOW_DIMS,
                  special_param_values: Optional[dict] = None,
                  max_unique_values_per_param: Optional[int] = DEFAULT_MAX_UNIQUE_VALUES_PER_PARAM,
@@ -42,7 +42,7 @@ class LlamaTuneAdapter(BaseSpaceAdapter):   # pylint: disable=too-many-instance-
 
         Parameters
         ----------
-        parameter_space : ConfigSpace.ConfigurationSpace
+        orig_parameter_space : ConfigSpace.ConfigurationSpace
             The original (user-provided) parameter space to optimize.
         num_low_dims: int
             Number of dimensions used in the low-dimensional parameter search space.
@@ -52,9 +52,9 @@ class LlamaTuneAdapter(BaseSpaceAdapter):   # pylint: disable=too-many-instance-
             Number of unique values per parameter. Used to discretize the parameter space.
             If `None` space discretization is disabled.
         """
-        super().__init__(orig_parameter_space=orig_config_space)
+        super().__init__(orig_parameter_space=orig_parameter_space)
 
-        if num_low_dims >= len(orig_config_space):
+        if num_low_dims >= len(orig_parameter_space):
             raise ValueError("Number of target config space dimensions should be less than those of original config space.")
 
         # Validate input special param values dict

--- a/mlos_core/mlos_core/tests/optimizers/bayesian_optimizers_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/bayesian_optimizers_test.py
@@ -27,7 +27,7 @@ def test_context_not_implemented_error(configuration_space: CS.ConfigurationSpac
     """
     if kwargs is None:
         kwargs = {}
-    optimizer = optimizer_class(configuration_space, **kwargs)
+    optimizer = optimizer_class(parameter_space=configuration_space, **kwargs)
     suggestion = optimizer.suggest()
     scores = pd.DataFrame({'score': [1]})
     # test context not implemented errors

--- a/mlos_core/mlos_core/tests/optimizers/one_hot_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/one_hot_test.py
@@ -49,7 +49,7 @@ def test_to_1hot(configuration_space: CS.ConfigurationSpace,
     """
     Toy problem to test one-hot encoding.
     """
-    optimizer = EmukitOptimizer(configuration_space)
+    optimizer = EmukitOptimizer(parameter_space=configuration_space)
     assert optimizer._to_1hot(data_frame) == pytest.approx(one_hot)
 
 
@@ -58,7 +58,7 @@ def test_from_1hot(configuration_space: CS.ConfigurationSpace,
     """
     Toy problem to test one-hot decoding.
     """
-    optimizer = EmukitOptimizer(configuration_space)
+    optimizer = EmukitOptimizer(parameter_space=configuration_space)
     assert optimizer._from_1hot(one_hot).to_dict() == data_frame.to_dict()
 
 
@@ -66,7 +66,7 @@ def test_round_trip(configuration_space: CS.ConfigurationSpace, data_frame: pd.D
     """
     Round-trip test for one-hot-encoding and then decoding a data frame.
     """
-    optimizer = EmukitOptimizer(configuration_space)
+    optimizer = EmukitOptimizer(parameter_space=configuration_space)
     df_round_trip = optimizer._from_1hot(optimizer._to_1hot(data_frame))
     assert df_round_trip.x.to_numpy() == pytest.approx(data_frame.x)
     assert (df_round_trip.y == data_frame.y).all()
@@ -77,6 +77,6 @@ def test_round_trip_reverse(configuration_space: CS.ConfigurationSpace, one_hot:
     """
     Round-trip test for one-hot-decoding and then encoding of a numpy array.
     """
-    optimizer = EmukitOptimizer(configuration_space)
+    optimizer = EmukitOptimizer(parameter_space=configuration_space)
     round_trip = optimizer._to_1hot(optimizer._from_1hot(one_hot))
     assert round_trip == pytest.approx(one_hot)

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -36,7 +36,7 @@ def test_create_optimizer_and_suggest(configuration_space: CS.ConfigurationSpace
     """
     if kwargs is None:
         kwargs = {}
-    optimizer = optimizer_class(configuration_space, **kwargs)
+    optimizer = optimizer_class(parameter_space=configuration_space, **kwargs)
     assert optimizer is not None
 
     assert optimizer.parameter_space is not None
@@ -70,7 +70,7 @@ def test_basic_interface_toy_problem(configuration_space: CS.ConfigurationSpace,
         return ret
     # Emukit doesn't allow specifying a random state, so we set the global seed.
     np.random.seed(42)
-    optimizer = optimizer_class(configuration_space, **kwargs)
+    optimizer = optimizer_class(parameter_space=configuration_space, **kwargs)
 
     with pytest.raises(ValueError, match="No observations"):
         optimizer.get_best_observation()
@@ -137,9 +137,16 @@ def test_create_optimizer_with_factory_method(configuration_space: CS.Configurat
     if kwargs is None:
         kwargs = {}
     if optimizer_type is None:
-        optimizer = OptimizerFactory.create(configuration_space, optimizer_kwargs=kwargs)
+        optimizer = OptimizerFactory.create(
+            parameter_space=configuration_space,
+            optimizer_kwargs=kwargs,
+        )
     else:
-        optimizer = OptimizerFactory.create(configuration_space, optimizer_type, optimizer_kwargs=kwargs)
+        optimizer = OptimizerFactory.create(
+            parameter_space=configuration_space,
+            optimizer_type=optimizer_type,
+            optimizer_kwargs=kwargs,
+        )
     assert optimizer is not None
 
     assert optimizer.parameter_space is not None
@@ -176,7 +183,11 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     input_space.add_hyperparameter(CS.UniformFloatHyperparameter(name='y', lower=0, upper=3))
 
     # Initialize optimizer
-    optimizer: BaseOptimizer = OptimizerFactory.create(input_space, optimizer_type, optimizer_kwargs=kwargs)
+    optimizer: BaseOptimizer = OptimizerFactory.create(
+        parameter_space=input_space,
+        optimizer_type=optimizer_type,
+        optimizer_kwargs=kwargs,
+    )
     assert optimizer is not None
 
     # Initialize another optimizer that uses LlamaTune space adapter
@@ -186,11 +197,11 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
         "max_unique_values_per_param": None,
     }
     llamatune_optimizer: BaseOptimizer = OptimizerFactory.create(
-        input_space,
-        optimizer_type,
+        parameter_space=input_space,
+        optimizer_type=optimizer_type,
         optimizer_kwargs=kwargs,
         space_adapter_type=SpaceAdapterType.LLAMATUNE,
-        space_adapter_kwargs=space_adapter_kwargs
+        space_adapter_kwargs=space_adapter_kwargs,
     )
     assert llamatune_optimizer is not None
 

--- a/mlos_core/mlos_core/tests/spaces/adapters/identity_adapter_test.py
+++ b/mlos_core/mlos_core/tests/spaces/adapters/identity_adapter_test.py
@@ -26,7 +26,7 @@ def test_identity_adapter() -> None:
     input_space.add_hyperparameter(
         CS.CategoricalHyperparameter(name='str_1', choices=['on', 'off']))
 
-    adapter = IdentityAdapter(input_space)
+    adapter = IdentityAdapter(orig_parameter_space=input_space)
 
     num_configs = 10
     for sampled_config in input_space.sample_configuration(size=num_configs):

--- a/mlos_core/mlos_core/tests/spaces/adapters/llamatune_test.py
+++ b/mlos_core/mlos_core/tests/spaces/adapters/llamatune_test.py
@@ -67,13 +67,13 @@ def test_num_low_dims(num_target_space_dims: int, param_space_kwargs: dict) -> N
     # Number of target parameter space dimensions should be fewer than those of the original space
     with pytest.raises(ValueError):
         LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=len(input_space.get_hyperparameter_names())
         )
 
     # Enable only low-dimensional space projections
     adapter = LlamaTuneAdapter(
-        orig_config_space=input_space,
+        orig_parameter_space=input_space,
         num_low_dims=num_target_space_dims,
         special_param_values=None,
         max_unique_values_per_param=None
@@ -123,7 +123,7 @@ def test_special_parameter_values_validation() -> None:
     with pytest.raises(NotImplementedError):
         special_param_values_dict_1 = {'str': 'choice_1'}
         LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=2,
             special_param_values=special_param_values_dict_1,
             max_unique_values_per_param=None,
@@ -132,7 +132,7 @@ def test_special_parameter_values_validation() -> None:
     with pytest.raises(NotImplementedError):
         special_param_values_dict_2 = {'cont': -1}
         LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=2,
             special_param_values=special_param_values_dict_2,
             max_unique_values_per_param=None,
@@ -142,7 +142,7 @@ def test_special_parameter_values_validation() -> None:
     with pytest.raises(ValueError, match='value domain'):
         special_param_values_dict = {'int': -1}
         LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=2,
             special_param_values=special_param_values_dict,
             max_unique_values_per_param=None,
@@ -163,7 +163,7 @@ def test_special_parameter_values_validation() -> None:
     for spv_dict in invalid_special_param_values_dicts:
         with pytest.raises(ValueError):
             LlamaTuneAdapter(
-                orig_config_space=input_space,
+                orig_parameter_space=input_space,
                 num_low_dims=2,
                 special_param_values=spv_dict,
                 max_unique_values_per_param=None,
@@ -183,7 +183,7 @@ def test_special_parameter_values_validation() -> None:
     for spv_dict in invalid_special_param_values_dicts:
         with pytest.raises(ValueError):
             LlamaTuneAdapter(
-                orig_config_space=input_space,
+                orig_parameter_space=input_space,
                 num_low_dims=2,
                 special_param_values=spv_dict,
                 max_unique_values_per_param=None,
@@ -223,7 +223,7 @@ def test_special_parameter_values_biasing() -> None:    # pylint: disable=too-co
 
     for spv_dict in special_param_value_dicts:
         adapter = LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=1,
             special_param_values=spv_dict,
             max_unique_values_per_param=None,
@@ -241,7 +241,7 @@ def test_special_parameter_values_biasing() -> None:    # pylint: disable=too-co
 
     for spv_dict in special_param_value_dicts:
         adapter = LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=1,
             special_param_values=spv_dict,
             max_unique_values_per_param=None,
@@ -263,7 +263,7 @@ def test_special_parameter_values_biasing() -> None:    # pylint: disable=too-co
         'int_2': [(2, bias_percentage / 2), (100, bias_percentage * 1.5)]
     }
     adapter = LlamaTuneAdapter(
-        orig_config_space=input_space,
+        orig_parameter_space=input_space,
         num_low_dims=1,
         special_param_values=spv_dict,
         max_unique_values_per_param=None,
@@ -313,7 +313,7 @@ def test_max_unique_values_per_param() -> None:
     num_configs = 200
     for max_unique_values_per_param in (5, 25, 100):
         adapter = LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=3,
             special_param_values=None,
             max_unique_values_per_param=max_unique_values_per_param,
@@ -354,7 +354,7 @@ def test_approx_inverse_mapping(num_target_space_dims: int, param_space_kwargs: 
 
     # Enable low-dimensional space projection, but disable reverse mapping
     adapter = LlamaTuneAdapter(
-        orig_config_space=input_space,
+        orig_parameter_space=input_space,
         num_low_dims=num_target_space_dims,
         special_param_values=None,
         max_unique_values_per_param=None,
@@ -368,7 +368,7 @@ def test_approx_inverse_mapping(num_target_space_dims: int, param_space_kwargs: 
 
     # Enable low-dimensional space projection *and* reverse mapping
     adapter = LlamaTuneAdapter(
-        orig_config_space=input_space,
+        orig_parameter_space=input_space,
         num_low_dims=num_target_space_dims,
         special_param_values=None,
         max_unique_values_per_param=None,
@@ -412,7 +412,7 @@ def test_llamatune_pipeline(num_low_dims: int, special_param_values: dict, max_u
     # Define config space with a mix of different parameter types
     input_space = construct_parameter_space(n_continuous_params=10, n_integer_params=10, n_categorical_params=5)
     adapter = LlamaTuneAdapter(
-        orig_config_space=input_space,
+        orig_parameter_space=input_space,
         num_low_dims=num_low_dims,
         special_param_values=special_param_values,
         max_unique_values_per_param=max_unique_values_per_param,
@@ -484,7 +484,7 @@ def test_deterministic_behavior_for_same_seed(num_target_space_dims: int, param_
 
         # Init adapter and sample points in the low-dim space
         adapter = LlamaTuneAdapter(
-            orig_config_space=input_space,
+            orig_parameter_space=input_space,
             num_low_dims=num_target_space_dims,
             special_param_values=None,
             max_unique_values_per_param=None,

--- a/mlos_core/mlos_core/tests/spaces/adapters/space_adapter_factory_test.py
+++ b/mlos_core/mlos_core/tests/spaces/adapters/space_adapter_factory_test.py
@@ -57,9 +57,13 @@ def test_create_space_adapter_with_factory_method(space_adapter_type: Optional[S
 
     space_adapter: BaseSpaceAdapter
     if space_adapter_type is None:
-        space_adapter = SpaceAdapterFactory.create(input_space)
+        space_adapter = SpaceAdapterFactory.create(parameter_space=input_space)
     else:
-        space_adapter = SpaceAdapterFactory.create(input_space, space_adapter_type, space_adapter_kwargs=kwargs)
+        space_adapter = SpaceAdapterFactory.create(
+            parameter_space=input_space,
+            space_adapter_type=space_adapter_type,
+            space_adapter_kwargs=kwargs,
+        )
 
     if space_adapter_type is None or space_adapter_type is SpaceAdapterType.IDENTITY:
         assert isinstance(space_adapter, IdentityAdapter)

--- a/mlos_core/notebooks/BayesianOptimization.ipynb
+++ b/mlos_core/notebooks/BayesianOptimization.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -114,12 +115,12 @@
    "source": [
     "# Choose an optimizer.\n",
     "\n",
-    "#optimizer = mlos_core.optimizers.RandomOptimizer(input_space)\n",
+    "#optimizer = mlos_core.optimizers.RandomOptimizer(parameter_space=input_space)\n",
     "\n",
     "# can optionally select a different base estimator for some optimizer backends\n",
-    "#optimizer = mlos_core.optimizers.SkoptOptimizer(input_space, base_estimator='gp')\n",
+    "# optimizer = mlos_core.optimizers.SkoptOptimizer(parameter_space=input_space, base_estimator='gp')\n",
     "\n",
-    "optimizer = mlos_core.optimizers.EmukitOptimizer(input_space)"
+    "optimizer = mlos_core.optimizers.EmukitOptimizer(parameter_space=input_space)"
    ]
   },
   {
@@ -147,6 +148,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -242,6 +244,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -434,6 +437,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -495,6 +499,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -885,6 +890,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -946,6 +952,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
As per #363 
Also fix some collateral pylint issues and remove unnecessary pylint exceptions.