### PR TITLE
Bugfix: update the env tunable values in setup, do not mutate the parent when loading the tunables

### DIFF
--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -224,7 +224,10 @@ class Environment(metaclass=abc.ABCMeta):
         """
         _LOG.info("Setup %s :: %s", self, tunables)
         assert isinstance(tunables, TunableGroups)
-
+        # Assign new values to the environment's tunable parameters:
+        groups = list(self._tunable_params.get_covariant_group_names())
+        self._tunable_params.assign(tunables.get_param_values(groups))
+        # Combine tunables, const_args, and global config into `self._params`:
         self._params = self._combine_tunables(tunables)
         merge_parameters(dest=self._params, source=global_config)
 

--- a/mlos_bench/mlos_bench/environments/composite_env.py
+++ b/mlos_bench/mlos_bench/environments/composite_env.py
@@ -48,8 +48,10 @@ class CompositeEnv(Environment):
             An optional service object (e.g., providing methods to
             deploy or reboot a VM, etc.).
         """
-        super().__init__(name=name, config=config, global_config=global_config, tunables=tunables, service=service)
+        super().__init__(name=name, config=config, global_config=global_config,
+                         tunables=tunables, service=service)
 
+        _LOG.debug("Build composite environment '%s' START: %s", self, self.tunable_params)
         self._children: List[Environment] = []
 
         # To support trees of composite environments (e.g. for multiple VM experiments),
@@ -61,12 +63,16 @@ class CompositeEnv(Environment):
 
         for child_config_file in config.get("include_children", []):
             for env in self._config_loader_service.load_environment_list(
-                    child_config_file, self._tunable_params, global_config, self._const_args, self._service):
+                    child_config_file, self._tunable_params, global_config,
+                    self._const_args, self._service):
                 self._add_child(env)
 
         for child_config in config.get("children", []):
             self._add_child(self._config_loader_service.build_environment(
-                child_config, self._tunable_params, global_config, self._const_args, self._service))
+                child_config, self._tunable_params, global_config,
+                self._const_args, self._service))
+
+        _LOG.debug("Build composite environment '%s' END: %s", self, self.tunable_params)
 
         if not self._children:
             raise ValueError("At least one child environment must be present")
@@ -102,6 +108,7 @@ class CompositeEnv(Environment):
         Add a new child environment to the composite environment.
         This method is called from the constructor only.
         """
+        _LOG.debug("Merge tunables: '%s' <- '%s' :: %s", self, env, env.tunable_params)
         self._children.append(env)
         self._tunable_params.merge(env.tunable_params)
 

--- a/mlos_bench/mlos_bench/launcher.py
+++ b/mlos_bench/mlos_bench/launcher.py
@@ -94,15 +94,20 @@ class Launcher:
 
         self.environment: Environment = self._config_loader.load_environment(
             self.root_env_config, TunableGroups(), self.global_config, service=self._parent_service)
+        _LOG.info("Init environment: %s", self.environment)
 
         # NOTE: Init tunable values *after* the Environment, but *before* the Optimizer
         self.tunables = self._init_tunable_values(
             args.random_init or config.get("random_init", False),
             config.get("random_seed") if args.random_seed is None else args.random_seed,
             args.tunable_values or config.get("tunable_values", []))
+        _LOG.info("Init tunables: %s", self.tunables)
 
         self.optimizer = self._load_optimizer(args.optimizer or config.get("optimizer"))
+        _LOG.info("Init optimizer: %s", self.optimizer)
+
         self.storage = self._load_storage(args.storage or config.get("storage"))
+        _LOG.info("Init storage: %s", self.storage)
 
         self.teardown = args.teardown or config.get("teardown", True)
 
@@ -228,17 +233,21 @@ class Launcher:
         from given JSON files, if specified.
         """
         tunables = self.environment.tunable_params
+        _LOG.debug("Init tunables: default = %s", tunables)
 
         if random_init:
             tunables = MockOptimizer(
                 tunables=tunables, service=None,
                 config={"start_with_defaults": False, "seed": seed}).suggest()
+            _LOG.debug("Init tunables: random = %s", tunables)
 
         if args_tunables is not None:
             for data_file in args_tunables:
                 values = self._config_loader.load_config(data_file, ConfigSchema.TUNABLE_VALUES)
                 assert isinstance(values, Dict)
                 tunables.assign(values)
+                _LOG.debug("Init tunables: load %s = %s", data_file, tunables)
+
         return tunables
 
     def _load_optimizer(self, args_optimizer: Optional[str]) -> Optimizer:

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -238,7 +238,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
             tunables = self._load_tunables(tunables_path, tunables)
         (class_name, class_config) = self.prepare_class_load(config, global_config)
         inst = instantiate_from_config(base_cls, class_name, tunables, service, class_config)
