### PR TITLE
Add the ability to re-run the benchmark for configurations already in DB

### DIFF
--- a/mlos_bench/mlos_bench/optimizers/base_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/base_optimizer.py
@@ -68,6 +68,13 @@ class Optimizer(metaclass=ABCMeta):     # pylint: disable=too-many-instance-attr
         """
         return self._opt_target
 
+    @property
+    def supports_preload(self) -> bool:
+        """
+        Return True if the optimizer supports pre-loading the data from previous experiments.
+        """
+        return True
+
     @abstractmethod
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
                       status: Optional[Sequence[Status]] = None) -> bool:

--- a/mlos_bench/mlos_bench/optimizers/one_shot_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/one_shot_optimizer.py
@@ -30,6 +30,10 @@ class OneShotOptimizer(MockOptimizer):
         _LOG.info("Run a single iteration for: %s", self._tunables)
         self._max_iter = 1  # Always run for just one iteration.
 
+    @property
+    def supports_preload(self) -> bool:
+        return False
+
     def suggest(self) -> TunableGroups:
         _LOG.info("Suggest: %s", self._tunables)
         return self._tunables.copy()

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -154,6 +154,12 @@ class Storage(metaclass=ABCMeta):
             """
 
         @abstractmethod
+        def load_config(self, config_id: int) -> Dict[str, Any]:
+            """
+            Load tunable values for a given config ID.
+            """
+
+        @abstractmethod
         def load(self, opt_target: Optional[str] = None) -> Tuple[List[dict], List[Optional[float]], List[Status]]:
             """
             Load (tunable values, benchmark scores, status) to warm-up the optimizer.

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -89,6 +89,10 @@ class Experiment(Storage.Experiment):
         _LOG.info("Merge: %s <- %s", self._experiment_id, experiment_ids)
         raise NotImplementedError()
 
+    def load_config(self, config_id: int) -> Dict[str, Any]:
+        with self._engine.connect() as conn:
+            return self._get_params(conn, self._schema.config_param, config_id=config_id)
+
     def load(self, opt_target: Optional[str] = None) -> Tuple[List[dict], List[Optional[float]], List[Status]]:
         opt_target = opt_target or self._opt_target
         (configs, scores, status) = ([], [], [])


### PR DESCRIPTION
Introduce `--configId` command line option, e.g., 
`mlos_bench --config config/cli/cli-azure-mysql-bench.jsonc --globals experiment_mysql-kernel-hp.jsonc --configId 377`

Also, do not preload the existing results or resume pending trials if we just want to run a single benchmark.