### PR TITLE
Do not inherit any tunables if `tunable_params` not specified.

### DIFF
--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -118,10 +118,9 @@ class Environment(metaclass=abc.ABCMeta):
             _LOG.warning("No tunables provided for %s. Tunable inheritance across composite environments may be broken.", name)
             tunables = TunableGroups()
 
-        tunable_groups = config.get("tunable_params")
-        self._tunable_params = tunables.subgroup(tunable_groups) if tunable_groups else tunables
-
+        self._tunable_params = tunables.subgroup(config.get("tunable_params", []))
         self._params = self._combine_tunables(self._tunable_params)
+        _LOG.debug("Parameters for %s :: %s", name, self._params)
 
         if _LOG.isEnabledFor(logging.DEBUG):
             _LOG.debug("Config for: %s\n%s",

--- a/mlos_bench/mlos_bench/tests/conftest.py
+++ b/mlos_bench/mlos_bench/tests/conftest.py
@@ -111,7 +111,7 @@ def mock_env(tunable_groups: TunableGroups) -> MockEnv:
     return MockEnv(
         name="Test Env",
         config={
-            "tunable_groups": ["provision", "boot", "kernel"],
+            "tunable_params": ["provision", "boot", "kernel"],
             "seed": 13,
             "range": [60, 120],
             "metrics": ["score"],
@@ -128,7 +128,7 @@ def mock_env_no_noise(tunable_groups: TunableGroups) -> MockEnv:
     return MockEnv(
         name="Test Env No Noise",
         config={
-            "tunable_groups": ["provision", "boot", "kernel"],
+            "tunable_params": ["provision", "boot", "kernel"],
             "range": [60, 120],
             "metrics": ["score", "other_score"],
         },

--- a/mlos_bench/mlos_bench/tests/environments/composite_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/composite_env_test.py
@@ -23,6 +23,7 @@ def composite_env(tunable_groups: TunableGroups) -> CompositeEnv:
     return CompositeEnv(
         name="Composite Test Environment",
         config={
+            "tunable_params": ["provision", "boot"],
             "const_args": {
                 "vmName": "Mock VM",
             },


### PR DESCRIPTION
 (Old default was to use ALL tunables). @bpkroth you were right about this one