-        _LOG.info("Created: %s", inst)
+        _LOG.info("Created: %s %s", base_cls.__name__, inst)
         return inst
 
     def build_environment(self,     # pylint: disable=too-many-arguments
@@ -516,8 +516,9 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
             The larger collection of tunable parameters.
         """
         _LOG.info("Load tunables: '%s'", json_file_names)
+        tunables = parent.copy()
         for fname in json_file_names:
             config = self.load_config(fname, ConfigSchema.TUNABLE_PARAMS)
             assert isinstance(config, dict)
-            parent.merge(TunableGroups(config))
-        return parent
+            tunables.merge(TunableGroups(config))
+        return tunables

--- a/mlos_bench/mlos_bench/tests/environments/include_tunables_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/include_tunables_test.py
@@ -1,0 +1,124 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Test the selection of tunables / tunable groups for the environment.
+"""
+
+from mlos_bench.environments.mock_env import MockEnv
+from mlos_bench.tunables.tunable_groups import TunableGroups
+
+
+def test_one_group(tunable_groups: TunableGroups) -> None:
+    """
+    Make sure only one tunable group is available to the environment.
+    """
+    env = MockEnv(
+        name="Test Env",
+        config={"tunable_params": ["provision"]},
+        tunables=tunable_groups
+    )
+    assert env.tunable_params.get_param_values() == {
+        "vmSize": "Standard_B4ms",
+    }
+
+
+def test_two_groups(tunable_groups: TunableGroups) -> None:
+    """
+    Make sure only the selected tunable groups are available to the environment.
+    """
+    env = MockEnv(
+        name="Test Env",
+        config={"tunable_params": ["provision", "kernel"]},
+        tunables=tunable_groups
+    )
+    assert env.tunable_params.get_param_values() == {
+        "vmSize": "Standard_B4ms",
+        "kernel_sched_migration_cost_ns": -1,
+        "kernel_sched_latency_ns": 2000000,
+    }
+
+
+def test_two_groups_setup(tunable_groups: TunableGroups) -> None:
+    """
+    Make sure only the selected tunable groups are available to the environment,
+    the set is not changed after calling the `.setup()` method.
+    """
+    env = MockEnv(
+        name="Test Env",
+        config={
+            "tunable_params": ["provision", "kernel"],
+            "const_args": {
+                "const_param1": 10,
+                "const_param2": "foo",
+            },
+        },
+        tunables=tunable_groups
+    )
+    expected_params = {
+        "vmSize": "Standard_B4ms",
+        "kernel_sched_migration_cost_ns": -1,
+        "kernel_sched_latency_ns": 2000000,
+    }
+    assert env.tunable_params.get_param_values() == expected_params
+
+    assert env.setup(tunable_groups)
+    # Make sure the set of tunables does not change after the setup:
+    assert env.tunable_params.get_param_values() == expected_params
+    assert env.parameters == {
+        **expected_params,
+        "const_param1": 10,
+        "const_param2": "foo",
+    }
+
+
+def test_zero_groups_implicit(tunable_groups: TunableGroups) -> None:
+    """
+    Make sure that no tunable groups are available to the environment by default.
+    """
+    env = MockEnv(
+        name="Test Env",
+        config={},
+        tunables=tunable_groups
+    )
+    assert env.tunable_params.get_param_values() == {}
+
+
+def test_zero_groups_explicit(tunable_groups: TunableGroups) -> None:
+    """
+    Make sure that no tunable groups are available to the environment
+    when explicitly specifying an empty list of tunable_params.
+    """
+    env = MockEnv(
+        name="Test Env",
+        config={"tunable_params": []},
+        tunables=tunable_groups
+    )
+    assert env.tunable_params.get_param_values() == {}
+
+
+def test_zero_groups_implicit_setup(tunable_groups: TunableGroups) -> None:
+    """
+    Make sure that no tunable groups are available to the environment by default
+    and it does not change after the setup.
+    """
+    env = MockEnv(
+        name="Test Env",
+        config={
+            "const_args": {
+                "const_param1": 10,
+                "const_param2": "foo",
+            },
+        },
+        tunables=tunable_groups
+    )
+    assert env.tunable_params.get_param_values() == {}
+
+    assert env.setup(tunable_groups)
+    # Make sure the set of tunables does not change after the setup:
+    assert env.tunable_params.get_param_values() == {}
+    assert env.parameters == {
+        "const_param1": 10,
+        "const_param2": "foo",
+    }

--- a/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
@@ -48,12 +48,12 @@ def test_mock_optimization_loop(mock_env_no_noise: MockEnv,
     Toy optimization loop with mock environment and optimizer.
     """
     (score, tunables) = _optimize(mock_env_no_noise, mock_opt)
-    assert score == pytest.approx(75.0, 0.01)
+    assert score == pytest.approx(64.9, 0.01)
     assert tunables.get_param_values() == {
-        "vmSize": "Standard_B4ms",
+        "vmSize": "Standard_B2ms",
         "idle": "halt",
-        "kernel_sched_migration_cost_ns": -1,
-        "kernel_sched_latency_ns": 2000000,
+        "kernel_sched_migration_cost_ns": 117025,
+        "kernel_sched_latency_ns": 149827706,
     }
 
 
@@ -63,12 +63,12 @@ def test_mock_optimization_loop_no_defaults(mock_env_no_noise: MockEnv,
     Toy optimization loop with mock environment and optimizer.
     """
     (score, tunables) = _optimize(mock_env_no_noise, mock_opt_no_defaults)
-    assert score == pytest.approx(75.0, 0.01)
+    assert score == pytest.approx(60.97, 0.01)
     assert tunables.get_param_values() == {
-        "vmSize": "Standard_B4ms",
+        "vmSize": "Standard_B2s",
         "idle": "halt",
-        "kernel_sched_migration_cost_ns": 13111,
-        "kernel_sched_latency_ns": 796233790,
+        "kernel_sched_migration_cost_ns": 49122,
+        "kernel_sched_latency_ns": 234760738,
     }
 
 


### PR DESCRIPTION
Summary of changes:
* Do not mutate the parent collection of tunables when loading them from a file.
* Fix the confusing behavior of the environment: we did not assign the new values to the environment's tunables after `.setup()`. That is ok most of the time as we never use the tunables alone when setting up the environment (we merge them into `self._params` along with `const_args` and globals), but it is still a bit confusing to not update the tunables on setup.
* Add unit tests to check the new behavior.
* Add logging statements to debug the issue