### PR TITLE
Use of service principal for generating access tokens

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-auth-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-auth-service-subschema.json
@@ -23,6 +23,18 @@
                         "tokenRequestInterval": {
                             "description": "Time before token expiration to request a new token",
                             "type": "number"
+                        },
+                        "keyVaultName": {
+                            "description": "Name of key vault to retrieve the certificate from, for authorizing the Service Principal",
+                            "type": "string"
+                        },
+                        "certName": {
+                            "description": "Name of the Service Principal's certificate in the key vault",
+                            "type": "string"
+                        },
+                        "spClientId": {
+                            "description": "Client ID of the Service Principal to authenticate as",
+                            "type": "string"
                         }
                     }
                 }

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-auth.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-auth.jsonc
@@ -1,6 +1,9 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureAuthService",
     "config": {
-        "tokenRequestInterval": 300  // seconds
+        "tokenRequestInterval": 300,  // seconds
+        "keyVaultName": "PLACEHOLDER; e.g. mlos-autotune-kv",
+        "certName": "PLACEHOLDER; e.g. mlos-autotune-sp-cert",
+        "spClientId": "PLACEHOLDER;"
     }
 }

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_auth.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_auth.py
@@ -7,13 +7,16 @@ A collection Service functions for managing VMs on Azure.
 """
 
 import datetime
-import json
 import logging
-import subprocess
+from base64 import b64decode
 from typing import Any, Dict, Optional
+
+import azure.identity as azure_id
+import azure.keyvault.secrets as keyvault_secrets
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.authenticator_type import SupportsAuth
+from mlos_bench.util import check_required_params
 
 _LOG = logging.getLogger(__name__)
 
@@ -24,6 +27,7 @@ class AzureAuthService(Service, SupportsAuth):
     """
 
     _REQ_INTERVAL = 300   # = 5 min
+    _TENTANT_ID = "72f988bf-86f1-41af-91ab-2d7cd011db47"
 
     def __init__(self,
                  config: Optional[Dict[str, Any]] = None,
@@ -47,11 +51,41 @@ class AzureAuthService(Service, SupportsAuth):
         # Register methods that we want to expose to the Environment objects.
         self.register([self.get_access_token])
 
+        check_required_params(
+            self.config, {
+                "keyVaultName",
+                "certName",
+                "spClientId",
+            }
+        )
+
         # This parameter can come from command line as strings, so conversion is needed.
         self._req_interval = float(self.config.get("tokenRequestInterval", self._REQ_INTERVAL))
+        keyvault_name = self.config.get("keyVaultName")
+        cert_name = self.config.get("certName")
+        sp_client_id = self.config.get("spClientId")
+        tenant_id = self.config.get("tenant", self._TENTANT_ID)
 
         self._access_token = "RENEW *NOW*"
         self._token_expiration_ts = datetime.datetime.now()  # Typically, some future timestamp.
+
+        # Login as ourselves
+        local_user_cred = azure_id.AzureCliCredential()
+
+        # Get a client for fetching cert info.
+        keyvault_secrets_client = keyvault_secrets.SecretClient(
+            vault_url=f"https://{keyvault_name}.vault.azure.net",
+            credential=local_user_cred,
+        )
+
+        # The certificate private key data is stored as hidden "Secret" (not Key strangely)
+        #  in PKCS12 format, but we need to decode it.
+        secret = keyvault_secrets_client.get_secret(cert_name)
+        assert secret.value is not None
+        cert_bytes = b64decode(secret.value)
+
+        # Reauthenticate as the service principal.
+        self._sp_cred = azure_id.CertificateCredential(tenant_id=tenant_id, client_id=sp_client_id, certificate_data=cert_bytes)
 
     def get_access_token(self) -> str:
         """
@@ -61,10 +95,8 @@ class AzureAuthService(Service, SupportsAuth):
         _LOG.debug("Time to renew the token: %.2f sec.", ts_diff)
         if ts_diff < self._req_interval:
             _LOG.debug("Request new accessToken")
-            # TODO: Use azure-identity SDK and a key valut instead of `az` CLI.
-            res = json.loads(subprocess.check_output(
-                'az account get-access-token', shell=True, text=True))
-            self._token_expiration_ts = datetime.datetime.fromisoformat(res["expiresOn"])
-            self._access_token = res["accessToken"]
+            res = self._sp_cred.get_token("https://management.azure.com/.default")
+            self._token_expiration_ts = datetime.datetime.fromtimestamp(res.expires_on)
+            self._access_token = res.token
             _LOG.info("Got new accessToken. Expiration time: %s", self._token_expiration_ts)
         return self._access_token

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -27,7 +27,7 @@ except LookupError as e:
 
 extra_requires: Dict[str, List[str]] = {    # pylint: disable=consider-using-namedtuple-or-dataclass
     # Additional tools for extra functionality.
-    'azure': ['azure-storage-file-share'],
+    'azure': ['azure-storage-file-share', 'azure-identity', 'azure-keyvault'],
     'storage-sql-duckdb': ['sqlalchemy', 'duckdb_engine'],
     'storage-sql-mysql': ['sqlalchemy', 'mysql-connector-python'],
     'storage-sql-postgres': ['sqlalchemy', 'psycopg2'],


### PR DESCRIPTION
This PR aims to reduce the need for interactive logins during an ongoing experiment by authenticating as a service principal (instead of personal account). This should enable us to run longer experiments without having to re-login.

The requirements of this are:
- An existing SP that has the correct access to the target resource group
- A certificate to authenticate as the SP, which is stored in a key vault that the current user has access to

The flow of authentication is inspired by @bpkroth's protocol:
1) On initialization, as the current user retrieve the SP's certificate from the key vault
2) Log in as the SP using the certificate
3) During runtime when tokens are requested, we request them as the SP

Will follow up with a PR in the MySQL repo with an example script that automates the set up of the SP, key vault, certificates and resource group in general.