### PR TITLE
Impute missing values when restoring configs from earlier experiments/trials

### DIFF
--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -56,9 +56,7 @@ class MlosCoreOptimizer(Optimizer):
                       status: Optional[Sequence[Status]] = None) -> bool:
         if not super().bulk_register(configs, scores, status):
             return False
-        # By default, hyperparameters in ConfigurationSpace are sorted by name:
-        tunables_names = sorted(self._tunables.get_param_values().keys())
-        df_configs = pd.DataFrame(configs)[tunables_names]
+        df_configs = self._to_df(configs)  # Impute missing values, if necessary
         df_scores = pd.Series(scores, dtype=float) * self._opt_sign
         if status is not None:
             # TODO: mlos_core currently does not support registration of failed trials:
@@ -73,6 +71,34 @@ class MlosCoreOptimizer(Optimizer):
             (score, _) = self.get_best_observation()
             _LOG.debug("Warm-up end: %s = %s", self.target, score)
         return True
+
+    def _to_df(self, configs: Sequence[dict]) -> pd.DataFrame:
+        """
+        Select from past trials only the columns required in this experiment and
+        impute default values for the tunables that are missing in the dataframe.
+
+        Parameters
+        ----------
+        configs : Sequence[dict]
+            Sequence of dicts with past trials data.
+
+        Returns
+        -------
+        df_configs : pd.DataFrame
+            A dataframe with past trials data, with missing values imputed.
+        """
+        df_configs = pd.DataFrame(configs)
+        tunables_names = self._tunables.get_param_values().keys()
+        missing_cols = set(tunables_names).difference(df_configs.columns)
+        for (tunable, _group) in self._tunables:
+            if tunable.name in missing_cols:
+                df_configs[tunable.name] = tunable.default
+            else:
+                df_configs[tunable.name].fillna(tunable.default, inplace=True)
+        # By default, hyperparameters in ConfigurationSpace are sorted by name:
+        df_configs = df_configs[sorted(tunables_names)]
+        _LOG.debug("Loaded configs:\n%s", df_configs)
+        return df_configs
 
     def suggest(self) -> TunableGroups:
         use_defaults = self._use_defaults and self._iter == 1

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -68,6 +68,9 @@ class SmacOptimizer(BaseBayesianOptimizer):
             space_adapter=space_adapter,
         )
 
+        # Declare at the top because we need it in __del__/cleanup()
+        self._temp_output_directory: Optional[TemporaryDirectory] = None
+
         # pylint: disable=import-outside-toplevel
         from smac import HyperparameterOptimizationFacade as Optimizer_Smac
         from smac import Scenario
@@ -86,14 +89,13 @@ class SmacOptimizer(BaseBayesianOptimizer):
         seed = -1 if seed is None else seed
 
         # Create temporary directory for SMAC output (if none provided)
-        self.temp_output_directory: Optional[TemporaryDirectory] = None
         if output_directory is None:
             # pylint: disable=consider-using-with
             try:
-                self.temp_output_directory = TemporaryDirectory(ignore_cleanup_errors=True)  # Argument added in Python 3.10
+                self._temp_output_directory = TemporaryDirectory(ignore_cleanup_errors=True)  # Argument added in Python 3.10
             except TypeError:
-                self.temp_output_directory = TemporaryDirectory()
-            output_directory = self.temp_output_directory.name
+                self._temp_output_directory = TemporaryDirectory()
+            output_directory = self._temp_output_directory.name
 
         scenario: Scenario = Scenario(
             self.optimizer_parameter_space,
@@ -234,9 +236,9 @@ class SmacOptimizer(BaseBayesianOptimizer):
         return self.base_optimizer._config_selector._acquisition_function(configs).reshape(-1,)
 
     def cleanup(self) -> None:
-        if self.temp_output_directory is not None:
-            self.temp_output_directory.cleanup()
-            self.temp_output_directory = None
+        if self._temp_output_directory is not None:
+            self._temp_output_directory.cleanup()
+            self._temp_output_directory = None
 
     def _to_configspace_configs(self, configurations: pd.DataFrame) -> list:
         """Convert a dataframe of configurations to a list of ConfigSpace configurations.


### PR DESCRIPTION
This is the first step towards mergeable experiments. Replace missing values with the defaults when restoring trail data from storage.