### PR TITLE
experiment_id fixups and restrictions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,10 +50,14 @@
         },
         {
             "fileMatch": [
-                "global_config.jsonc",
-                "global_config.json",
+                "mlos_bench/mlos_bench/tests/config/globals/**/*.jsonc",
+                "mlos_bench/mlos_bench/tests/config/globals/**/*.json",
+                "globals*.jsonc",
+                "globals*.json",
+                "global*.jsonc",
+                "global*.json",
                 "config.jsonc",
-                "config.json"
+                "config.json",
             ],
             "url": "./mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json"
         },

--- a/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
@@ -14,7 +14,7 @@
                     "tunable_params": ["$redis"],
                     "required_args": [
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     // Dump tunable parameters to a local JSON file:
                     "dump_params_file": "redis-params.json",
@@ -25,11 +25,11 @@
                     "upload": [
                         {
                             "from": "redis.cfg",
-                            "to": "$experiment_id/$trialId/input/redis.cfg"
+                            "to": "$experiment_id/$trial_id/input/redis.cfg"
                         },
                         {
                             "from": "environments/apps/redis/scripts/remote/",
-                            "to": "$experiment_id/$trialId/scripts"
+                            "to": "$experiment_id/$trial_id/scripts"
                         }
                     ]
                 }
@@ -42,22 +42,22 @@
                     "required_args": [
                         "vmName",
                         "experiment_id",
-                        "trialId",
+                        "trial_id",
                         "mountPoint"
                     ],
                     "setup": [
-                        "$mountPoint/$experiment_id/$trialId/scripts/setup-workload.sh",
-                        "$mountPoint/$experiment_id/$trialId/scripts/setup-app.sh"
+                        "$mountPoint/$experiment_id/$trial_id/scripts/setup-workload.sh",
+                        "$mountPoint/$experiment_id/$trial_id/scripts/setup-app.sh"
                     ],
                     "run": [
                         "mkdir -p /tmp/mlos_bench/output/",
-                        "$mountPoint/$experiment_id/$trialId/scripts/run-workload.sh",
-                        "mkdir -p $mountPoint/$experiment_id/$trialId/output/",
-                        "cp -r /tmp/mlos_bench/output/* $mountPoint/$experiment_id/$trialId/output/"
+                        "$mountPoint/$experiment_id/$trial_id/scripts/run-workload.sh",
+                        "mkdir -p $mountPoint/$experiment_id/$trial_id/output/",
+                        "cp -r /tmp/mlos_bench/output/* $mountPoint/$experiment_id/$trial_id/output/"
                     ],
                     "teardown": [
-                        "$mountPoint/$experiment_id/$trialId/scripts/cleanup-workload.sh",
-                        "$mountPoint/$experiment_id/$trialId/scripts/cleanup-app.sh",
+                        "$mountPoint/$experiment_id/$trial_id/scripts/cleanup-workload.sh",
+                        "$mountPoint/$experiment_id/$trial_id/scripts/cleanup-app.sh",
                         "rm -r /tmp/mlos_bench/"
                     ]
                 }
