### PR TITLE
Autopep8 devcontainer fixups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,6 +44,7 @@
                 // Adjust the python interpreter path to point to the conda environment
                 "python.defaultInterpreterPath": "/opt/conda/envs/mlos/bin/python",
                 "python.testing.pytestPath": "/opt/conda/envs/mlos/bin/pytest",
+                "python.formatting.autopep8Path": "/opt/conda/envs/mlos/bin/autopep8",
                 "python.linting.pylintPath": "/opt/conda/envs/mlos/bin/pylint",
                 "pylint.path": [
                     "/opt/conda/envs/mlos/bin/pylint"
@@ -70,7 +71,7 @@
                 "lextudio.restructuredtext",
                 "matangover.mypy",
                 "ms-azuretools.vscode-docker",
-                "ms-python.autopep8",
+                //"ms-python.autopep8",
                 "ms-python.flake8",
                 "ms-python.pylint",
                 "ms-python.python",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -15,7 +15,7 @@
         "lextudio.restructuredtext",
         "matangover.mypy",
         "ms-azuretools.vscode-docker",
-        "ms-python.autopep8",
+        //"ms-python.autopep8",
         "ms-python.flake8",
         "ms-python.pylint",
         "ms-python.python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,20 +112,20 @@
     ],
     "esbonio.sphinx.confDir": "${workspaceFolder}/doc/source",
     "esbonio.sphinx.buildDir": "${workspaceFolder}/doc/build/",
-    "python.formatting.provider": "none",
+    "python.formatting.provider": "autopep8",
+    "python.formatting.autopep8Args": [
+        "--experimental"
+    ],
+    "autopep8.args": [
+        "--experimental"
+    ],
     "[python]": {
-        "editor.defaultFormatter": "ms-python.autopep8",
+        "editor.defaultFormatter": "ms-python.python",
         "editor.formatOnSave": true,
         "editor.formatOnSaveMode": "modifications"
     },
     "python.testing.pytestArgs": [
         "."
     ],
-    "python.testing.unittestEnabled": false,
-    "autopep8.args": [
-        "--experimental"
-    ],
-    "python.formatting.autopep8Args": [
-        "--experimental"
-    ]
+    "python.testing.unittestEnabled": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -121,5 +121,11 @@
     "python.testing.pytestArgs": [
         "."
     ],
-    "python.testing.unittestEnabled": false
+    "python.testing.unittestEnabled": false,
+    "autopep8.args": [
+        "--experimental"
+    ],
+    "python.formatting.autopep8Args": [
+        "--experimental"
+    ]
 }

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - pylint
   - pycodestyle
-  - autopep8
   - pydocstyle
   - flake8
   - setuptools
@@ -21,6 +20,7 @@ dependencies:
   # See comments in mlos.yml.
   #- gcc_linux-64
   - pip:
+    - autopep8>=1.7.0
     - bump2version
     - check-jsonschema
     - licenseheaders

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - pylint
   - pycodestyle
-  - autopep8
   - pydocstyle
   - flake8
   - setuptools
@@ -22,6 +21,7 @@ dependencies:
   # See comments in mlos.yml.
   #- gcc_linux-64
   - pip:
+    - autopep8>=1.7.0
     - bump2version
     - check-jsonschema
     - licenseheaders

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - pylint
   - pycodestyle
-  - autopep8
   - pydocstyle
   - flake8
   - setuptools
@@ -21,6 +20,7 @@ dependencies:
   # See comments in mlos.yml.
   #- gcc_linux-64
   - pip:
+    - autopep8>=1.7.0
     - bump2version
     - check-jsonschema
     - licenseheaders

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - pylint
   - pycodestyle
-  - autopep8
   - pydocstyle
   - flake8
   - setuptools
@@ -21,6 +20,7 @@ dependencies:
   # See comments in mlos.yml.
   #- gcc_linux-64
   - pip:
+    - autopep8>=1.7.0
     - bump2version
     - check-jsonschema
     - licenseheaders

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -10,7 +10,6 @@ dependencies:
   - pip
   - pylint
   - pycodestyle
-  - autopep8
   - pydocstyle
   - flake8
   - setuptools
@@ -26,6 +25,7 @@ dependencies:
   # This also requires a more recent vs2015_runtime from conda-forge.
   - conda-forge::pyrfr>=0.9.0
   - pip:
+    - autopep8>=1.7.0
     - bump2version
     - check-jsonschema
     - licenseheaders

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -7,7 +7,6 @@ dependencies:
   - pip
   - pylint
   - pycodestyle
-  - autopep8
   - pydocstyle
   - flake8
   - setuptools
@@ -20,6 +19,7 @@ dependencies:
   - swig
   - python
   - pip:
+    - autopep8>=1.7.0
     - bump2version
     - check-jsonschema
     - licenseheaders


### PR DESCRIPTION
The recommended autopep8 extension doesn't seem to be working for us:
https://github.com/microsoft/vscode-autopep8/issues/16

So, for now I'm reverting to the old way of doing things.

Also, the previous extension relied on a newer version of autopep8 than conda was installing anyways, so I switched to installing it from pip.