### PR TITLE
mlos_bench: pass global_config to remaining base classes

### DIFF
--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -70,6 +70,7 @@ class Environment(metaclass=abc.ABCMeta):
         env : Environment
             An instance of the `Environment` class initialized with `config`.
         """
+        assert issubclass(cls, Environment)
         return instantiate_from_config(
             cls,
             class_name,

--- a/mlos_bench/mlos_bench/launcher.py
+++ b/mlos_bench/mlos_bench/launcher.py
@@ -259,7 +259,7 @@ class Launcher:
         """
         if args_optimizer is None:
             return OneShotOptimizer(
-                self.tunables, self._parent_service, self.global_config)
+                self.tunables, config=self.global_config, service=self._parent_service)
         optimizer = self._load(Optimizer, args_optimizer, ConfigSchema.OPTIMIZER)   # type: ignore[type-abstract]
         return optimizer
 
@@ -272,8 +272,8 @@ class Launcher:
         if args_storage is None:
             # pylint: disable=import-outside-toplevel
             from mlos_bench.storage.sql.storage import SqlStorage
-            return SqlStorage(self.tunables, self._parent_service,
-                              {"drivername": "sqlite", "database": ":memory:"})
+            return SqlStorage(self.tunables, service=self._parent_service,
+                              config={"drivername": "sqlite", "database": ":memory:"})
         storage = self._load(Storage, args_storage, ConfigSchema.STORAGE)   # type: ignore[type-abstract]
         return storage
 

--- a/mlos_bench/mlos_bench/optimizers/base_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/base_optimizer.py
@@ -24,7 +24,11 @@ class Optimizer(metaclass=ABCMeta):     # pylint: disable=too-many-instance-attr
     An abstract interface between the benchmarking framework and mlos_core optimizers.
     """
 
-    def __init__(self, tunables: TunableGroups, service: Optional[Service], config: dict):
+    def __init__(self,
+                 tunables: TunableGroups,
+                 config: dict,
+                 global_config: Optional[dict] = None,
+                 service: Optional[Service] = None):
         """
         Create a new optimizer for the given configuration space defined by the tunables.
 
@@ -40,6 +44,9 @@ class Optimizer(metaclass=ABCMeta):     # pylint: disable=too-many-instance-attr
         self._config = config.copy()
         self._tunables = tunables
         self._service = service
+
+        self._global_config = global_config or {}
+
         self._iter = 1
         # If False, use the optimizer to suggest the initial configuration;
         # if True (default), use the already initialized values for the first iteration.

--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -28,9 +28,12 @@ class MlosCoreOptimizer(Optimizer):
     A wrapper class for the mlos_core optimizers.
     """
 
-    def __init__(self, tunables: TunableGroups, service: Optional[Service], config: dict):
-
-        super().__init__(tunables, service, config)
+    def __init__(self,
+                 tunables: TunableGroups,
+                 config: dict,
+                 global_config: Optional[dict] = None,
+                 service: Optional[Service] = None):
+        super().__init__(tunables, config, global_config, service)
 
         space = tunable_groups_to_configspace(tunables)
         _LOG.debug("ConfigSpace: %s", space)

--- a/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
@@ -26,8 +26,12 @@ class MockOptimizer(Optimizer):
     Mock optimizer to test the Environment API.
     """
 