@@ -69,11 +69,11 @@
                 "config": {
                     "required_args": [
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "download": [
                         {
-                            "from": "$experiment_id/$trialId/output",
+                            "from": "$experiment_id/$trial_id/output",
                             "to": "$PWD/redis-bench-output/"
                         }
                     ],

--- a/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
@@ -13,7 +13,7 @@
                 "config": {
                     "tunable_params": ["$redis"],
                     "required_args": [
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     // Dump tunable parameters to a local JSON file:
@@ -25,11 +25,11 @@
                     "upload": [
                         {
                             "from": "redis.cfg",
-                            "to": "$experimentId/$trialId/input/redis.cfg"
+                            "to": "$experiment_id/$trialId/input/redis.cfg"
                         },
                         {
                             "from": "environments/apps/redis/scripts/remote/",
-                            "to": "$experimentId/$trialId/scripts"
+                            "to": "$experiment_id/$trialId/scripts"
                         }
                     ]
                 }
@@ -41,23 +41,23 @@
                 "config": {
                     "required_args": [
                         "vmName",
-                        "experimentId",
+                        "experiment_id",
                         "trialId",
                         "mountPoint"
                     ],
                     "setup": [
-                        "$mountPoint/$experimentId/$trialId/scripts/setup-workload.sh",
-                        "$mountPoint/$experimentId/$trialId/scripts/setup-app.sh"
+                        "$mountPoint/$experiment_id/$trialId/scripts/setup-workload.sh",
+                        "$mountPoint/$experiment_id/$trialId/scripts/setup-app.sh"
                     ],
                     "run": [
                         "mkdir -p /tmp/mlos_bench/output/",
-                        "$mountPoint/$experimentId/$trialId/scripts/run-workload.sh",
-                        "mkdir -p $mountPoint/$experimentId/$trialId/output/",
-                        "cp -r /tmp/mlos_bench/output/* $mountPoint/$experimentId/$trialId/output/"
+                        "$mountPoint/$experiment_id/$trialId/scripts/run-workload.sh",
+                        "mkdir -p $mountPoint/$experiment_id/$trialId/output/",
+                        "cp -r /tmp/mlos_bench/output/* $mountPoint/$experiment_id/$trialId/output/"
                     ],
                     "teardown": [
-                        "$mountPoint/$experimentId/$trialId/scripts/cleanup-workload.sh",
-                        "$mountPoint/$experimentId/$trialId/scripts/cleanup-app.sh",
+                        "$mountPoint/$experiment_id/$trialId/scripts/cleanup-workload.sh",
+                        "$mountPoint/$experiment_id/$trialId/scripts/cleanup-app.sh",
                         "rm -r /tmp/mlos_bench/"
                     ]
                 }
@@ -68,12 +68,12 @@
                 "class": "mlos_bench.environments.local.LocalFileShareEnv",
                 "config": {
                     "required_args": [
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "download": [
                         {
-                            "from": "$experimentId/$trialId/output",
+                            "from": "$experiment_id/$trialId/output",
                             "to": "$PWD/redis-bench-output/"
                         }
                     ],

--- a/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
@@ -25,13 +25,13 @@
 
                     // Values provided from the global config/optimizer:
                     "required_args": [
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     // Dump tunable parameters to a local JSON file:
                     "dump_params_file": "boot-params.json",
                     "shell_env_params": [
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "setup": [
@@ -40,7 +40,7 @@
                     "upload": [
                         {
                             "from": "grub.cfg",
-                            "to": "$experimentId/$trialId/input/grub.cfg"
+                            "to": "$experiment_id/$trialId/input/grub.cfg"
                         }
                     ]
                 }
@@ -56,7 +56,7 @@
                         "storageFileShareName",
                         "storageAccountKey",
                         "mountPoint",
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "wait_boot": true,
@@ -65,17 +65,17 @@
                         "storageFileShareName",
                         "storageAccountKey",
                         "mountPoint",
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "setup": [
                         "sudo mkdir -p $mountPoint",
                         "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
                         // TODO: Apply GRUB parameters from config on shared storage at:
-                        // "$mountPoint/$experimentId/$trialId/input/grub.cfg"
+                        // "$mountPoint/$experiment_id/$trialId/input/grub.cfg"
                         // "sudo update-grub",
                         // "sudo shutdown -r now"  // Reboot to apply the parameters
-                        "cat $mountPoint/$experimentId/$trialId/input/grub.cfg"
+                        "cat $mountPoint/$experiment_id/$trialId/input/grub.cfg"
                     ],
                     "teardown": [
                         // "sudo umount $mountPoint"

--- a/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
@@ -26,13 +26,13 @@
                     // Values provided from the global config/optimizer:
                     "required_args": [
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     // Dump tunable parameters to a local JSON file:
                     "dump_params_file": "boot-params.json",
                     "shell_env_params": [
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "setup": [
                         "environments/os/linux/boot/scripts/local/generate_grub_config.py boot-params.json grub.cfg"
@@ -40,7 +40,7 @@
                     "upload": [
                         {
                             "from": "grub.cfg",
-                            "to": "$experiment_id/$trialId/input/grub.cfg"
+                            "to": "$experiment_id/$trial_id/input/grub.cfg"
                         }
                     ]
                 }
@@ -57,7 +57,7 @@
                         "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "wait_boot": true,
                     "shell_env_params": [
@@ -66,16 +66,16 @@
                         "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "setup": [
                         "sudo mkdir -p $mountPoint",
                         "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
                         // TODO: Apply GRUB parameters from config on shared storage at:
-                        // "$mountPoint/$experiment_id/$trialId/input/grub.cfg"
+                        // "$mountPoint/$experiment_id/$trial_id/input/grub.cfg"
                         // "sudo update-grub",
                         // "sudo shutdown -r now"  // Reboot to apply the parameters
-                        "cat $mountPoint/$experiment_id/$trialId/input/grub.cfg"
+                        "cat $mountPoint/$experiment_id/$trial_id/input/grub.cfg"
                     ],
                     "teardown": [
                         // "sudo umount $mountPoint"

--- a/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
@@ -16,14 +16,14 @@
                     "tunable_params": ["$linux-runtime"],
 
                     "required_args": [
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     // Dump tunable parameters to a local JSON file:
                     "dump_params_file": "kernel-params.json",
                     "dump_meta_file": "kernel-params-meta.json",
                     "shell_env_params": [
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "setup": [
@@ -32,17 +32,17 @@
                     "upload": [
                         {
                             "from": "config-kernel.sh",
-                            "to": "$experimentId/$trialId/input/config-kernel.sh"
+                            "to": "$experiment_id/$trialId/input/config-kernel.sh"
                         },
                         // We don't really need `kernel-params*.json` files on the remote side,
                         // but it's nice to have them in a shared storage for debugging purposes.
                         {
                             "from": "kernel-params.json",
-                            "to": "$experimentId/$trialId/input/kernel-params.json"
+                            "to": "$experiment_id/$trialId/input/kernel-params.json"
                         },
                         {
                             "from": "kernel-params-meta.json",
-                            "to": "$experimentId/$trialId/input/kernel-params-meta.json"
+                            "to": "$experiment_id/$trialId/input/kernel-params-meta.json"
                         }
                     ]
                 }
@@ -58,7 +58,7 @@
                         "storageFileShareName",
                         "storageAccountKey",
                         "mountPoint",
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "wait_boot": true,
@@ -67,13 +67,13 @@
                         "storageFileShareName",
                         "storageAccountKey",
                         "mountPoint",
-                        "experimentId",
+                        "experiment_id",
                         "trialId"
                     ],
                     "setup": [
                         "sudo mkdir -p $mountPoint",
                         "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
-                        "sudo $mountPoint/$experimentId/$trialId/input/config-kernel.sh"
+                        "sudo $mountPoint/$experiment_id/$trialId/input/config-kernel.sh"
                     ]
                 }
             }

--- a/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
@@ -17,14 +17,14 @@
 
                     "required_args": [
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     // Dump tunable parameters to a local JSON file:
                     "dump_params_file": "kernel-params.json",
                     "dump_meta_file": "kernel-params-meta.json",
                     "shell_env_params": [
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "setup": [
                         "environments/os/linux/runtime/scripts/local/generate_kernel_config_script.py kernel-params.json kernel-params-meta.json config-kernel.sh"
@@ -32,17 +32,17 @@
                     "upload": [
                         {
                             "from": "config-kernel.sh",
-                            "to": "$experiment_id/$trialId/input/config-kernel.sh"
+                            "to": "$experiment_id/$trial_id/input/config-kernel.sh"
                         },
                         // We don't really need `kernel-params*.json` files on the remote side,
                         // but it's nice to have them in a shared storage for debugging purposes.
                         {
                             "from": "kernel-params.json",
-                            "to": "$experiment_id/$trialId/input/kernel-params.json"
+                            "to": "$experiment_id/$trial_id/input/kernel-params.json"
                         },
                         {
                             "from": "kernel-params-meta.json",
-                            "to": "$experiment_id/$trialId/input/kernel-params-meta.json"
+                            "to": "$experiment_id/$trial_id/input/kernel-params-meta.json"
                         }
                     ]
                 }
@@ -59,7 +59,7 @@
                         "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "wait_boot": true,
                     "shell_env_params": [
@@ -68,12 +68,12 @@
                         "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
-                        "trialId"
+                        "trial_id"
                     ],
                     "setup": [
                         "sudo mkdir -p $mountPoint",
                         "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
-                        "sudo $mountPoint/$experiment_id/$trialId/input/config-kernel.sh"
+                        "sudo $mountPoint/$experiment_id/$trial_id/input/config-kernel.sh"
                     ]
                 }
             }

--- a/mlos_bench/mlos_bench/config/experiments/README.md
+++ b/mlos_bench/mlos_bench/config/experiments/README.md
@@ -13,7 +13,7 @@ it looks like this:
 ```jsonc
 {
     "experiment_id": "RedisBench",
-    "trialId": 1,
+    "trial_id": 1,
 
     "deploymentName": "RedisBench",
     "vmName": "os-autotune-linux-vm",

--- a/mlos_bench/mlos_bench/config/experiments/README.md
+++ b/mlos_bench/mlos_bench/config/experiments/README.md
@@ -12,7 +12,7 @@ it looks like this:
 
 ```jsonc
 {
-    "experimentId": "RedisBench",
+    "experiment_id": "RedisBench",
     "trialId": 1,
 
     "deploymentName": "RedisBench",

--- a/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
+++ b/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
@@ -1,8 +1,8 @@
 {
-    "experimentId": "RedisBench",
+    "experiment_id": "RedisBench",
     "trialId": 1,
 
-    // TODO: Generate these names from $experimentId
+    // TODO: Generate these names from $experiment_id
     "deploymentName": "RedisBench",
     "vmName": "os-autotune-linux-vm",
 

--- a/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
+++ b/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
@@ -1,6 +1,6 @@
 {
     "experiment_id": "RedisBench",
-    "trialId": 1,
+    "trial_id": 1,
 
     // TODO: Generate these names from $experiment_id
     "deploymentName": "RedisBench",

--- a/mlos_bench/mlos_bench/config/schemas/cli/cli-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/cli-schema.json
@@ -86,7 +86,7 @@
             "$ref": "#/$defs/json_config_path_or_paths"
         },
 
-        "experimentId": {
+        "experiment_id": {
             "description": "Name of the experiment.",
             "$comment": "TODO: Rename this to conform to snake case.",
             "type": "string"

--- a/mlos_bench/mlos_bench/config/schemas/cli/cli-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/cli-schema.json
@@ -86,8 +86,8 @@
             "$ref": "#/$defs/json_config_path_or_paths"
         },
 
-        "experimentId": {
-            "$ref": "./common-defs-subschemas.json#/$defs/experimentId"
+        "experiment_id": {
+            "$ref": "./common-defs-subschemas.json#/$defs/experiment_id"
         },
         "trial_id": {
             "$ref": "./common-defs-subschemas.json#/$defs/trial_id"

--- a/mlos_bench/mlos_bench/config/schemas/cli/cli-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/cli-schema.json
@@ -86,15 +86,14 @@
             "$ref": "#/$defs/json_config_path_or_paths"
         },
 
-        "experiment_id": {
-            "description": "Name of the experiment.",
-            "$comment": "TODO: Rename this to conform to snake case.",
-            "type": "string"
+        "experimentId": {
+            "$ref": "./common-defs-subschemas.json#/$defs/experimentId"
         },
-        "trialId": {
-            "description": "Trial id to use for the experiment.",
-            "$comment": "TODO: Rename this to conform to snake case.",
-            "type": "integer"
+        "trial_id": {
+            "$ref": "./common-defs-subschemas.json#/$defs/trial_id"
+        },
+        "config_id": {
+            "$ref": "./common-defs-subschemas.json#/$defs/config_id"
         },
 
         "teardown": {

--- a/mlos_bench/mlos_bench/config/schemas/cli/common-defs-subschemas.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/common-defs-subschemas.json
@@ -13,6 +13,22 @@
                 },
                 "uniqueItems": true
             }
+        },
+        "experiment_id": {
+            "description": "The name of the experiment. Sometimes appended to various resources.",
+            "type": "string",
+            "$comment": "No spaces allowed.",
+            "pattern": "^[a-zA-Z0-9_.-]+$"
+        },
+        "trial_id": {
+            "description": "Trial ID to use (or resume) for the experiment.",
+            "type": "integer",
+            "minimum": 0
+        },
+        "config_id": {
+            "description": "Config ID to use (or resume) for the experiment.",
+            "type": "integer",
+            "minimum": 0
         }
     }
 }

--- a/mlos_bench/mlos_bench/config/schemas/cli/common-defs-subschemas.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/common-defs-subschemas.json
@@ -5,6 +5,7 @@
     "$comment": "Includes common subschemas for both cli configs and globals.",
     "$defs": {
         "tunable_params_map": {
+            "description": "Maps tunable_params to a set of covariant tunable groups.",
             "type": "object",
             "additionalProperties": {
                 "type": "array",
@@ -14,6 +15,7 @@
                 "uniqueItems": true
             }
         },
+
         "experiment_id": {
             "description": "The name of the experiment. Sometimes appended to various resources.",
             "type": "string",

--- a/mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json
@@ -12,6 +12,12 @@
         },
         "tunable_params_map": {
             "$ref": "./common-defs-subschemas.json#/$defs/tunable_params_map"
+        },
+        "experiment_id": {
+            "description": "The name of the experiment. Sometimes appended to various resources.",
+            "type": "string",
+            "$comment": "No spaces allowed.",
+            "pattern": "^[a-zA-Z0-9_.-]+$"
         }
     },
     "additionalProperties": {

--- a/mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/cli/globals-schema.json
@@ -10,14 +10,19 @@
             "type": "string",
             "pattern": "/schemas/cli/globals-schema.json$"
         },
+
         "tunable_params_map": {
             "$ref": "./common-defs-subschemas.json#/$defs/tunable_params_map"
         },
+
         "experiment_id": {
-            "description": "The name of the experiment. Sometimes appended to various resources.",
-            "type": "string",
-            "$comment": "No spaces allowed.",
-            "pattern": "^[a-zA-Z0-9_.-]+$"
+            "$ref": "./common-defs-subschemas.json#/$defs/experiment_id"
+        },
+        "trial_id": {
+            "$ref": "./common-defs-subschemas.json#/$defs/trial_id"
+        },
+        "config_id": {
+            "$ref": "./common-defs-subschemas.json#/$defs/config_id"
         }
     },
     "additionalProperties": {

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -28,7 +28,7 @@
                             "type": "string"
                         },
                         "deploymentName": {
-                            "$comment": "TODO: provide templating strings to augment names via experimentId/trialId, for instance.",
+                            "$comment": "TODO: provide templating strings to augment names via experiment_id/trialId, for instance.",
                             "description": "Name of the deployment to create for the experiment resources.",
                             "type": "string"
                         },

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -28,7 +28,7 @@
                             "type": "string"
                         },
                         "deploymentName": {
-                            "$comment": "TODO: provide templating strings to augment names via experiment_id/trialId, for instance.",
+                            "$comment": "TODO: provide templating strings to augment names via experiment_id/trial_id, for instance.",
                             "description": "Name of the deployment to create for the experiment resources.",
                             "type": "string"
                         },

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -69,7 +69,7 @@ def _optimize(env: Environment,
     if _LOG.isEnabledFor(logging.INFO):
         _LOG.info("Root Environment:\n%s", env.pprint())
 
-    experiment_id = global_config["experimentId"].strip()
+    experiment_id = global_config["experiment_id"].strip()
     trial_id = int(global_config.get("trialId", 1))
     config_id = int(global_config.get("configId", -1))
 

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -70,8 +70,8 @@ def _optimize(env: Environment,
         _LOG.info("Root Environment:\n%s", env.pprint())
 
     experiment_id = global_config["experiment_id"].strip()
-    trial_id = int(global_config.get("trialId", 1))
-    config_id = int(global_config.get("configId", -1))
+    trial_id = int(global_config.get("trial_id", 1))
+    config_id = int(global_config.get("config_id", -1))
 
     # Start new or resume the existing experiment. Verify that the
     # experiment configuration is compatible with the previous runs.

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -257,7 +257,7 @@ class Storage(metaclass=ABCMeta):
             config = self._config.copy()
             config.update(global_config or {})
             config["experiment_id"] = self._experiment_id
-            config["trialId"] = self._trial_id
+            config["trial_id"] = self._trial_id
             return config
 
         @abstractmethod

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -256,7 +256,7 @@ class Storage(metaclass=ABCMeta):
             """
             config = self._config.copy()
             config.update(global_config or {})
-            config["experimentId"] = self._experiment_id
+            config["experiment_id"] = self._experiment_id
             config["trialId"] = self._trial_id
             return config
 

--- a/mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc
@@ -22,7 +22,7 @@
     // "globals": ["global_config.json"],
 
     "experiment_id": "MockExperiment",
-    "trialId": 1,
+    "trial_id": 1,
 
     "teardown": true,
 

--- a/mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc
@@ -21,7 +21,7 @@
 
     // "globals": ["global_config.json"],
 
-    "experimentId": "MockExperiment",
+    "experiment_id": "MockExperiment",
     "trialId": 1,
 
     "teardown": true,

--- a/mlos_bench/mlos_bench/tests/config/cli/test_load_cli_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/cli/test_load_cli_config_examples.py
@@ -54,7 +54,7 @@ def test_load_cli_config_examples(config_loader_service: ConfigPersistenceServic
         "globals",      # we don't commit globals to the repo generally, so skip testing them
         "log_file",
         "log_level",
-        "experimentId",
+        "experiment_id",
         "trialId",
         "teardown",
     }

--- a/mlos_bench/mlos_bench/tests/config/cli/test_load_cli_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/cli/test_load_cli_config_examples.py
@@ -55,7 +55,7 @@ def test_load_cli_config_examples(config_loader_service: ConfigPersistenceServic
         "log_file",
         "log_level",
         "experiment_id",
-        "trialId",
+        "trial_id",
         "teardown",
     }
     for arg in config:

--- a/mlos_bench/mlos_bench/tests/config/environments/test_load_environment_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/environments/test_load_environment_config_examples.py
@@ -52,7 +52,7 @@ def load_environment_config_examples(config_loader_service: ConfigPersistenceSer
     # Make sure that any "required_args" are provided.
     global_config = {
         "experiment_id": "test",
-        "trialId": 1,
+        "trial_id": 1,
 
         "mountPoint": "/mnt/tmp",
 

--- a/mlos_bench/mlos_bench/tests/config/environments/test_load_environment_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/environments/test_load_environment_config_examples.py
@@ -51,7 +51,7 @@ def load_environment_config_examples(config_loader_service: ConfigPersistenceSer
     """Loads an environment config example."""
     # Make sure that any "required_args" are provided.
     global_config = {
-        "experimentId": "test",
+        "experiment_id": "test",
         "trialId": 1,
 
         "mountPoint": "/mnt/tmp",

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/invalid/invalid-experiment-id.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/invalid/invalid-experiment-id.jsonc
@@ -1,0 +1,5 @@
+{
+    "experiment_id": "Spaces Not Allowed",
+    "log_file": "/tmp/mlos_bench.log",
+    "log_level": "DEBUG"
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/invalid/wrong-schema-path.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/invalid/wrong-schema-path.jsonc
@@ -18,7 +18,7 @@
         "global_config.json"
     ],
 
-    "experimentId": "RedisBench",
+    "experiment_id": "RedisBench",
     "trialId": 1,
 
     "teardown": false,

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/invalid/wrong-schema-path.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/invalid/wrong-schema-path.jsonc
@@ -19,7 +19,7 @@
     ],
 
     "experiment_id": "RedisBench",
-    "trialId": 1,
+    "trial_id": 1,
 
     "teardown": false,
 

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/unhandled/cli-with-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/unhandled/cli-with-extras.jsonc
@@ -16,7 +16,7 @@
         "global_config.json"
     ],
 
-    "experimentId": "RedisBench",
+    "experiment_id": "RedisBench",
     "trialId": 1,
 
     "teardown": false,

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/unhandled/cli-with-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/bad/unhandled/cli-with-extras.jsonc
@@ -17,7 +17,7 @@
     ],
 
     "experiment_id": "RedisBench",
-    "trialId": 1,
+    "trial_id": 1,
 
     "teardown": false,
 

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/good/full/full-cli.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/good/full/full-cli.jsonc
@@ -25,7 +25,7 @@
         "mysql": ["mysql-innodb", "mysql-buffer"]
     },
 
-    "experimentId": "RedisBench",
+    "experiment_id": "RedisBench",
     "trialId": 1,
 
     "teardown": false,

--- a/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/good/full/full-cli.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/cli/test-cases/good/full/full-cli.jsonc
@@ -26,7 +26,7 @@
     },
 
     "experiment_id": "RedisBench",
-    "trialId": 1,
+    "trial_id": 1,
 
     "teardown": false,
 

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-tunable-values-disallowed.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-tunable-values-disallowed.jsonc
@@ -1,0 +1,6 @@
+{
+    "foo": "bar",
+    "tunable_values": {
+        "not": "allowed"
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-bad-experiment-id.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-bad-experiment-id.jsonc
@@ -1,0 +1,7 @@
+{
+    "foo": "bar",
+    "bar": "baz",
+    "num": 1,
+    "bool": true,
+    "experiment_id": "Spaces Not Allowed"
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-bad-trial-id.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/bad/invalid/globals-with-bad-trial-id.jsonc
@@ -1,0 +1,7 @@
+{
+    "foo": "bar",
+    "bar": "baz",
+    "num": 1,
+    "bool": true,
+    "trial_id": -1
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/good/full/globals-with-schema.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/good/full/globals-with-schema.jsonc
@@ -8,5 +8,7 @@
     "tunable_params_map": {
         // Examples
         "mysql": ["mysql-innodb", "mysql-myisam", "mysql-binlog", "mysql-hugepages"]
-    }
+    },
+    "experiment_id": "ExperimentName",
+    "trial_id": 1
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/good/partial/globals-with-null.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/globals/test-cases/good/partial/globals-with-null.jsonc
@@ -3,5 +3,7 @@
     "bar": "baz",
     "num": 1,
     "bool": true,
-    "null": null
+    "null": null,
+    "experiment_id": "ExperimentName",
+    "trial_id": 1
 }

--- a/mlos_bench/mlos_bench/tests/storage/trial_config_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/trial_config_test.py
@@ -24,7 +24,7 @@ def test_exp_trial_pending(exp_storage_memory_sql: Storage.Experiment,
         "location": "westus2",
         "num_repeats": "100",
         "experiment_id": "Test-001",
-        "trialId": 1,
+        "trial_id": 1,
     }
 
 

--- a/mlos_bench/mlos_bench/tests/storage/trial_config_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/trial_config_test.py
@@ -23,7 +23,7 @@ def test_exp_trial_pending(exp_storage_memory_sql: Storage.Experiment,
     assert pending.config() == {
         "location": "westus2",
         "num_repeats": "100",
-        "experimentId": "Test-001",
+        "experiment_id": "Test-001",
         "trialId": 1,
     }
 


### PR DESCRIPTION
Adds schema restrictions on experiment_id since we use (or plan to use) it in path names.

Per #357, also renames for snake case consistency.