### PR TITLE
Explicitly specify which parameters to pass as shell env variables to the remote script

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/environments/common-environment-subschemas.json
+++ b/mlos_bench/mlos_bench/config/schemas/environments/common-environment-subschemas.json
@@ -40,8 +40,10 @@
             },
             "minProperties": 1
         },
+
         "command_lines": {
             "type": "array",
+            "description": "The command lines to execute.",
             "items": {
                 "$comment": "TODO: Add support for array syntax for command lines that execute without a shell.",
                 "type": [
@@ -54,12 +56,15 @@
             "type": "object",
             "properties": {
                 "setup": {
+                    "description": "The command lines to execute for the setup phase.",
                     "$ref": "#/$defs/command_lines"
                 },
                 "run": {
+                    "description": "The command lines to execute for the run phase.",
                     "$ref": "#/$defs/command_lines"
                 },
                 "teardown": {
+                    "description": "The command lines to execute for the teardown phase.",
                     "$ref": "#/$defs/command_lines"
                 }
             },
@@ -82,6 +87,48 @@
                 }
             ]
         },
+
+        "shell_param_type": {
+            "description": "All parameters must be valid shell variable names, else use shell_params_mapping.",
+            "type": "string",
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]+$"
+        },
+        "shell_params_config": {
+            "type": "object",
+            "properties": {
+                "shell_params_match": {
+                    "description": "A list of regexes to match against the environment parameters. All matches will be exposed to shell commands as environment variables.",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "regex",
+                        "examples": [
+                            "^MLOS_[a-zA-Z0-9_]+$"
+                        ]
+                    }
+                },
+                "shell_params": {
+                    "description": "An explicit list of parameters (and their values) to pass to the shell as environment variables.  These will override any parameters matched by shell_params_match.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/shell_param_type"
+                    },
+                    "uniqueItems": true,
+                    "minItems": 1
+                },
+                "shell_params_mapping": {
+                    "description": "An explicit mapping of environment variable names from params to be populated with the parameter values and passed to the shell commands. These will override any parameters matched by shell_params_match.",
+                    "type": "object",
+                    "propertyNames": {
+                        "$ref": "#/$defs/shell_param_type"
+                    },
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+
         "file_download_config": {
             "type": "object",
             "properties": {

--- a/mlos_bench/mlos_bench/config/schemas/environments/local/local-env-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/environments/local/local-env-subschema.json
@@ -70,6 +70,9 @@
                     "$ref": "../common-environment-subschemas.json#/$defs/setup_run_teardown_configs"
                 },
                 {
+                    "$ref": "../common-environment-subschemas.json#/$defs/shell_params_config"
+                },
+                {
                     "$ref": "#/$defs/local_env_config"
                 }
             ],

--- a/mlos_bench/mlos_bench/config/schemas/environments/remote/remote-env-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/environments/remote/remote-env-subschema.json
@@ -24,6 +24,9 @@
                     "$ref": "../common-environment-subschemas.json#/$defs/setup_run_teardown_configs"
                 },
                 {
+                    "$ref": "../common-environment-subschemas.json#/$defs/shell_params_config"
+                },
+                {
                     "type": "object",
                     "properties": {
                         "wait_boot": {

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -14,7 +14,7 @@ from typing import Optional, Tuple
 import pandas
 
 from mlos_bench.environments.status import Status
-from mlos_bench.environments.base_environment import Environment
+from mlos_bench.environments.script_env import ScriptEnv
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.local_exec_type import SupportsLocalExec
 from mlos_bench.tunables.tunable_groups import TunableGroups
@@ -23,8 +23,7 @@ from mlos_bench.util import path_join
 _LOG = logging.getLogger(__name__)
 
 
-class LocalEnv(Environment):
-    # pylint: disable=too-many-instance-attributes
+class LocalEnv(ScriptEnv):
     """
     Scheduler-side Environment that runs scripts locally.
     """
@@ -58,24 +57,17 @@ class LocalEnv(Environment):
             An optional service object (e.g., providing methods to
             deploy or reboot a VM, etc.).
         """
-        super().__init__(name=name, config=config, global_config=global_config, tunables=tunables, service=service)
+        super().__init__(name=name, config=config, global_config=global_config,
+                         tunables=tunables, service=service)
 
         assert self._service is not None and isinstance(self._service, SupportsLocalExec), \
             "LocalEnv requires a service that supports local execution"
         self._local_exec_service: SupportsLocalExec = self._service
 
         self._temp_dir = self.config.get("temp_dir")
-        self._script_setup = self.config.get("setup")
-        self._script_run = self.config.get("run")
-        self._script_teardown = self.config.get("teardown")
 
         self._dump_params_file: Optional[str] = self.config.get("dump_params_file")
         self._read_results_file: Optional[str] = self.config.get("read_results_file")
-
-        if self._script_setup is None and \
-           self._script_run is None and \
-           self._script_teardown is None:
-            raise ValueError("At least one of {setup, run, teardown} must be present")
 
         if self._script_setup is None and self._dump_params_file is not None:
             raise ValueError("'setup' must be present if 'dump_params_file' is specified")

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -181,7 +181,7 @@ class LocalEnv(ScriptEnv):
         Returns
         -------
         return_code : int
-            Return code of the script. 0 if sucdessful.
+            Return code of the script. 0 if successful.
         """
         env_params = self._get_env_params()
         _LOG.info("Run script locally on: %s at %s with env %s", self, cwd, env_params)

--- a/mlos_bench/mlos_bench/environments/remote/remote_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/remote_env.py
@@ -159,7 +159,8 @@ class RemoteEnv(ScriptEnv):
         """
         env_params = self._get_env_params()
         _LOG.debug("Submit script: %s with %s", self, env_params)
-        (status, output) = self._remote_exec_service.remote_exec(script, self._params, env_params)
+        (status, output) = self._remote_exec_service.remote_exec(
+            script, config=self._params, env_params=env_params)
         _LOG.debug("Script submitted: %s %s :: %s", self, status, output)
         if status in {Status.PENDING, Status.SUCCEEDED}:
             (status, output) = self._remote_exec_service.get_remote_exec_results(output)

--- a/mlos_bench/mlos_bench/environments/remote/remote_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/remote_env.py
@@ -21,10 +21,10 @@ _LOG = logging.getLogger(__name__)
 
 
 class RemoteEnv(Environment):
+    # pylint: disable=too-many-instance-attributes
     """
     Environment to run benchmarks and scripts on a remote host.
     """
-    # pylint: disable=too-many-instance-attributes
 
     def __init__(self,
                  *,

--- a/mlos_bench/mlos_bench/environments/script_env.py
+++ b/mlos_bench/mlos_bench/environments/script_env.py
@@ -1,0 +1,79 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Base scriptable benchmark environment.
+"""
+
+import abc
+import re
+import logging
+from typing import Dict, Iterable, Optional
+
+from mlos_bench.environments.base_environment import Environment
+from mlos_bench.services.base_service import Service
+from mlos_bench.tunables.tunable_groups import TunableGroups
+
+_LOG = logging.getLogger(__name__)
+
+
+class ScriptEnv(Environment, metaclass=abc.ABCMeta):
+    """
+    Base Environment that runs scripts for setup/run/teardown.
+    """
+
+    def __init__(self,
+                 *,
+                 name: str,
+                 config: dict,
+                 global_config: Optional[dict] = None,
+                 tunables: Optional[TunableGroups] = None,
+                 service: Optional[Service] = None):
+        """
+        Create a new environment for script execution.
+
+        Parameters
+        ----------
+        name: str
+            Human-readable name of the environment.
+        config : dict
+            Free-format dictionary that contains the benchmark environment
+            configuration. Each config must have at least the "tunable_params"
+            and the "const_args" sections. It must also have at least one of
+            the following parameters: {setup, run, teardown}
+        global_config : dict
+            Free-format dictionary of global parameters (e.g., security credentials)
+            to be mixed in into the "const_args" section of the local config.
+        tunables : TunableGroups
+            A collection of tunable parameters for *all* environments.
+        service: Service
+            An optional service object (e.g., providing methods to
+            deploy or reboot a VM, etc.).
+        """
+        super().__init__(name=name, config=config, global_config=global_config,
+                         tunables=tunables, service=service)
+
+        self._script_setup = self.config.get("setup")
+        self._script_run = self.config.get("run")
+        self._script_teardown = self.config.get("teardown")
+
+        self._script_params: Optional[Iterable[str]] = self.config.get("script_params")
+
+        if self._script_setup is None and \
+           self._script_run is None and \
+           self._script_teardown is None:
+            raise ValueError("At least one of {setup, run, teardown} must be present")
+
+    def _get_env_params(self) -> Dict[str, str]:
+        """
+        Get the *shell* environment parameters to be passed to the script.
+
+        Returns
+        -------
+        env_params : Dict[str, str]
+            Parameters to pass as *shell* environment variables into the script.
+            This is usually a subset of `_params` with some possible conversions.
+        """
+        keys = self._params.keys() if self._script_params is None else self._script_params
+        return {re.sub(r"\W", "_", key): str(self._params[key]) for key in keys}

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -686,13 +686,8 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             A pair of Status and result.
             Status is one of {PENDING, SUCCEEDED, FAILED, TIMED_OUT}
         """
-        config = merge_parameters(
-            dest=self.config.copy(), source=config, required_keys=["vmName"])
-
         _LOG.info("Check the results on VM: %s", config["vmName"])
-
         (status, result) = self.wait_vm_operation(config)
-
         if status.is_succeeded:
             return (status, result.get("properties", {}).get("output", {}))
         else:

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -686,7 +686,7 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
             A pair of Status and result.
             Status is one of {PENDING, SUCCEEDED, FAILED, TIMED_OUT}
         """
-        _LOG.info("Check the results on VM: %s", config["vmName"])
+        _LOG.info("Check the results on VM: %s", config.get("vmName"))
         (status, result) = self.wait_vm_operation(config)
         if status.is_succeeded:
             return (status, result.get("properties", {}).get("output", {}))

--- a/mlos_bench/mlos_bench/services/types/remote_exec_type.py
+++ b/mlos_bench/mlos_bench/services/types/remote_exec_type.py
@@ -20,7 +20,8 @@ class SupportsRemoteExec(Protocol):
     scripts on a remote host OS.
     """
 
-    def remote_exec(self, script: Iterable[str], params: dict) -> Tuple["Status", dict]:
+    def remote_exec(self, script: Iterable[str], config: dict,
+                    env_params: dict) -> Tuple["Status", dict]:
         """
         Run a command on remote host OS.
 
@@ -28,10 +29,13 @@ class SupportsRemoteExec(Protocol):
         ----------
         script : Iterable[str]
             A list of lines to execute as a script on a remote VM.
-        params : dict
+        config : dict
             Flat dictionary of (key, value) pairs of parameters.
             They usually come from `const_args` and `tunable_params`
             properties of the Environment.
+        env_params : dict
+            Parameters to pass as *shell* environment variables into the script.
+            This is usually a subset of `config` with some possible conversions.
 
         Returns
         -------
@@ -40,13 +44,13 @@ class SupportsRemoteExec(Protocol):
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
 
-    def get_remote_exec_results(self, params: dict) -> Tuple["Status", dict]:
+    def get_remote_exec_results(self, config: dict) -> Tuple["Status", dict]:
         """
         Get the results of the asynchronously running command.
 
         Parameters
         ----------
-        params : dict
+        config : dict
             Flat dictionary of (key, value) pairs of tunable parameters.
             Must have the "asyncResultsUrl" key to get the results.
             If the key is not present, return Status.PENDING.

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-bad_shell_params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-bad_shell_params.jsonc
@@ -1,0 +1,13 @@
+{
+    "name": "local_env-partial",
+    "class": "mlos_bench.environments.LocalEnv",
+    "config": {
+        "run": [
+            "/bin/true"
+        ],
+        "shell_params": [
+            "/this/is/an/invalid/param/name/to/expose",
+            "so.is.this"
+        ]
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-bad_shell_params_mapping.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-bad_shell_params_mapping.jsonc
@@ -1,0 +1,12 @@
+{
+    "name": "local_env-partial",
+    "class": "mlos_bench.environments.LocalEnv",
+    "config": {
+        "run": [
+            "/bin/true"
+        ],
+        "shell_params_mapping": {
+            "invalid.target.name": "/source/param/name"
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-bad_shell_params_mapping_type.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-bad_shell_params_mapping_type.jsonc
@@ -1,0 +1,16 @@
+{
+    "name": "local_env-partial",
+    "class": "mlos_bench.environments.LocalEnv",
+    "config": {
+        "run": [
+            "/bin/true"
+        ],
+        "shell_params_mapping": {
+            "source_param_num_invalid": 0,
+            "source_param_bool_invalid": true,
+            "source_param_null_invalid": null,
+            "source_param_list_invalid": ["foo", "bar"],
+            "source_param_obj_invalid": { "invalid": "type" }
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-non-unique-shell-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/local_env-non-unique-shell-params.jsonc
@@ -1,0 +1,13 @@
+{
+    "name": "local_env-partial",
+    "class": "mlos_bench.environments.LocalEnv",
+    "config": {
+        "run": [
+            "/bin/true"
+        ],
+        "shell_params": [
+            "foo",
+            "foo"
+        ]
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_env-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_env-full.jsonc
@@ -25,7 +25,18 @@
         "teardown": [
             "/bin/bash -c true"
         ],
+
         "read_results_file": "/tmp/results.json",
-        "dump_params_file": "/tmp/dump_params.json"
+        "dump_params_file": "/tmp/dump_params.json",
+
+        "shell_params_match": [
+            "^MLOS_[a-zA-Z0-9_]+$"
+        ],
+        "shell_params": [
+            "foo"
+        ],
+        "shell_params_mapping": {
+            "gets_mapped_to_this_env_name": "/source/param/name/that/is/otherwise/invalid/env/name"
+        }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/remote_env-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/remote_env-full.jsonc
@@ -24,6 +24,16 @@
         ],
         "teardown": [
             "/bin/bash -c true"
-        ]
+        ],
+
+        "shell_params_match": [
+            "^MLOS_[a-zA-Z0-9_]+$"
+        ],
+        "shell_params": [
+            "foo"
+        ],
+        "shell_params_mapping": {
+            "gets_mapped_to_this_env_name": "/source/param/name/that/is/otherwise/invalid/env/name"
+        }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test_environment_schemas.py
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test_environment_schemas.py
@@ -15,6 +15,7 @@ from mlos_core.tests import get_all_concrete_subclasses
 from mlos_bench.config.schemas import ConfigSchema
 from mlos_bench.environments.base_environment import Environment
 from mlos_bench.environments.composite_env import CompositeEnv
+from mlos_bench.environments.script_env import ScriptEnv
 
 from mlos_bench.tests import try_resolve_class_name
 from mlos_bench.tests.config.schemas import (get_schema_test_cases,
@@ -32,9 +33,13 @@ TEST_CASES = get_schema_test_cases(path.join(path.dirname(__file__), "test-cases
 
 # Dynamically enumerate some of the cases we want to make sure we cover.
 
+NON_CONFIG_ENV_CLASSES = {
+    ScriptEnv   # ScriptEnv is ABCMeta abstract, but there's no good way to test that dynamically in Python.
+}
 expected_environment_class_names = [subclass.__module__ + "." + subclass.__name__
                                     for subclass
-                                    in get_all_concrete_subclasses(Environment, pkg_name='mlos_bench')]
+                                    in get_all_concrete_subclasses(Environment, pkg_name='mlos_bench')
+                                    if subclass not in NON_CONFIG_ENV_CLASSES]
 assert expected_environment_class_names
 
 COMPOSITE_ENV_CLASS_NAME = CompositeEnv.__module__ + "." + CompositeEnv.__name__

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/temp_dir_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/temp_dir_service-config-missing.jsonc
@@ -1,8 +1,0 @@
-{
-    "class": "mlos_bench.services.local.temp_dir_context.TempDirContextService"
-    /* Required section missing.
-    "config": {
-        "temp_dir": "/tmp"
-    }
-    */
-}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/temp_dir_service-config-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/temp_dir_service-config-extras.jsonc
@@ -1,8 +1,0 @@
-{
-    "class": "mlos_bench.services.local.temp_dir_context.TempDirContextService",
-    "config": {
-        "temp_dir": null,
-
-        "extras": "invalid"
-    }
-}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/temp_dir_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/temp_dir_service-full.jsonc
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/services/service-schema.json",
-    "description": "TempDir Context Service configuration.",
-
-    "class": "mlos_bench.services.local.temp_dir_context.TempDirContextService",
-    "config": {
-        "temp_dir": "/tmp"
-    }
-}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/temp_dir_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/temp_dir_service-partial.jsonc
@@ -1,6 +1,0 @@
-{
-    "class": "mlos_bench.services.local.temp_dir_context.TempDirContextService",
-    "config": {
-        "temp_dir": null
-    }
-}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test_services_schemas.py
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test_services_schemas.py
@@ -16,6 +16,7 @@ from mlos_core.tests import get_all_concrete_subclasses
 from mlos_bench.config.schemas import ConfigSchema
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.config_persistence import ConfigPersistenceService
+from mlos_bench.services.local.temp_dir_context import TempDirContextService
 
 from mlos_bench.tests import try_resolve_class_name
 from mlos_bench.tests.config.schemas import (get_schema_test_cases,
@@ -35,6 +36,7 @@ TEST_CASES = get_schema_test_cases(path.join(path.dirname(__file__), "test-cases
 
 NON_CONFIG_SERVICE_CLASSES = {
     ConfigPersistenceService,   # configured thru the launcher cli args
+    TempDirContextService,      # ABCMeta abstract class, but no good way to test that dynamically in Python.
 }
 
 expected_service_class_names = [subclass.__module__ + "." + subclass.__name__

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -111,7 +111,7 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
     mock_response.status_code = http_status_code
     mock_requests.post.return_value = mock_response
 
-    status, _ = azure_vm_service.remote_exec(script, {}, {})
+    status, _ = azure_vm_service.remote_exec(script, config={}, env_params={})
 
     assert status == operation_status
 
@@ -130,7 +130,7 @@ def test_remote_exec_headers_output(mock_requests: MagicMock, azure_vm_service: 
     }
     mock_requests.post.return_value = mock_response
 
-    _, cmd_output = azure_vm_service.remote_exec(script, {}, {
+    _, cmd_output = azure_vm_service.remote_exec(script, config={}, env_params={
         "param_1": 123,
         "param_2": "abc",
     })

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -111,7 +111,7 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
     mock_response.status_code = http_status_code
     mock_requests.post.return_value = mock_response
 
-    status, _ = azure_vm_service.remote_exec(script, {})
+    status, _ = azure_vm_service.remote_exec(script, {}, {})
 
     assert status == operation_status
 
@@ -130,7 +130,7 @@ def test_remote_exec_headers_output(mock_requests: MagicMock, azure_vm_service: 
     }
     mock_requests.post.return_value = mock_response
 
-    _, cmd_output = azure_vm_service.remote_exec(script, {
+    _, cmd_output = azure_vm_service.remote_exec(script, {}, {
         "param_1": 123,
         "param_2": "abc",
     })
@@ -175,5 +175,4 @@ def test_get_remote_exec_results(azure_vm_service: AzureVMService, operation_sta
     status, cmd_output = azure_vm_service.get_remote_exec_results(params)
 
     assert status == operation_status
-    assert mock_wait_vm_operation.call_args[0][0] == params
     assert cmd_output == results_output


### PR DESCRIPTION
Presently we pass *all* Environment parameters (i.e., a combination of `const_args` and `tunable_params`) as shell env variables when we run a local or remote script. this approach has several problems:
* too many parameters leak into the shell environment;
* all names must be valid shell env variable identifiers (e.g., we crash on parameters like `ima.ahash_bufsize`)
* all values must be strings

In this PR:
* keep the old behavior by default;
* explicitly convert all values to strings and all keys to valid identifiers
* implement `ScriptEnv` base class for `RemoteEnv` and `LocalEnv` that contains `setup/run/teardown` script properties and the renaming logic for the shell script parameters
* add `shell_params` parameter so that the user can specify which parameters to pass to shell scripts
* add `shell_params_rename` parameter to explicitly rename the parameters, if necessary.

TODO:
* [x] add `shell_params` and `shell_params_rename` to JSON templates
* [x] fix the unit tests for JSON templates that involve `ScriptEnv` and derived classes