### PR TITLE
Support pulling Azure configs from local dir

### DIFF
--- a/scripts/generate-azure-credentials-config.ps1
+++ b/scripts/generate-azure-credentials-config.ps1
@@ -3,7 +3,7 @@
 
 $AZURE_DEFAULTS_GROUP = $Env:AZURE_DEFAULTS_GROUP
 if (-not $AZURE_DEFAULTS_GROUP) {
-    $AZURE_DEFAULTS_GROUP = (az config get defaults.group --query value --output tsv)
+    $AZURE_DEFAULTS_GROUP = (az config get --local defaults.group --query value --output tsv)
 }
 if (-not $AZURE_DEFAULTS_GROUP) {
     Write-Error "Missing default az resource group config."
@@ -11,7 +11,7 @@ if (-not $AZURE_DEFAULTS_GROUP) {
 
 $AZURE_STORAGE_ACCOUNT_NAME = $Env:AZURE_STORAGE_ACCOUNT_NAME
 if (-not $AZURE_STORAGE_ACCOUNT_NAME) {
-    $AZURE_STORAGE_ACCOUNT_NAME = (az config get storage.account --query value --output tsv)
+    $AZURE_STORAGE_ACCOUNT_NAME = (az config get --local storage.account --query value --output tsv)
 }
 if (-not $AZURE_STORAGE_ACCOUNT_NAME) {
     Write-Error "Missing default az storage account name config."

--- a/scripts/generate-azure-credentials-config.sh
+++ b/scripts/generate-azure-credentials-config.sh
@@ -7,8 +7,8 @@
 set -eu
 set -x
 
-AZURE_DEFAULTS_GROUP=${AZURE_DEFAULTS_GROUP:-$(az config get defaults.group --query value -o tsv)}
-AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME:-$(az config get storage.account --query value -o tsv)}
+AZURE_DEFAULTS_GROUP=${AZURE_DEFAULTS_GROUP:-$(az config get --local defaults.group --query value -o tsv)}
+AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME:-$(az config get --local storage.account --query value -o tsv)}
 
 az account get-access-token \
     --query "{tenant:tenant,subscription:subscription}" |


### PR DESCRIPTION
This allows one to use something like 

```sh
az config set defaults.group=myRG --local
```

To configure the RG and storage account to use for `az` commands executed in the local directory, reducing some environment setup between shell invocations (e.g. needing to source an `env.sh` file for instance).