### PR TITLE
Dump the tunables' metdata to JSON file so that the `LocalEnv` scripts can use it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -117,5 +117,9 @@
         "editor.defaultFormatter": "ms-python.autopep8",
         "editor.formatOnSave": true,
         "editor.formatOnSaveMode": "modifications"
-    }
+    },
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false
 }

--- a/mlos_bench/mlos_bench/config/schemas/environments/local/local-env-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/environments/local/local-env-subschema.json
@@ -16,6 +16,10 @@
                     "description": "Path to a file to dump the parameters to.",
                     "type": "string"
                 },
+                "dump_meta_file": {
+                    "description": "Path to a file to dump the tunables' metadata to.",
+                    "type": "string"
+                },
                 "read_results_file": {
                     "description": "Path to a file to read the results from.",
                     "type": "string",

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -67,6 +67,7 @@ class LocalEnv(ScriptEnv):
         self._temp_dir = self.config.get("temp_dir")
 
         self._dump_params_file: Optional[str] = self.config.get("dump_params_file")
+        self._dump_meta_file: Optional[str] = self.config.get("dump_meta_file")
         self._read_results_file: Optional[str] = self.config.get("read_results_file")
 
     def setup(self, tunables: TunableGroups, global_config: Optional[dict] = None) -> bool:
@@ -102,8 +103,16 @@ class LocalEnv(ScriptEnv):
                 _LOG.debug("Dump tunables to file: %s", fname)
                 with open(fname, "wt", encoding="utf-8") as fh_tunables:
                     # json.dump(self._params, fh_tunables)  # Tunables *and* const_args
-                    json.dump(tunables.get_param_values(
-                        self._tunable_params.get_covariant_group_names()), fh_tunables)
+                    json.dump(tunables.get_param_values(), fh_tunables)
+
+            if self._dump_meta_file:
+                fname = path_join(temp_dir, self._dump_meta_file)
+                _LOG.debug("Dump tunables metadata to file: %s", fname)
+                with open(fname, "wt", encoding="utf-8") as fh_meta:
+                    json.dump({
+                        tunable.name: tunable.meta
+                        for (tunable, _group) in tunables if tunable.meta
+                    }, fh_meta)
 
             if self._script_setup:
                 return_code = self._local_exec(self._script_setup, temp_dir)

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -103,7 +103,7 @@ class LocalEnv(ScriptEnv):
                 _LOG.debug("Dump tunables to file: %s", fname)
                 with open(fname, "wt", encoding="utf-8") as fh_tunables:
                     # json.dump(self._params, fh_tunables)  # Tunables *and* const_args
-                    json.dump(tunables.get_param_values(), fh_tunables)
+                    json.dump(self._tunable_params.get_param_values(), fh_tunables)
 
             if self._dump_meta_file:
                 fname = path_join(temp_dir, self._dump_meta_file)
@@ -111,7 +111,7 @@ class LocalEnv(ScriptEnv):
                 with open(fname, "wt", encoding="utf-8") as fh_meta:
                     json.dump({
                         tunable.name: tunable.meta
-                        for (tunable, _group) in tunables if tunable.meta
+                        for (tunable, _group) in self._tunable_params if tunable.meta
                     }, fh_meta)
 
             if self._script_setup:

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_env-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_env-full.jsonc
@@ -28,6 +28,7 @@
 
         "read_results_file": "/tmp/results.csv",
         "dump_params_file": "/tmp/dump_params.json",
+        "dump_meta_file": "/tmp/dump_params_meta.json",
 
         "shell_env_params_match": [
             "^MLOS_[a-zA-Z0-9_]+$"

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_fileshare_env-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_fileshare_env-full.jsonc
@@ -27,6 +27,7 @@
         ],
         "read_results_file": "/tmp/results.csv",
         "dump_params_file": "/tmp/dump_params.json",
+        "dump_meta_file": "/tmp/dump_params_meta.json",
         "download": [
             {
                 "from": "https://some-host/some-path/some-file.tar.gz",


### PR DESCRIPTION
In the subsequent PRs, we will port the tunables' metadata and Linux kernel configuration scripts that use it from our private repo.
A PR with unit tests will also follow (turns out, we don't have *any* tests for `LocalEnv` atm).