### PR TITLE
Support arrays for ARM templates

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json
@@ -13,13 +13,23 @@
     },
     "patternProperties": {
         "^[^$]+$": {
-            "$comment": "Global configs are either strings, numbers, booleans or nulls.",
+            "$comment": "Global configs are either strings, numbers, booleans, or nulls, or an array of the same.",
             "type": [
                 "string",
                 "number",
                 "boolean",
-                "null"
-            ]
+                "null",
+                "array"
+            ],
+            "items": {
+                "$comment": "The value of any const_arg list can be a string, number, boolean, or null.",
+                "type": [
+                    "string",
+                    "number",
+                    "boolean",
+                    "null"
+                ]
+            }
         }
     },
     "not": {

--- a/mlos_bench/mlos_bench/config/schemas/environments/common-environment-subschemas.json
+++ b/mlos_bench/mlos_bench/config/schemas/environments/common-environment-subschemas.json
@@ -28,13 +28,23 @@
                     "description": "Default argument value constants to use for the Environment when not overridden by globals.",
                     "type": "object",
                     "additionalProperties": {
-                        "$comment": "The value of any const_arg can be a string, number, boolean, or null.",
+                        "$comment": "The value of any const_arg can be a string, number, boolean, or null, or an array of the same.",
                         "type": [
                             "string",
                             "number",
                             "boolean",
-                            "null"
-                        ]
+                            "null",
+                            "array"
+                        ],
+                        "items": {
+                            "$comment": "The value of any const_arg list can be a string, number, boolean, or null.",
+                            "type": [
+                                "string",
+                                "number",
+                                "boolean",
+                                "null"
+                            ]
+                        }
                     }
                 }
             },

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -45,13 +45,23 @@
                             "description": "Key/value pairs of ARM template parameters.",
                             "type": "object",
                             "additionalProperties": {
-                                "$comment": "The value of any parameter can be a string, number, boolean, or null.",
+                                "$comment": "The value of any parameter can be a string, number, boolean, or null or an array of the same.",
                                 "type": [
                                     "string",
                                     "number",
                                     "boolean",
-                                    "null"
-                                ]
+                                    "null",
+                                    "array"
+                                ],
+                                "items": {
+                                    "$comment": "The value of any const_arg list can be a string, number, boolean, or null.",
+                                    "type": [
+                                        "string",
+                                        "number",
+                                        "boolean",
+                                        "null"
+                                    ]
+                                }
                             },
                             "minProperties": 1
                         }

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/mock_env-const-args-list-obj.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/mock_env-const-args-list-obj.jsonc
@@ -1,0 +1,15 @@
+{
+    "name": "partial mock env",
+    "class": "mlos_bench.environments.MockEnv",
+    "config": {
+        "seed": 42,
+        "const_args": {
+            "foo": "bar",
+            "int": 1,
+            "float": 1.1,
+            "bool": true,
+            "null": null,
+            "array": [{"obj": "invalid"}]
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/mock_env-const-args-nested-list.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/bad/invalid/mock_env-const-args-nested-list.jsonc
@@ -1,0 +1,15 @@
+{
+    "name": "partial mock env",
+    "class": "mlos_bench.environments.MockEnv",
+    "config": {
+        "seed": 42,
+        "const_args": {
+            "foo": "bar",
+            "int": 1,
+            "float": 1.1,
+            "bool": true,
+            "null": null,
+            "array": [["nested", "list", "invalid"]]
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/partial/mock_env-const-args.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/partial/mock_env-const-args.jsonc
@@ -1,0 +1,15 @@
+{
+    "name": "partial mock env",
+    "class": "mlos_bench.environments.MockEnv",
+    "config": {
+        "seed": 42,
+        "const_args": {
+            "foo": "bar",
+            "int": 1,
+            "float": 1.1,
+            "bool": true,
+            "null": null,
+            "array": [123, "abc", true, null]
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-array-with-list.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-array-with-list.jsonc
@@ -3,5 +3,5 @@
     "bar": "baz",
     "num": 1,
     "bool": true,
-    "array": ["foo", "bar", "baz"]
+    "array": [["nested", "list"], "should", "be", "disallowed"]
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-array-with-obj.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-array-with-obj.jsonc
@@ -1,0 +1,7 @@
+{
+    "foo": "bar",
+    "bar": "baz",
+    "num": 1,
+    "bool": true,
+    "array": [{"obj": "invalid"}]
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/good/full/globals-with-schema.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/good/full/globals-with-schema.jsonc
@@ -2,5 +2,7 @@
     "foo": "bar",
     "int": 1,
     "float": 1.1,
-    "bool": true
+    "bool": true,
+    "null": null,
+    "array": [123, "abc", true, null]
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array-object.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array-object.jsonc
@@ -8,7 +8,7 @@
         "resourceGroup": "rg",
         "deploymentName": "deployment",
         "deploymentTemplateParameters": {
-            "array": [ ["nested", "array", "invalid"] ]
+            "array": [ { "invalid": "type"} ]
         }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -19,7 +19,14 @@
             "virtualNetworkName": "vnet",
             "subnetName": "subnet",
             "networkSecurityGroupName": "nsg",
-            "ubuntuOSVersion": "18.04-LTS"
+            "ubuntuOSVersion": "18.04-LTS",
+
+            "string": "bar",
+            "int": 1,
+            "float": 1.1,
+            "bool": true,
+            "null": null,
+            "array": [123, "abc", true, null]
         },
 
         "pollInterval": 1,


### PR DESCRIPTION
This allows supporting arrays in const_args, armDeploymentTemplateParams, and globals.

One use case for this are vmPort listings in ARM templates, for instance.