### PR TITLE
json schema resolution referencing lib updates

### DIFF
--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -76,7 +76,7 @@ setup(
         'mlos-core==' + _VERSION,
         'requests',
         'json5',
-        'jsonschema',
+        'jsonschema>=4.18.0', 'referencing>=0.29.1',
         'importlib_resources;python_version<"3.10"',
     ] + extra_requires['storage-sql-sqlite'],   # NOTE: For now sqlite is a fallback storage backend, so we always install it.
     extras_require=extra_requires,


### PR DESCRIPTION
Updates our json schema resolution code to use the referencing lib per upstream updates.
Closes #437 
See Also: https://python-jsonschema.readthedocs.io/en/stable/referencing/#migrating-from-refresolver