### PR TITLE
Bulk load the data of failed and timed out trials into the optimizer

### DIFF
--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -84,8 +84,8 @@ def _optimize(env: Environment,
         # Load (tunable values, benchmark scores) to warm-up the optimizer.
         # `.load()` returns data from ALL merged-in experiments and attempts
         # to impute the missing tunable values.
-        (configs, scores) = exp.load()
-        opt.bulk_register(configs, scores)
+        (configs, scores, status) = exp.load()
+        opt.bulk_register(configs, scores, status)
 
         # First, complete any pending trials.
         for trial in exp.pending_trials():

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -154,9 +154,9 @@ class Storage(metaclass=ABCMeta):
             """
 
         @abstractmethod
-        def load(self, opt_target: Optional[str] = None) -> Tuple[List[dict], List[float]]:
+        def load(self, opt_target: Optional[str] = None) -> Tuple[List[dict], List[float], List[Status]]:
             """
-            Load (tunable values, benchmark scores) to warm-up the optimizer.
+            Load (tunable values, benchmark scores, status) to warm-up the optimizer.
             This call returns data from ALL merged-in experiments and attempts
             to impute the missing tunable values.
             """

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -117,7 +117,7 @@ class Experiment(Storage.Experiment):
                     conn, self._schema.config_param, config_id=trial.config_id)
                 configs.append(tunables)
                 scores.append(float(trial.metric_value))
-                status.append(Status(trial.status))
+                status.append(Status[trial.status])
             return (configs, scores, status)
 
     @staticmethod

--- a/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
@@ -18,9 +18,10 @@ def test_exp_load_empty(exp_storage_memory_sql: Storage.Experiment) -> None:
     """
     Try to retrieve old experimental data from the empty storage.
     """
-    (configs, scores) = exp_storage_memory_sql.load()
+    (configs, scores, status) = exp_storage_memory_sql.load()
     assert not configs
     assert not scores
+    assert not status
 
 
 def test_exp_pending_empty(exp_storage_memory_sql: Storage.Experiment) -> None:
@@ -110,8 +111,8 @@ def test_exp_trial_pending_3(exp_storage_memory_sql: Storage.Experiment,
     (pending,) = list(exp_storage_memory_sql.pending_trials())
     assert pending.trial_id == trial_pend.trial_id
 
-    (configs, scores) = exp_storage_memory_sql.load()
-    assert len(configs) == 1
-    assert len(scores) == 1
-    assert scores[0] == score
-    assert tunable_groups.copy().assign(configs[0]).reset() == trial_succ.tunables
+    (configs, scores, status) = exp_storage_memory_sql.load()
+    assert len(configs) == 2
+    assert scores == [None, score]
+    assert status == [Status.FAILED, Status.SUCCEEDED]
+    assert tunable_groups.copy().assign(configs[1]).reset() == trial_succ.tunables

--- a/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
@@ -115,4 +115,5 @@ def test_exp_trial_pending_3(exp_storage_memory_sql: Storage.Experiment,
     assert len(configs) == 2
     assert scores == [None, score]
     assert status == [Status.FAILED, Status.SUCCEEDED]
+    assert tunable_groups.copy().assign(configs[0]).reset() == trial_fail.tunables
     assert tunable_groups.copy().assign(configs[1]).reset() == trial_succ.tunables


### PR DESCRIPTION
Before that, we loaded only the data from successful runs.
We probably need to merge #412 and #407 before this one