### PR TITLE
bugfix: do not expand the script path in run/setup/teardown if it is not executable

### DIFF
--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -122,6 +122,8 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
         """
         cmd = shlex.split(script_line)
         script_path = self.config_loader_service.resolve_path(cmd[0])
+        # special case handling for leading lone `.` character, which also means `source`
+        # (as in, include, but not execute) in shell syntax
         if os.path.exists(script_path) and not os.path.isdir(script_path):
             script_path = os.path.abspath(script_path)
         else:

--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -90,8 +90,8 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
                 if return_code != 0 and return_on_error:
                     break
 
-        stdout = "\n".join(stdout_list)
-        stderr = "\n".join(stderr_list)
+        stdout = "".join(stdout_list)
+        stderr = "".join(stderr_list)
 
         _LOG.debug("Run: stdout:\n%s", stdout)
         _LOG.debug("Run: stderr:\n%s", stderr)
@@ -122,8 +122,10 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
         """
         cmd = shlex.split(script_line)
         script_path = self.config_loader_service.resolve_path(cmd[0])
-        if os.path.exists(script_path):
+        if os.path.exists(script_path) and not os.path.isdir(script_path):
             script_path = os.path.abspath(script_path)
+        else:
+            script_path = cmd[0]  # rollback to the original value
 
         cmd = [script_path] + cmd[1:]
         if script_path.strip().lower().endswith(".py"):


### PR DESCRIPTION
Checking for an actual executable is a bit tricky on Windows, so we'll do it properly later; (also, it is ok to have X bits not set for Python scripts). For now, add some minimal checks to prevent `.` (as in `. script.sh`) from expanding into a current directory path instead of being treated as `source script.sh` in bash.
Also, remove extra newlines when logging the script's stdout/stderr.