### PR TITLE
bugfix: Process result files of the form (metric, value) as dictionaries or scalar with the column name score

### DIFF
--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -159,8 +159,6 @@ class LocalEnv(ScriptEnv):
                 _LOG.warning(
                     "Local run has %d rows: assume long format of (metric, value)", len(data))
                 data = pandas.DataFrame([data.value.to_list()], columns=data.metric.to_list())
-            else:
-                assert 'score' in data.columns
 
             data_dict = data.iloc[-1].to_dict()
             _LOG.info("Local run complete: %s ::\n%s", self, data_dict)

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -155,7 +155,7 @@ class LocalEnv(ScriptEnv):
                     self._read_results_file, extra_paths=[temp_dir]))
 
             _LOG.debug("Read data:\n%s", data)
-            if 'metric' in data.columns and 'value' in data.columns:
+            if list(data.columns) == ["metric", "value"]:
                 _LOG.warning(
                     "Local run has %d rows: assume long format of (metric, value)", len(data))
                 data = pandas.DataFrame([data.value.to_list()], columns=data.metric.to_list())

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -155,10 +155,12 @@ class LocalEnv(ScriptEnv):
                     self._read_results_file, extra_paths=[temp_dir]))
 
             _LOG.debug("Read data:\n%s", data)
-            if len(data) != 1:
+            if 'metric' in data.columns and 'value' in data.columns:
                 _LOG.warning(
                     "Local run has %d rows: assume long format of (metric, value)", len(data))
                 data = pandas.DataFrame([data.value.to_list()], columns=data.metric.to_list())
+            else:
+                assert 'score' in data.columns
 
             data_dict = data.iloc[-1].to_dict()
             _LOG.info("Local run complete: %s ::\n%s", self, data_dict)


### PR DESCRIPTION
The LocalEnv.run() function processed any results DataFrame containing a single record as a scalar record. This change ensures that even if the result file contains a single line of the form `(metric, value)`, it is processed as a dictionary. 