-    def __init__(self, tunables: TunableGroups, service: Optional[Service], config: dict):
-        super().__init__(tunables, service, config)
+    def __init__(self,
+                 tunables: TunableGroups,
+                 config: dict,
+                 global_config: Optional[dict] = None,
+                 service: Optional[Service] = None):
+        super().__init__(tunables, config, global_config, service)
         rnd = random.Random(config.get("seed", 42))
         self._random: Dict[str, Callable[[Tunable], TunableValue]] = {
             "categorical": lambda tunable: rnd.choice(tunable.categories),

--- a/mlos_bench/mlos_bench/optimizers/one_shot_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/one_shot_optimizer.py
@@ -7,7 +7,7 @@ No-op optimizer for mlos_bench that proposes a single configuration.
 """
 
 import logging
-from typing import Dict, Optional, Any
+from typing import Optional
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.tunables.tunable_groups import TunableGroups
@@ -24,9 +24,12 @@ class OneShotOptimizer(MockOptimizer):
 
     # TODO: Add support for multiple explicit configs (i.e., FewShot or Manual Optimizer) - #344
 
-    def __init__(self, tunables: TunableGroups,
-                 service: Optional[Service], config: Dict[str, Any]):
-        super().__init__(tunables, service, config)
+    def __init__(self,
+                 tunables: TunableGroups,
+                 config: dict,
+                 global_config: Optional[dict] = None,
+                 service: Optional[Service] = None):
+        super().__init__(tunables, config, global_config, service)
         _LOG.info("Run a single iteration for: %s", self._tunables)
         self._max_iter = 1  # Always run for just one iteration.
 

--- a/mlos_bench/mlos_bench/services/base_service.py
+++ b/mlos_bench/mlos_bench/services/base_service.py
@@ -51,6 +51,7 @@ class Service:
         svc : Service
             An instance of the `Service` class initialized with `config`.
         """
+        assert issubclass(cls, Service)
         return instantiate_from_config(cls, class_name, config, global_config, parent)
 
     def __init__(self,

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -211,8 +211,8 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         Generic instantiation of mlos_bench objects like Storage and Optimizer
         that depend on Service and TunableGroups.
 
-        A class *MUST* have a constructor that takes exactly three arguments:
-        (tunables, service, config)
+        A class *MUST* have a constructor that takes four named arguments:
+        (tunables, config, global_config, service)
 
         Parameters
         ----------
@@ -237,7 +237,11 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         if tunables_path is not None:
             tunables = self._load_tunables(tunables_path, tunables)
         (class_name, class_config) = self.prepare_class_load(config, global_config)
-        inst = instantiate_from_config(base_cls, class_name, tunables, service, class_config)
+        inst = instantiate_from_config(base_cls, class_name,
+                                       tunables=tunables,
+                                       config=class_config,
+                                       global_config=global_config,
+                                       service=service)
         _LOG.info("Created: %s %s", base_cls.__name__, inst)
         return inst
 

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -28,8 +28,11 @@ class Storage(metaclass=ABCMeta):
     and storage systems (e.g., SQLite or MLFLow).
     """
 
-    def __init__(self, tunables: TunableGroups, service: Optional[Service],
-                 config: Dict[str, Any]):
+    def __init__(self,
+                 tunables: TunableGroups,
+                 config: Dict[str, Any],
+                 global_config: Optional[dict] = None,
+                 service: Optional[Service] = None):
         """
         Create a new storage object.
 
@@ -45,6 +48,7 @@ class Storage(metaclass=ABCMeta):
         self._tunables = tunables.copy()
         self._service = service
         self._config = config.copy()
+        self._global_config = global_config or {}
 
     @abstractmethod
     def experiment(self, *,

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -25,8 +25,12 @@ class SqlStorage(Storage):
     An implementation of the Storage interface using SQLAlchemy backend.
     """
 
-    def __init__(self, tunables: TunableGroups, service: Optional[Service], config: dict):
-        super().__init__(tunables, service, config)
+    def __init__(self,
+                 tunables: TunableGroups,
+                 config: dict,
+                 global_config: Optional[dict] = None,
+                 service: Optional[Service] = None):
+        super().__init__(tunables, config, global_config, service)
         lazy_schema_create = self._config.pop("lazy_schema_create", False)
         self._log_sql = self._config.pop("log_sql", False)
         self._url = URL.create(**self._config)


### PR DESCRIPTION
For supporting `experiment_id` as `run_name` in #470.

Future work:
- Consolidate global_config variable expansion recursively and in other configs.