### PR TITLE
CI debugging tweaks: group parallel job output

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -52,6 +52,7 @@ jobs:
           --volume $(pwd):/workspaces/MLOS \
           --env CONTAINER_WORKSPACE_FOLDER=/workspaces/MLOS \
           --env LOCAL_WORKSPACE_FOLDER=$(pwd) \
+          --env MAKEFLAGS=-Oline \
           --workdir /workspaces/MLOS \
           --name mlos-devcontainer mlos-devcontainer sleep infinity
     - name: Fixup vscode uid/gid in the running container

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,6 +36,8 @@ jobs:
       CONDA_ENV_NAME: unset
       # See notes about $CONDA below.
       CONDA_DIR: unset
+      # When parallel jobs are used, group the output to make debugging easier.
+      MAKEFLAGS: -Oline
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Minor tweak that's helpful for CI jobs but less so for local dev loops.
See Also: https://github.com/microsoft/MLOS/blob/f7348f1c231fecd453af40f474cb9dcc5c65bda6/Makefile#L22