### PR TITLE
Lower the devcontainer rebuild timeout again

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -103,7 +103,7 @@ jobs:
         docker exec --user vscode mlos-devcontainer make CONDA_INFO_LEVEL=-v dist dist-test
 
     - name: Test rebuilding the devcontainer in the devcontainer
-      timeout-minutes: 5
+      timeout-minutes: 3
       run: |
         set -x
         docker exec --user vscode mlos-devcontainer make CONDA_INFO_LEVEL=-v devcontainer


### PR DESCRIPTION
Closes #396

Whatever was going on previously seems to be fixed now and the rebuilds I've looked at all finished in tens of seconds like they're supposed to.  This fixup isn't strictly required, but is a good test on our internal scripts.