### PR TITLE
Pytest warnings fixups

### DIFF
--- a/mlos_core/mlos_core/__init__.py
+++ b/mlos_core/mlos_core/__init__.py
@@ -23,4 +23,4 @@ def config_to_dataframe(config: ConfigSpace.Configuration) -> pd.DataFrame:
     pd.DataFrame
         A DataFrame with a single row, containing the config's parameters.
     """
-    return pd.DataFrame([config.get_dictionary()])
+    return pd.DataFrame([dict(config)])

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -8,7 +8,7 @@ See Also: <https://automl.github.io/SMAC3/main/index.html>
 """
 
 from pathlib import Path
-from typing import Mapping, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 from tempfile import TemporaryDirectory
 
 import ConfigSpace
@@ -81,7 +81,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
         from smac.runhistory import TrialInfo
 
         # Store for TrialInfo instances returned by .ask()
-        self.trial_info_map: Mapping[ConfigSpace.Configuration, TrialInfo] = {}
+        self.trial_info_map: Dict[ConfigSpace.Configuration, TrialInfo] = {}
 
         # The default when not specified is to use a known seed (0) to keep results reproducible.
         # However, if a `None` seed is explicitly provided, we let a random seed be produced by SMAC.
@@ -190,16 +190,15 @@ class SmacOptimizer(BaseBayesianOptimizer):
         configuration : pd.DataFrame
             Pandas dataframe with a single row. Column names are the parameter names.
         """
-        from smac.runhistory import TrialInfo  # pylint: disable=import-outside-toplevel
+        if TYPE_CHECKING:
+            from smac.runhistory import TrialInfo  # pylint: disable=import-outside-toplevel
 
         if context is not None:
             raise NotImplementedError()
 
         trial: TrialInfo = self.base_optimizer.ask()
-        # Type ignore because this is WIP from ConfigSpace side
-        # Check here: https://github.com/automl/ConfigSpace/issues/293
-        self.trial_info_map[trial.config] = trial  # type: ignore
-        return pd.DataFrame([trial.config], columns=self.optimizer_parameter_space.get_hyperparameter_names())
+        self.trial_info_map[trial.config] = trial
+        return pd.DataFrame([trial.config], columns=list(self.optimizer_parameter_space.keys()))
 
     def register_pending(self, configurations: pd.DataFrame, context: Optional[pd.DataFrame] = None) -> None:
         raise NotImplementedError()
@@ -240,7 +239,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
             self._temp_output_directory.cleanup()
             self._temp_output_directory = None
 
-    def _to_configspace_configs(self, configurations: pd.DataFrame) -> list:
+    def _to_configspace_configs(self, configurations: pd.DataFrame) -> List[ConfigSpace.Configuration]:
         """Convert a dataframe of configurations to a list of ConfigSpace configurations.
 
         Parameters

--- a/mlos_core/mlos_core/optimizers/optimizer.py
+++ b/mlos_core/mlos_core/optimizers/optimizer.py
@@ -201,7 +201,7 @@ class BaseOptimizer(metaclass=ABCMeta):
         df_dict = collections.defaultdict(list)
         for i in range(config.shape[0]):
             j = 0
-            for param in self.optimizer_parameter_space.get_hyperparameters():
+            for param in self.optimizer_parameter_space.values():
                 if isinstance(param, ConfigSpace.CategoricalHyperparameter):
                     for (offset, val) in enumerate(param.choices):
                         if config[i][j + offset] == 1:
@@ -222,7 +222,7 @@ class BaseOptimizer(metaclass=ABCMeta):
         """
         n_cols = 0
         n_rows = config.shape[0] if config.ndim > 1 else 1
-        for param in self.optimizer_parameter_space.get_hyperparameters():
+        for param in self.optimizer_parameter_space.values():
             if isinstance(param, ConfigSpace.CategoricalHyperparameter):
                 n_cols += len(param.choices)
             else:
@@ -230,7 +230,7 @@ class BaseOptimizer(metaclass=ABCMeta):
         one_hot = np.zeros((n_rows, n_cols), dtype=np.float32)
         for i in range(n_rows):
             j = 0
-            for param in self.optimizer_parameter_space.get_hyperparameters():
+            for param in self.optimizer_parameter_space.values():
                 if config.ndim > 1:
                     col = config.columns.get_loc(param.name)
                     val = config.iloc[i, col]

--- a/mlos_core/mlos_core/tests/spaces/adapters/llamatune_test.py
+++ b/mlos_core/mlos_core/tests/spaces/adapters/llamatune_test.py
@@ -68,7 +68,7 @@ def test_num_low_dims(num_target_space_dims: int, param_space_kwargs: dict) -> N
     with pytest.raises(ValueError):
         LlamaTuneAdapter(
             orig_parameter_space=input_space,
-            num_low_dims=len(input_space.get_hyperparameter_names())
+            num_low_dims=len(list(input_space.keys()))
         )
 
     # Enable only low-dimensional space projections
@@ -320,7 +320,7 @@ def test_max_unique_values_per_param() -> None:
         )
 
         # Keep track of unique values generated for each parameter
-        unique_values_dict: Dict[str, set] = {param: set() for param in input_space.get_hyperparameter_names()}
+        unique_values_dict: Dict[str, set] = {param: set() for param in list(input_space.keys())}
         for config in gen_random_configs(adapter, num_configs):
             for param, value in config.items():
                 unique_values_dict[param].add(value)
@@ -422,7 +422,7 @@ def test_llamatune_pipeline(num_low_dims: int, special_param_values: dict, max_u
         param: {special_value: 0 for special_value, _ in tuples_list}
         for param, tuples_list in adapter._special_param_values_dict.items()    # pylint: disable=protected-access
     }
-    unique_values_dict: Dict[str, Set] = {param: set() for param in input_space.get_hyperparameter_names()}
+    unique_values_dict: Dict[str, Set] = {param: set() for param in input_space.keys()}
 
     num_configs = 1000
     for config in adapter.target_parameter_space.sample_configuration(size=num_configs):    # pylint: disable=not-an-iterable

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,19 @@ max-line-length = 132
 [tool:pytest]
 minversion = 7.1
 #pythonpath = .
+# Run all tests to completion on multiple processes.
+# Run failed and new tests first by default.
 addopts =
-    -svxl
+    -svl --ff --nf
     -n auto
-# Moved these to Makefile
+# Moved these to Makefile (coverage is expensive and we only need it in the pipelines generally).
 #--cov=mlos_core --cov-report=xml
 testpaths = mlos_core mlos_bench
+# Ignore some upstream deprecation warnings.
+filterwarnings =
+    ignore:.*(get_hyperparam|get_dictionary).*:DeprecationWarning:smac:0
+    ignore:.*(Trying to register a configuration that was not previously suggested).*:UserWarning:.*llamatune.*:0
+    ignore:.*(DISPLAY environment variable is set).*:UserWarning:.*conftest.*:0
 
 #
 # mypy static type checker configs


### PR DESCRIPTION
Some improvements for tight dev cycle and making debugging easier by cleaning up some noise:
- Fix some pytest DeprecationWarnings
- Ignore some others that aren't in our code.
- When rerunning pytest, run the last failed or new tests first.