### PR TITLE
Migrate Azure-specific parameters from VMEnv to AzureVMService

### DIFF
--- a/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
@@ -48,11 +48,13 @@
                         "redis"
                     ],
                     "required_args": [
+                        "vmName",
                         "experimentId",
                         "trialId",
                         "mountPoint"
                     ],
                     "const_args": {
+                        "vmName": "os-autotune-linux-vm",
                         "mountPoint": "/mnt/osat_fs"
                     },
                     "setup": [

--- a/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
@@ -61,6 +61,7 @@
                         "linux-kernel-boot"
                     ],
                     "required_args": [
+                        "vmName",
                         "storageAccountName",
                         "storageFileShareName",
                         "storageAccountKey",
@@ -69,6 +70,7 @@
                         "trialId"
                     ],
                     "const_args": {
+                        "vmName": "os-autotune-linux-vm",
                         "storageAccountName": "osatsharedstorage",
                         "storageFileShareName": "os-autotune-file-share",
                         "mountPoint": "/mnt/osat_fs"

--- a/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
@@ -6,7 +6,12 @@
             // Boot and shutdown Azure VM - all logic is in Python
             {
                 "name": "Boot Ubuntu VM on Azure",
-                "class": "mlos_bench.environments.remote.OSEnv"
+                "class": "mlos_bench.environments.remote.OSEnv",
+                "config": {
+                    "const_args": {
+                        "vmName": "os-autotune-linux-vm"
+                    }
+                }
             },
             // Local: Generate GRUB config and upload it to the shared storage
             {

--- a/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
@@ -41,6 +41,7 @@
                 ],
                 "config": {
                     "required_args": [
+                        "vmName",
                         "storageAccountName",
                         "storageFileShareName",
                         "storageAccountKey",
@@ -49,6 +50,7 @@
                         "trialId"
                     ],
                     "const_args": {
+                        "vmName": "os-autotune-linux-vm",
                         "storageAccountName": "osatsharedstorage",
                         "storageFileShareName": "os-autotune-file-share",
                         "mountPoint": "/mnt/osat_fs"

--- a/mlos_bench/mlos_bench/config/environments/vm/azure/provision-ubuntu-vm.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/vm/azure/provision-ubuntu-vm.jsonc
@@ -3,24 +3,13 @@
     "class": "mlos_bench.environments.remote.VMEnv",
 
     "include_tunables": ["environments/vm/azure/azure-vm-tunables.jsonc"],
+
     "config": {
+
         "tunable_params": ["azure-vm"],
 
         "const_args": {
-
-            "location": "westus2",
-
-            "adminUsername": "os-autotune",
-            "authenticationType": "sshPublicKey",
-
-            // Fake public key, safe to publish.
-            "adminPasswordOrKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZnRBZZWYoPaAf4ZFP3rj1IKpdjW3QySgfOfrw6gUcqWN8OnUdxXzJJ35DxDhtZY3Qq038Y7IHfocrxrKL2ID/rrYvo77/uuqaEpELOXU9YA1ervTqlUagARSfeoUQDOZkDsbm603D4/3t3l0hxNHPGDyqjLtP2U+RelhLEngaSGSvwAiFNHJef8ldDfOxgBSVprBvU+48g4mZp5QZ2O50gzhcoFI2+Ho/Am4el2SS6ptxS1BjeVR1/GoLpB/POYfWqgs5/0rrG2gUyRQZdvY97LhMVd3jUK0DeiRnQpv44fnKTh8px3sl6N5sTg9a4tL8PBZC31MqP7QTj9KqMh8HfMp0wEIXPUWinBpTjXtknZiOWodLuAtZ82GzO8sW5HhXW5ZdU6aaNZ1JUakQX+eWTAzF3qQCp2BDIrXccxa5HMjneLczHug5VH1Y4wo3LyI4QBmxoQzYUsvSDBHAGqSu3u6XJVfJbgA5Di1ykGpVaMda0iLc7wG9ADevEfOmSQIMI2PEW6ZLv/+1w+uHYJi4c+3cIr9nSPpBu1HmefY4Hrz9XtYhFwTAk8RCla9v4WPn0hrVQnTBcuW3a79d87v6O2NIv1gosnsEWpWwIHycIe3G/Y6btsoDHcYMWbWewSOVsTru5UAfiZYZk8psjMwc4wcGkIHxcgzFlWb9r8ZOzw== os-autotune-fake-key",
-
-            "virtualNetworkName": "os-autotune-vnet",
-            "subnetName": "os-autotune-subnet",
-            "networkSecurityGroupName": "os-autotune-nsg",
-
-            "ubuntuOSVersion": "18.04-LTS"
+            "vmName": "os-autotune-linux-vm"
         }
     }
 }

--- a/mlos_bench/mlos_bench/config/environments/vm/azure/provision-ubuntu-vm.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/vm/azure/provision-ubuntu-vm.jsonc
@@ -3,9 +3,7 @@
     "class": "mlos_bench.environments.remote.VMEnv",
 
     "include_tunables": ["environments/vm/azure/azure-vm-tunables.jsonc"],
-
     "config": {
-
         "tunable_params": ["azure-vm"],
 
         "const_args": {

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
@@ -21,18 +21,19 @@
                     "type": "object",
                     "properties": {
                         "storageAccountName": {
+                            "description": "Azure storage account name (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "storageFileShareName": {
+                            "description": "Azure storage file share name.",
                             "type": "string"
                         },
                         "storageAccountKey": {
+                            "description": "Azure storage account key (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         }
                     },
                     "required": [
-                        "storageAccountKey",
-                        "storageAccountName",
                         "storageFileShareName"
                     ]
                 }

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -20,18 +20,24 @@
                 {
                     "properties": {
                         "subscription": {
+                            "description": "Azure subscription id (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "accessToken": {
+                            "description": "Azure access token (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "resourceGroup": {
+                            "description": "The name of the resource group to place the deployment in (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "deploymentName": {
+                            "$comment": "TODO: provide templating strings to augment names via experimentId/trialId, for instance.",
+                            "description": "Name of the deployment to create for the experiment resources.",
                             "type": "string"
                         },
                         "deploymentTemplatePath": {
+                            "description": "Path to an ARM template file.",
                             "type": "string",
                             "pattern": "[.]json[c]?$"
                         },
@@ -46,16 +52,13 @@
                                     "boolean",
                                     "null"
                                 ]
-                            }
+                            },
+                            "minProperties": 1
                         }
                     },
                     "required": [
-                        "subscription",
-                        "accessToken",
-                        "resourceGroup",
                         "deploymentName",
-                        "deploymentTemplatePath",
-                        "deploymentTemplateParameters"
+                        "deploymentTemplatePath"
                     ]
                 }
             ],

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -34,10 +34,6 @@
                         },
                         "deploymentName": {
                             "type": "string"
-                        },
-                        "vmName": {
-                            "$comment": "TODO: Fix this so we can support multi-VMs",
-                            "type": "string"
                         }
                     },
                     "required": [
@@ -45,9 +41,17 @@
                         "subscription",
                         "accessToken",
                         "resourceGroup",
-                        "deploymentName",
-                        "vmName"
-                    ]
+                        "deploymentName"
+                    ],
+                    "additionalProperties": {
+                        "$comment": "Free-format properties of the ARM Template specified in deploymentTemplatePath",
+                        "type": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "null"
+                        ]
+                    }
                 }
             ],
             "unevaluatedProperties": false

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -19,10 +19,6 @@
                 },
                 {
                     "properties": {
-                        "deploymentTemplatePath": {
-                            "type": "string",
-                            "pattern": "[.]json[c]?$"
-                        },
                         "subscription": {
                             "type": "string"
                         },
@@ -34,24 +30,33 @@
                         },
                         "deploymentName": {
                             "type": "string"
+                        },
+                        "deploymentTemplatePath": {
+                            "type": "string",
+                            "pattern": "[.]json[c]?$"
+                        },
+                        "deploymentTemplateParameters": {
+                            "description": "Key/value pairs of ARM template parameters.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "$comment": "The value of any parameter can be a string, number, boolean, or null.",
+                                "type": [
+                                    "string",
+                                    "number",
+                                    "boolean",
+                                    "null"
+                                ]
+                            }
                         }
                     },
                     "required": [
-                        "deploymentTemplatePath",
                         "subscription",
                         "accessToken",
                         "resourceGroup",
-                        "deploymentName"
-                    ],
-                    "additionalProperties": {
-                        "$comment": "Free-format properties of the ARM Template specified in deploymentTemplatePath",
-                        "type": [
-                            "string",
-                            "number",
-                            "boolean",
-                            "null"
-                        ]
-                    }
+                        "deploymentName",
+                        "deploymentTemplatePath",
+                        "deploymentTemplateParameters"
+                    ]
                 }
             ],
             "unevaluatedProperties": false

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
@@ -5,27 +5,29 @@
 
             "config": {
 
-                "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-
                 "subscription": "AZURE SUBSCRIPTION ID",
                 "accessToken": "AZURE ACCESS TOKEN FROM `az account get-access-token`",
 
                 "resourceGroup": "os-autotune",
                 "deploymentName": "os-autotune-001",
 
-                "location": "westus2",
+                "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
 
-                "adminUsername": "os-autotune",
-                "authenticationType": "sshPublicKey",
+                "deploymentTemplateParameters": {
+                    "location": "westus2",
 
-                // Fake public key, safe to publish.
-                "adminPasswordOrKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZnRBZZWYoPaAf4ZFP3rj1IKpdjW3QySgfOfrw6gUcqWN8OnUdxXzJJ35DxDhtZY3Qq038Y7IHfocrxrKL2ID/rrYvo77/uuqaEpELOXU9YA1ervTqlUagARSfeoUQDOZkDsbm603D4/3t3l0hxNHPGDyqjLtP2U+RelhLEngaSGSvwAiFNHJef8ldDfOxgBSVprBvU+48g4mZp5QZ2O50gzhcoFI2+Ho/Am4el2SS6ptxS1BjeVR1/GoLpB/POYfWqgs5/0rrG2gUyRQZdvY97LhMVd3jUK0DeiRnQpv44fnKTh8px3sl6N5sTg9a4tL8PBZC31MqP7QTj9KqMh8HfMp0wEIXPUWinBpTjXtknZiOWodLuAtZ82GzO8sW5HhXW5ZdU6aaNZ1JUakQX+eWTAzF3qQCp2BDIrXccxa5HMjneLczHug5VH1Y4wo3LyI4QBmxoQzYUsvSDBHAGqSu3u6XJVfJbgA5Di1ykGpVaMda0iLc7wG9ADevEfOmSQIMI2PEW6ZLv/+1w+uHYJi4c+3cIr9nSPpBu1HmefY4Hrz9XtYhFwTAk8RCla9v4WPn0hrVQnTBcuW3a79d87v6O2NIv1gosnsEWpWwIHycIe3G/Y6btsoDHcYMWbWewSOVsTru5UAfiZYZk8psjMwc4wcGkIHxcgzFlWb9r8ZOzw== os-autotune-fake-key",
+                    "adminUsername": "os-autotune",
+                    "authenticationType": "sshPublicKey",
 
-                "virtualNetworkName": "os-autotune-vnet",
-                "subnetName": "os-autotune-subnet",
-                "networkSecurityGroupName": "os-autotune-nsg",
+                    // Fake public key, safe to publish.
+                    "adminPasswordOrKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZnRBZZWYoPaAf4ZFP3rj1IKpdjW3QySgfOfrw6gUcqWN8OnUdxXzJJ35DxDhtZY3Qq038Y7IHfocrxrKL2ID/rrYvo77/uuqaEpELOXU9YA1ervTqlUagARSfeoUQDOZkDsbm603D4/3t3l0hxNHPGDyqjLtP2U+RelhLEngaSGSvwAiFNHJef8ldDfOxgBSVprBvU+48g4mZp5QZ2O50gzhcoFI2+Ho/Am4el2SS6ptxS1BjeVR1/GoLpB/POYfWqgs5/0rrG2gUyRQZdvY97LhMVd3jUK0DeiRnQpv44fnKTh8px3sl6N5sTg9a4tL8PBZC31MqP7QTj9KqMh8HfMp0wEIXPUWinBpTjXtknZiOWodLuAtZ82GzO8sW5HhXW5ZdU6aaNZ1JUakQX+eWTAzF3qQCp2BDIrXccxa5HMjneLczHug5VH1Y4wo3LyI4QBmxoQzYUsvSDBHAGqSu3u6XJVfJbgA5Di1ykGpVaMda0iLc7wG9ADevEfOmSQIMI2PEW6ZLv/+1w+uHYJi4c+3cIr9nSPpBu1HmefY4Hrz9XtYhFwTAk8RCla9v4WPn0hrVQnTBcuW3a79d87v6O2NIv1gosnsEWpWwIHycIe3G/Y6btsoDHcYMWbWewSOVsTru5UAfiZYZk8psjMwc4wcGkIHxcgzFlWb9r8ZOzw== os-autotune-fake-key",
 
-                "ubuntuOSVersion": "18.04-LTS",
+                    "virtualNetworkName": "os-autotune-vnet",
+                    "subnetName": "os-autotune-subnet",
+                    "networkSecurityGroupName": "os-autotune-nsg",
+
+                    "ubuntuOSVersion": "18.04-LTS"
+                },
 
                 "pollInterval": 10,
                 "pollTimeout": 300

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
@@ -4,7 +4,6 @@
             "class": "mlos_bench.services.remote.azure.AzureVMService",
 
             "config": {
-
                 "subscription": "AZURE SUBSCRIPTION ID",
                 "accessToken": "AZURE ACCESS TOKEN FROM `az account get-access-token`",
 

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
@@ -1,20 +1,31 @@
 {
-    //"$schema": "../../../../config/schemas/services/service-schema.json",
-
     "services": [
         {
             "class": "mlos_bench.services.remote.azure.AzureVMService",
 
             "config": {
+
                 "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-                // `subscription` and `accessToken` are placeholders
-                // for values provided in the global config:
+
                 "subscription": "AZURE SUBSCRIPTION ID",
                 "accessToken": "AZURE ACCESS TOKEN FROM `az account get-access-token`",
 
                 "resourceGroup": "os-autotune",
                 "deploymentName": "os-autotune-001",
-                "vmName": "os-autotune-linux-vm",
+
+                "location": "westus2",
+
+                "adminUsername": "os-autotune",
+                "authenticationType": "sshPublicKey",
+
+                // Fake public key, safe to publish.
+                "adminPasswordOrKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDZnRBZZWYoPaAf4ZFP3rj1IKpdjW3QySgfOfrw6gUcqWN8OnUdxXzJJ35DxDhtZY3Qq038Y7IHfocrxrKL2ID/rrYvo77/uuqaEpELOXU9YA1ervTqlUagARSfeoUQDOZkDsbm603D4/3t3l0hxNHPGDyqjLtP2U+RelhLEngaSGSvwAiFNHJef8ldDfOxgBSVprBvU+48g4mZp5QZ2O50gzhcoFI2+Ho/Am4el2SS6ptxS1BjeVR1/GoLpB/POYfWqgs5/0rrG2gUyRQZdvY97LhMVd3jUK0DeiRnQpv44fnKTh8px3sl6N5sTg9a4tL8PBZC31MqP7QTj9KqMh8HfMp0wEIXPUWinBpTjXtknZiOWodLuAtZ82GzO8sW5HhXW5ZdU6aaNZ1JUakQX+eWTAzF3qQCp2BDIrXccxa5HMjneLczHug5VH1Y4wo3LyI4QBmxoQzYUsvSDBHAGqSu3u6XJVfJbgA5Di1ykGpVaMda0iLc7wG9ADevEfOmSQIMI2PEW6ZLv/+1w+uHYJi4c+3cIr9nSPpBu1HmefY4Hrz9XtYhFwTAk8RCla9v4WPn0hrVQnTBcuW3a79d87v6O2NIv1gosnsEWpWwIHycIe3G/Y6btsoDHcYMWbWewSOVsTru5UAfiZYZk8psjMwc4wcGkIHxcgzFlWb9r8ZOzw== os-autotune-fake-key",
+
+                "virtualNetworkName": "os-autotune-vnet",
+                "subnetName": "os-autotune-subnet",
+                "networkSecurityGroupName": "os-autotune-nsg",
+
+                "ubuntuOSVersion": "18.04-LTS",
 
                 "pollInterval": 10,
                 "pollTimeout": 300

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
@@ -4,13 +4,14 @@
             "class": "mlos_bench.services.remote.azure.AzureVMService",
 
             "config": {
+                "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
+                // `subscription`, `accessToken`, etc. are placeholders
+                // for values provided in the global config:
                 "subscription": "AZURE SUBSCRIPTION ID",
                 "accessToken": "AZURE ACCESS TOKEN FROM `az account get-access-token`",
 
                 "resourceGroup": "os-autotune",
                 "deploymentName": "os-autotune-001",
-
-                "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
 
                 "deploymentTemplateParameters": {
                     "location": "westus2",

--- a/mlos_bench/mlos_bench/environments/remote/os_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/os_env.py
@@ -96,7 +96,7 @@ class OSEnv(Environment):
         Clean up and shut down the host without deprovisioning it.
         """
         _LOG.info("OS tear down: %s", self)
-        (status, params) = self._host_service.vm_stop()
+        (status, params) = self._host_service.vm_stop(self._params)
         if status.is_pending:
             (status, _) = self._host_service.wait_vm_operation(params)
 

--- a/mlos_bench/mlos_bench/environments/remote/vm_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/vm_env.py
@@ -50,8 +50,7 @@ class VMEnv(Environment):
             An optional service object (e.g., providing methods to
             deploy or reboot a VM, etc.).
         """
-        super().__init__(name=name, config=config, global_config=global_config,
-                         tunables=tunables, service=service)
+        super().__init__(name=name, config=config, global_config=global_config, tunables=tunables, service=service)
 
         assert self._service is not None and isinstance(self._service, SupportsVMOps), \
             "VMEnv requires a service that supports VM operations"

--- a/mlos_bench/mlos_bench/environments/remote/vm_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/vm_env.py
@@ -50,7 +50,9 @@ class VMEnv(Environment):
             An optional service object (e.g., providing methods to
             deploy or reboot a VM, etc.).
         """
-        super().__init__(name=name, config=config, global_config=global_config, tunables=tunables, service=service)
+        super().__init__(name=name, config=config, global_config=global_config,
+                         tunables=tunables, service=service)
+
 
         assert self._service is not None and isinstance(self._service, SupportsVMOps), \
             "VMEnv requires a service that supports VM operations"

--- a/mlos_bench/mlos_bench/environments/remote/vm_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/vm_env.py
@@ -53,7 +53,6 @@ class VMEnv(Environment):
         super().__init__(name=name, config=config, global_config=global_config,
                          tunables=tunables, service=service)
 
-
         assert self._service is not None and isinstance(self._service, SupportsVMOps), \
             "VMEnv requires a service that supports VM operations"
         self._vm_service: SupportsVMOps = self._service

--- a/mlos_bench/mlos_bench/environments/remote/vm_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/vm_env.py
@@ -93,7 +93,7 @@ class VMEnv(Environment):
         Shut down the VM and release it.
         """
         _LOG.info("VM tear down: %s", self)
-        (status, params) = self._vm_service.vm_deprovision()
+        (status, params) = self._vm_service.vm_deprovision(self._params)
         if status.is_pending:
             (status, _) = self._vm_service.wait_vm_deployment(False, params)
 

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -627,7 +627,10 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
         json_req = {
             "commandId": "RunShellScript",
             "script": list(script),
-            "parameters": [{"name": key, "value": val} for (key, val) in config.items()]
+            "parameters": [
+                {"name": key, "value": val} for (key, val) in config.items()
+                if not isinstance(val, (dict, list, tuple))
+            ]
         }
 
         url = self._URL_REXEC_RUN.format(

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -551,8 +551,20 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             A pair of Status and result. The result is always the same as input `params`.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
-        _LOG.info("Deprovision: %s", params["deploymentName"])
-        return (Status.SUCCEEDED, params)
+        config = merge_parameters(
+            dest=self.config.copy(),
+            source=params,
+            required_keys=[
+                "subscription",
+                "resourceGroup",
+                "deploymentName",
+            ]
+        )
+        _LOG.info("Deprovision: %s", config["deploymentName"])
+        # TODO: Properly deprovision all resources specified in the ARM template.
+        if "vmName" in config:
+            return self.vm_stop(params)
+        return (Status.SUCCEEDED, config)
 
     def vm_restart(self, params: dict) -> Tuple[Status, dict]:
         """

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -10,7 +10,7 @@ import json
 import time
 import logging
 
-from typing import Any, Callable, Dict, Iterable, Tuple
+from typing import Callable, Iterable, Tuple
 
 import requests
 

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -278,13 +278,9 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             Status is one of {PENDING, SUCCEEDED, FAILED, TIMED_OUT}
             Result is info on the operation runtime if SUCCEEDED, otherwise {}.
         """
-        config = merge_parameters(
-            dest=self.config.copy(), source=params, required_keys=["deploymentName"])
-
-        _LOG.info("Wait for %s to %s", config["deploymentName"],
+        _LOG.info("Wait for %s to %s", params["deploymentName"],
                   "provision" if is_setup else "deprovision")
-
-        return self._wait_while(self._check_deployment, Status.PENDING, config)
+        return self._wait_while(self._check_deployment, Status.PENDING, params)
 
     def wait_vm_operation(self, params: dict) -> Tuple[Status, dict]:
         """
@@ -305,12 +301,8 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             Status is one of {PENDING, SUCCEEDED, FAILED, TIMED_OUT}
             Result is info on the operation runtime if SUCCEEDED, otherwise {}.
         """
-        config = merge_parameters(
-            dest=self.config.copy(), source=params, required_keys=["vmName"])
-
-        _LOG.info("Wait for operation on VM %s", config["vmName"])
-
-        return self._wait_while(self._check_vm_operation_status, Status.RUNNING, config)
+        _LOG.info("Wait for operation on VM %s", params["vmName"])
+        return self._wait_while(self._check_vm_operation_status, Status.RUNNING, params)
 
     def _wait_while(self, func: Callable[[dict], Tuple[Status, dict]],
                     loop_status: Status, params: dict) -> Tuple[Status, dict]:

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -203,7 +203,7 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
         # Logical flow for async operations based on:
         # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations
         if response.status_code == 200:
-            return (Status.SUCCEEDED, params)
+            return (Status.SUCCEEDED, params.copy())
         elif response.status_code == 202:
             result = params.copy()
             if "Azure-AsyncOperation" in response.headers:

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -418,7 +418,8 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
         Returns
         -------
         result : (Status, dict={})
-            A pair of Status and result. The result is always {}.
+            A pair of Status and result. The result is the input `params` plus the
+            parameters extracted from the response JSON, or {} if the status is FAILED.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
         config = merge_parameters(
@@ -469,9 +470,9 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             output = self._extract_arm_parameters(response.json())
             if _LOG.isEnabledFor(logging.DEBUG):
                 _LOG.debug("Extracted parameters:\n%s", json.dumps(output, indent=2))
-            # self.config.update(params)
-            output.setdefault("asyncResultsUrl", url)
-            return (Status.PENDING, output)
+            config.update(output)
+            config.setdefault("asyncResultsUrl", url)
+            return (Status.PENDING, config)
         else:
             _LOG.error("Response: %s :: %s", response, response.text)
             # _LOG.error("Bad Request:\n%s", response.request.body)
@@ -551,11 +552,11 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
         Returns
         -------
         result : (Status, dict={})
-            A pair of Status and result. The result is always {}.
+            A pair of Status and result. The result is always the same as input `params`.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
         _LOG.info("Deprovision: %s", params["deploymentName"])
-        return (Status.SUCCEEDED, {})
+        return (Status.SUCCEEDED, params)
 
     def vm_restart(self, params: dict) -> Tuple[Status, dict]:
         """

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -147,6 +147,9 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
         # TODO: Provide external schema validation?
         self._deploy_template = self.config_loader_service.load_config(
             config['deploymentTemplatePath'], schema_type=None)
+        assert isinstance(self._deploy_template, dict)
+
+        self._template_params = frozenset(self._deploy_template.get("parameters", {}).keys())
 
         self._headers = {
             # Access token from `az account get-access-token`:
@@ -440,7 +443,10 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             "properties": {
                 "mode": "Incremental",
                 "template": self._deploy_template,
-                "parameters": {key: {"value": val} for (key, val) in params.items()}
+                "parameters": {
+                    key: {"value": val} for (key, val) in params.items()
+                    if key in self._template_params
+                }
             }
         }
 

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -623,14 +623,10 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
         if _LOG.isEnabledFor(logging.INFO):
             _LOG.info("Run a script on VM: %s\n  %s", config["vmName"], "\n  ".join(script))
 
-        # FIXME: Filter the parameters for the remote script?? (RN we pass all of them)
         json_req = {
             "commandId": "RunShellScript",
             "script": list(script),
-            "parameters": [
-                {"name": key, "value": val} for (key, val) in config.items()
-                if not isinstance(val, (dict, list, tuple))
-            ]
+            "parameters": [{"name": key, "value": val} for (key, val) in params.items()]
         }
 
         url = self._URL_REXEC_RUN.format(

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -453,7 +453,7 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             _LOG.info("Response: %s", response)
 
         if response.status_code == 200:
-            return (Status.PENDING, {})
+            return (Status.PENDING, params)
         elif response.status_code == 201:
             output = self._extract_arm_parameters(response.json())
             if _LOG.isEnabledFor(logging.DEBUG):

--- a/mlos_bench/mlos_bench/services/types/vm_provisioner_type.py
+++ b/mlos_bench/mlos_bench/services/types/vm_provisioner_type.py
@@ -72,10 +72,15 @@ class SupportsVMOps(Protocol):
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
 
-    def vm_stop(self) -> Tuple["Status", dict]:
+    def vm_stop(self, params: dict) -> Tuple["Status", dict]:
         """
         Stops the VM by initiating a graceful shutdown.
 
+        Parameters
+        ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of tunable parameters.
+
         Returns
         -------
         result : (Status, dict={})
@@ -83,10 +88,15 @@ class SupportsVMOps(Protocol):
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
 
-    def vm_restart(self) -> Tuple["Status", dict]:
+    def vm_restart(self, params: dict) -> Tuple["Status", dict]:
         """
         Restarts the VM by initiating a graceful shutdown.
 
+        Parameters
+        ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of tunable parameters.
+
         Returns
         -------
         result : (Status, dict={})
@@ -94,9 +104,14 @@ class SupportsVMOps(Protocol):
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
 
-    def vm_deprovision(self) -> Tuple["Status", dict]:
+    def vm_deprovision(self, params: dict) -> Tuple["Status", dict]:
         """
         Deallocates the VM by shutting it down then releasing the compute resources.
+
+        Parameters
+        ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of tunable parameters.
 
         Returns
         -------

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_fileshare_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_fileshare_service-config-missing.jsonc
@@ -2,7 +2,7 @@
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
         "storageAccountName": "storage-account-name",
-        "storageFileShareName": "file-share-name",
-        //"storageAccountKey": "required param missing"
+        //"storageFileShareName": "required param missing",
+        "storageAccountKey": "required param missing"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array.jsonc
@@ -1,13 +1,14 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureVMService",
     "config": {
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
-        "accessToken": "access-token-blob",
+        // "accessToken": "access-token-blob",
+
         "resourceGroup": "rg",
         "deploymentName": "deployment",
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
-            "param": "value"
+            "array": [ "invalid" ]
         }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-object.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-object.jsonc
@@ -1,13 +1,14 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureVMService",
     "config": {
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
-        "accessToken": "access-token-blob",
+        // "accessToken": "access-token-blob",
+
         "resourceGroup": "rg",
         "deploymentName": "deployment",
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
-            "param": "value"
+            "object": { "invalid": "type" }
         }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-empty-arm-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-empty-arm-params.jsonc
@@ -7,7 +7,7 @@
         "deploymentName": "deployment",
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
-            "param": "value"
+            // "param": "value" // <-- need at least one parameter
         }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
@@ -3,9 +3,9 @@
     "config": {
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
-        // "accessToken": "access-token-blob",
+        "accessToken": "access-token-blob",
 
-        "resourceGroup": "rg",
-        "deploymentName": "deployment"
+        "resourceGroup": "rg"
+        //"deploymentName": "deployment"    // <-- missing
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
@@ -3,10 +3,9 @@
     "config": {
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
-        "accessToken": "access-token-blob",
+        // "accessToken": "access-token-blob",
 
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
-        //"vmName": "test-vm"
+        "deploymentName": "deployment"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -24,8 +24,6 @@
             "networkSecurityGroupName": "nsg",
 
             "ubuntuOSVersion": "18.04-LTS",
-
-            "vmName": "test-vm"
         },
 
         "pollInterval": 1,

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -19,7 +19,7 @@
             "virtualNetworkName": "vnet",
             "subnetName": "subnet",
             "networkSecurityGroupName": "nsg",
-            "ubuntuOSVersion": "18.04-LTS",
+            "ubuntuOSVersion": "18.04-LTS"
         },
 
         "pollInterval": 1,

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/services/service-schema.json",
+    // "$schema": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/services/service-schema.json",
     "description": "Azure VM Service configuration.",
 
     "class": "mlos_bench.services.remote.azure.azure_services.AzureVMService",
@@ -10,6 +10,19 @@
 
         "resourceGroup": "rg",
         "deploymentName": "deployment",
+
+        "location": "westus2",
+
+        "adminUsername": "admin",
+        "authenticationType": "sshPublicKey",
+        "adminPasswordOrKey": "ssh-rsa ...",
+
+        "virtualNetworkName": "vnet",
+        "subnetName": "subnet",
+        "networkSecurityGroupName": "nsg",
+
+        "ubuntuOSVersion": "18.04-LTS",
+
         "vmName": "test-vm",
 
         "pollInterval": 1,

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -4,26 +4,29 @@
 
     "class": "mlos_bench.services.remote.azure.azure_services.AzureVMService",
     "config": {
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+
         "subscription": "subscription-id",
         "accessToken": "access-token-blob",
 
         "resourceGroup": "rg",
         "deploymentName": "deployment",
 
-        "location": "westus2",
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+        "deploymentTemplateParameters": {
+            "location": "westus2",
 
-        "adminUsername": "admin",
-        "authenticationType": "sshPublicKey",
-        "adminPasswordOrKey": "ssh-rsa ...",
+            "adminUsername": "admin",
+            "authenticationType": "sshPublicKey",
+            "adminPasswordOrKey": "ssh-rsa ...",
 
-        "virtualNetworkName": "vnet",
-        "subnetName": "subnet",
-        "networkSecurityGroupName": "nsg",
+            "virtualNetworkName": "vnet",
+            "subnetName": "subnet",
+            "networkSecurityGroupName": "nsg",
 
-        "ubuntuOSVersion": "18.04-LTS",
+            "ubuntuOSVersion": "18.04-LTS",
 
-        "vmName": "test-vm",
+            "vmName": "test-vm"
+        },
 
         "pollInterval": 1,
         "pollTimeout": 60

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -4,25 +4,21 @@
 
     "class": "mlos_bench.services.remote.azure.azure_services.AzureVMService",
     "config": {
-
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "accessToken": "access-token-blob",
 
         "resourceGroup": "rg",
         "deploymentName": "deployment",
 
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
             "location": "westus2",
-
             "adminUsername": "admin",
             "authenticationType": "sshPublicKey",
             "adminPasswordOrKey": "ssh-rsa ...",
-
             "virtualNetworkName": "vnet",
             "subnetName": "subnet",
             "networkSecurityGroupName": "nsg",
-
             "ubuntuOSVersion": "18.04-LTS",
         },
 

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_fileshare_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_fileshare_service-partial.jsonc
@@ -1,8 +1,8 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
-        "storageAccountName": "storage-account-name",
-        "storageFileShareName": "file-share-name",
-        "storageAccountKey": "storage-account-key-blob"
+        //"storageAccountName": "storage-account-name",
+        //"storageAccountKey": "storage-account-key-blob",
+        "storageFileShareName": "file-share-name"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial-no-arm-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial-no-arm-params.jsonc
@@ -1,0 +1,7 @@
+{
+    "class": "mlos_bench.services.remote.azure.AzureVMService",
+    "config": {
+        "deploymentName": "deployment",
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc"
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial.jsonc
@@ -4,9 +4,7 @@
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "accessToken": "access-token-blob",
-
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
-        "vmName": "test-vm"
+        "deploymentName": "deployment"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial.jsonc
@@ -1,10 +1,11 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureVMService",
     "config": {
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "accessToken": "access-token-blob",
         "resourceGroup": "rg",
-        "deploymentName": "deployment"
+        "deploymentName": "deployment",
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+        "deploymentTemplateParameters": {}
     }
 }

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -21,9 +21,9 @@ from mlos_bench.services.remote.azure.azure_services import AzureVMService
 @pytest.mark.parametrize(
     ("operation_name", "accepts_params"), [
         ("vm_start", True),
-        ("vm_stop", False),
-        ("vm_deprovision", False),
-        ("vm_restart", False),
+        ("vm_stop", True),
+        ("vm_deprovision", True),
+        ("vm_restart", True),
     ])
 @pytest.mark.parametrize(
     ("http_status_code", "operation_status"), [
@@ -42,7 +42,7 @@ def test_vm_operation_status(mock_requests: MagicMock, azure_vm_service: AzureVM
 
     operation = getattr(azure_vm_service, operation_name)
     if accepts_params:
-        status, _ = operation({})
+        status, _ = operation({"vmName": "test-vm"})
     else:
         status, _ = operation()
 
@@ -58,6 +58,7 @@ def test_wait_vm_operation_ready(mock_requests: MagicMock, mock_sleep: MagicMock
     retry_after = 12345
     params = {
         "asyncResultsUrl": async_url,
+        "vmName": "test-vm",
         "pollInterval": retry_after,
     }
 
@@ -80,6 +81,7 @@ def test_wait_vm_operation_timeout(mock_requests: MagicMock, azure_vm_service: A
     # Mock response header
     params = {
         "asyncResultsUrl": "DUMMY_ASYNC_URL",
+        "vmName": "test-vm",
         "pollInterval": 1
     }
 

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -116,6 +116,7 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
     assert status == operation_status
 
 
+@pytest.mark.skip(reason="Enable after we fix the issue")
 @patch("mlos_bench.services.remote.azure.azure_services.requests")
 def test_remote_exec_headers_output(mock_requests: MagicMock, azure_vm_service: AzureVMService) -> None:
 

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -116,6 +116,7 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
     assert status == operation_status
 
 
+@pytest.mark.skip(reason="remote_exec() mixes config and script parameters - we'll fix it later.")
 @patch("mlos_bench.services.remote.azure.azure_services.requests")
 def test_remote_exec_headers_output(mock_requests: MagicMock, azure_vm_service: AzureVMService) -> None:
 

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -116,7 +116,6 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
     assert status == operation_status
 
 
-@pytest.mark.skip(reason="remote_exec() mixes config and script parameters - we'll fix it later.")
 @patch("mlos_bench.services.remote.azure.azure_services.requests")
 def test_remote_exec_headers_output(mock_requests: MagicMock, azure_vm_service: AzureVMService) -> None:
 

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -116,7 +116,6 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
     assert status == operation_status
 
 
-@pytest.mark.skip(reason="Enable after we fix the issue")
 @patch("mlos_bench.services.remote.azure.azure_services.requests")
 def test_remote_exec_headers_output(mock_requests: MagicMock, azure_vm_service: AzureVMService) -> None:
 

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
@@ -29,11 +29,11 @@ def azure_vm_service(config_persistence_service: ConfigPersistenceService) -> Az
     Creates a dummy Azure VM service for tests that require it.
     """
     return AzureVMService(config={
+        "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
+        "deploymentName": "TEST_DEPLOYMENT",
         "subscription": "TEST_SUB",
         "resourceGroup": "TEST_RG",
         "accessToken": "TEST_TOKEN",
-        "deploymentName": "TEST_DEPLOYMENT",
-        "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
         "deploymentTemplateParameters": {
             "location": "westus2",
         },

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
@@ -35,7 +35,7 @@ def azure_vm_service(config_persistence_service: ConfigPersistenceService) -> Az
         "deploymentName": "TEST_DEPLOYMENT",
         "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
         "deploymentTemplateParameters": {
-            "vmName": "dummy-vm",
+            "location": "westus2",
         },
         "pollInterval": 1,
         "pollTimeout": 2

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
@@ -37,6 +37,7 @@ def azure_vm_service(config_persistence_service: ConfigPersistenceService) -> Az
         "deploymentTemplateParameters": {
             "location": "westus2",
         },
+        "vmName": "test-vm",  # Should come from the upper-level config
         "pollInterval": 1,
         "pollTimeout": 2
     }, parent=config_persistence_service)

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
@@ -29,12 +29,14 @@ def azure_vm_service(config_persistence_service: ConfigPersistenceService) -> Az
     Creates a dummy Azure VM service for tests that require it.
     """
     return AzureVMService(config={
-        "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-        "deploymentName": "TEST_DEPLOYMENT",
         "subscription": "TEST_SUB",
         "resourceGroup": "TEST_RG",
         "accessToken": "TEST_TOKEN",
-        "vmName": "dummy-vm",
+        "deploymentName": "TEST_DEPLOYMENT",
+        "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
+        "deploymentTemplateParameters": {
+            "vmName": "dummy-vm",
+        },
         "pollInterval": 1,
         "pollTimeout": 2
     }, parent=config_persistence_service)


### PR DESCRIPTION
Note that in this PR we duplicate `vmName` in all environments that use `AzureVMService`. I will move this parameter into a global config in the `CompositeEnv` in the next PR.