### PR TITLE
make globals, config_path, and tunable_values complement each other in CLI config and command line options

### DIFF
--- a/mlos_bench/mlos_bench/launcher.py
+++ b/mlos_bench/mlos_bench/launcher.py
@@ -79,8 +79,8 @@ class Launcher:
         self._parent_service = LocalExecService(parent=self._config_loader)
 
         self.global_config = self._load_config(
-            args.globals or config.get("globals", []),
-            args.config_path or config.get("config_path", []),
+            config.get("globals", []) + (args.globals or []),
+            (args.config_path or []) + config.get("config_path", []),
             args_rest,
             {key: val for (key, val) in config.items() if key not in vars(args)},
         )
@@ -100,7 +100,7 @@ class Launcher:
         self.tunables = self._init_tunable_values(
             args.random_init or config.get("random_init", False),
             config.get("random_seed") if args.random_seed is None else args.random_seed,
-            args.tunable_values or config.get("tunable_values", []))
+            config.get("tunable_values", []) + (args.tunable_values or []))
         _LOG.info("Init tunables: %s", self.tunables)
 
         self.optimizer = self._load_optimizer(args.optimizer or config.get("optimizer"))


### PR DESCRIPTION
In our current implementation, command-line options like `--config_path` supersede the corresponding parameters in the CLI config file. For parameters like `globals`, `config_path`, and `tunable_values`, i.e., for lists of files and directories, such behavior is confusing and inconvenient. It would be much better for JSON and command line to complement each other - i.e., to *merge* the data from both sources. Note that the order of merging is important, since the command line parameters should still have priority to JSON