### PR TITLE
Fix SMAC optimizer logging issue

### DIFF
--- a/mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc
@@ -9,14 +9,12 @@
 
     "config_path": [
         // relative to the root of the repo (for now), where this is expected to be executed from
-        "mlos_bench/mlos_bench/tests/config"
+        "mlos_bench/mlos_bench/tests/config",
+        "mlos_bench/mlos_bench/config"
     ],
 
     "environment": "environments/mock/mock_env.jsonc",
-
-    "tunable_values": [
-        "tunable-values/tunable-values-example.jsonc"
-    ],
+    "optimizer": "optimizers/mlos_core_default_opt.jsonc",
 
     // "globals": ["global_config.json"],
 
@@ -25,6 +23,6 @@
 
     "teardown": true,
 
-    // "log_file": "mock-bench.log",
-    "log_level": "INFO"
+    // "log_file": "mock-opt.log",
+    "log_level": "DEBUG"
 }

--- a/mlos_bench/mlos_bench/tests/launcher_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_test.py
@@ -47,8 +47,6 @@ def _launch_main_app(root_path: str, local_exec_service: LocalExecService,
     with local_exec_service.temp_dir_context() as temp_dir:
 
         log_path = path_join(temp_dir, "mock-test.log")
-        if os.path.exists(log_path):
-            os.unlink(log_path)
         (return_code, _stdout, _stderr) = local_exec_service.local_exec(
             [f"./mlos_bench/mlos_bench/run.py {cli_config} --log_file '{log_path}'"],
             cwd=root_path)

--- a/mlos_bench/mlos_bench/tests/launcher_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_test.py
@@ -7,6 +7,7 @@ Unit tests to check the main CLI launcher.
 """
 import os
 import re
+from typing import List
 
 import pytest
 
@@ -39,7 +40,7 @@ def local_exec_service() -> LocalExecService:
 
 
 def _launch_main_app(root_path: str, local_exec_service: LocalExecService,
-                     cli_config: str, re_expected: list[str]) -> None:
+                     cli_config: str, re_expected: List[str]) -> None:
     """
     Run mlos_bench command-line application with given config
     and check the results in the log.

--- a/mlos_bench/mlos_bench/tests/launcher_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_test.py
@@ -6,6 +6,7 @@
 Unit tests to check the main CLI launcher.
 """
 import os
+import re
 
 import pytest
 
@@ -49,15 +50,11 @@ def test_launch_main_app(root_path: str,
               " --config mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc" + \
               f" --log_file '{log_path}'"
         (return_code, _stdout, _stderr) = local_exec_service.local_exec([cmd], cwd=root_path)
-
         assert return_code == 0
 
+        re_log = re.compile(
+            r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} run.py:\d+ " +
+            r"_optimize INFO Env: Mock environment best score: 65.67\d+\s*$")
+
         with open(log_path, "rt", encoding="utf-8") as fh_out:
-            best_score_lines = [
-                ln.strip() for ln in fh_out.readlines()
-                if " INFO Env: Mock environment best score: " in ln
-            ]
-            assert len([
-                ln for ln in best_score_lines
-                if " best score: 65.67" in ln
-            ]) == 1
+            assert any(re_log.match(ln) for ln in fh_out)

--- a/mlos_bench/mlos_bench/tests/launcher_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_test.py
@@ -47,6 +47,9 @@ def _launch_main_app(root_path: str, local_exec_service: LocalExecService,
     """
     with local_exec_service.temp_dir_context() as temp_dir:
 
+        # Test developers note: for local debugging,
+        # uncomment the following line to use a known file path that can be examined:
+        # temp_dir = '/tmp'
         log_path = path_join(temp_dir, "mock-test.log")
         (return_code, _stdout, _stderr) = local_exec_service.local_exec(
             [f"./mlos_bench/mlos_bench/run.py {cli_config} --log_file '{log_path}'"],

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -124,6 +124,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
             random_design=random_design,
             config_selector=config_selector,
             overwrite=True,
+            logging_level=False,  # Use the existing logger
         )
 
     def __del__(self) -> None:


### PR DESCRIPTION
By default, SMAC overrides the logging configuration and that prevents mlos_bench from writhing to a log file in proper format. This PR fixes the issue and also adds a test configuration file to run the optimizer.

Closes #475 