### PR TITLE
Implement "read_telemetry_file" feature

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/environments/local/local-env-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/environments/local/local-env-subschema.json
@@ -25,6 +25,12 @@
                     "type": "string",
                     "$comment": "Currently we only support CSV files.",
                     "pattern": "[.]csv$"
+                },
+                "read_telemetry_file": {
+                    "description": "Path to a file to read the telemetry data from.",
+                    "type": "string",
+                    "$comment": "Currently we only support CSV files.",
+                    "pattern": "[.]csv$"
                 }
             }
         }

--- a/mlos_bench/mlos_bench/environments/README.md
+++ b/mlos_bench/mlos_bench/environments/README.md
@@ -7,7 +7,7 @@ An [`Environment`](./base_environment.py) is a class that represents a system th
 It is responsible for setting up the system, running the benchmark, and tearing down the system.
 Each `Environment` object also keeps track of the current state of the system, and can be used to query the system for metrics.
 
-Environments have [`Tunable`](../tunables/tunable.py) parameters and [`TunableGroups`](../tunables/tunable_groups.py) for controlling their configuration.
+Environments can have [`Tunable`](../tunables/tunable.py) parameters and [`TunableGroups`](../tunables/tunable_groups.py) for controlling their configuration.
 It is generally expected that all [`Tunable`](../tunables/tunable.py) parameters within an `Environment` will have the same cost to change.
 
 Common and platform-specific functionality of the environments is implemented in [`Service`](../services/) classes.

--- a/mlos_bench/mlos_bench/environments/README.md
+++ b/mlos_bench/mlos_bench/environments/README.md
@@ -20,7 +20,7 @@ Each Environment has several stages that it goes through:
 - `run`
 - `teardown`
 
-One cal also query the current state of the system via the `.status()` method.
+One can also query the current state of the system via the `.status()` method.
 Our current implementation of the `Environment` classes is synchronous; that means, a `.status()` method can only be used *after* `.run()` method has been called.
 
 Once we implement an asynchronous mode of operation, the `.status()` method will be usable at any time during the `Environment` object lifecycle.

--- a/mlos_bench/mlos_bench/environments/README.md
+++ b/mlos_bench/mlos_bench/environments/README.md
@@ -4,7 +4,8 @@
 
 This directory contains the code for the [`Environment`](./base_environment.py) classes used in the [`mlos_bench`](../../../mlos_bench/) benchmarking automation framework.
 An [`Environment`](./base_environment.py) is a class that represents a system that can be benchmarked.
-It is responsible for setting up the system, running the benchmark, and tearing down the system.
+It is responsible for setting up a portion of the system, running the benchmark (or some other command), and tearing down that portion of the system.
+A `CompositeEnvironment` can be used to stack these together to represent the entire system under evaluation (e.g., VM, OS, App, etc.)
 Each `Environment` object also keeps track of the current state of the system, and can be used to query the system for metrics.
 
 Environments can have [`Tunable`](../tunables/tunable.py) parameters and [`TunableGroups`](../tunables/tunable_groups.py) for controlling their configuration.

--- a/mlos_bench/mlos_bench/environments/README.md
+++ b/mlos_bench/mlos_bench/environments/README.md
@@ -10,6 +10,7 @@ Each `Environment` object also keeps track of the current state of the system, a
 
 Environments can have [`Tunable`](../tunables/tunable.py) parameters and [`TunableGroups`](../tunables/tunable_groups.py) for controlling their configuration.
 It is generally expected that all [`Tunable`](../tunables/tunable.py) parameters within an `Environment` will have the same cost to change.
+> It may therefore make sense to split a portion of the system logically across `Environments` (e.g., boot-time vs. runtime settings).
 
 Common and platform-specific functionality of the environments is implemented in [`Service`](../services/) classes.
 

--- a/mlos_bench/mlos_bench/environments/README.md
+++ b/mlos_bench/mlos_bench/environments/README.md
@@ -1,6 +1,18 @@
 # Environments
 
-This directory contains the code for the `Environments` used in the [`mlos_bench`](../../../mlos_bench/) benchmarking automation framework.
+## Overview
+
+This directory contains the code for the [`Environment`](./base_environment.py) classes used in the [`mlos_bench`](../../../mlos_bench/) benchmarking automation framework.
+An [`Environment`](./base_environment.py) is a class that represents a system that can be benchmarked.
+It is responsible for setting up the system, running the benchmark, and tearing down the system.
+Each `Environment` object also keeps track of the current state of the system, and can be used to query the system for metrics.
+
+Environments have [`Tunable`](../tunables/tunable.py) parameters and [`TunableGroups`](../tunables/tunable_groups.py) for controlling their configuration.
+It is generally expected that all [`Tunable`](../tunables/tunable.py) parameters within an `Environment` will have the same cost to change.
+
+Common and platform-specific functionality of the environments is implemented in [`Service`](../services/) classes.
+
+## Lifecycle
 
 Each Environment has several stages that it goes through:
 
@@ -8,13 +20,13 @@ Each Environment has several stages that it goes through:
 - `run`
 - `teardown`
 
-Which are implemented using [`Services`](../services/).
+One cal also query the current state of the system via the `.status()` method.
+Our current implementation of the `Environment` classes is synchronous; that means, a `.status()` method can only be used *after* `.run()` method has been called.
 
-Environments also have [`Tunables`](../tunables/) and [`TunableGroups`](../tunables/) for controlling their configuration.
+Once we implement an asynchronous mode of operation, the `.status()` method will be usable at any time during the `Environment` object lifecycle.
 
-Environments can also be stackable via the [`CompositeEnvironment`](./composite_env.py) class.
+## Composite Environments
 
+Environments can be stacked via the [`CompositeEnv`](./composite_env.py) class.
 For instance, a VM, OS, and Application Environment can be stacked together to form a full benchmarking environment, each with their own tunables.
-
-It is generally expected that all `Tunables` within an `Environment` will have the same cost to change.
-Thus one may represent a system by multiple `Environments` (e.g. `BootTimeEnvironment`, `RuntimeEnvironment`, etc.)
+Thus one may represent a system by multiple `Environment` objects, e.g., [`VMEnv`](./remote/vm_env.py), [`RemoteEnv`](remote/remote_env.py), and so on.

--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -295,8 +295,8 @@ class Environment(metaclass=abc.ABCMeta):
         _LOG.info("Setup %s :: %s", self, tunables)
         assert isinstance(tunables, TunableGroups)
 
-        # TODO: Make sure we create a context before invoking setup/run/status/teardown
-        # assert self._in_context
+        # Make sure we create a context before invoking setup/run/status/teardown
+        assert self._in_context
 
         # Assign new values to the environment's tunable parameters:
         groups = list(self._tunable_params.get_covariant_group_names())
@@ -329,8 +329,8 @@ class Environment(metaclass=abc.ABCMeta):
         single call.
         """
         _LOG.info("Teardown %s", self)
-        # TODO: Make sure we create a context before invoking setup/run/status/teardown
-        # assert self._in_context
+        # Make sure we create a context before invoking setup/run/status/teardown
+        assert self._in_context
         self._is_ready = False
 
     def run(self) -> Tuple[Status, Optional[dict]]:
@@ -361,8 +361,8 @@ class Environment(metaclass=abc.ABCMeta):
             A pair of (benchmark status, telemetry) values.
             `telemetry` is a list (maybe empty) of (timestamp, metric, value) triplets.
         """
-        # TODO: Make sure we create a context before invoking setup/run/status/teardown
-        # assert self._in_context
+        # Make sure we create a context before invoking setup/run/status/teardown
+        assert self._in_context
         if self._is_ready:
             return (Status.READY, [])
         _LOG.warning("Environment not ready: %s", self)

--- a/mlos_bench/mlos_bench/environments/composite_env.py
+++ b/mlos_bench/mlos_bench/environments/composite_env.py
@@ -203,7 +203,7 @@ class CompositeEnv(Environment):
             (status, metrics) = env_context.run()
             _LOG.debug("Child env. run results: %s :: %s %s", env_context, status, metrics)
             if not status.is_good():
-                _LOG.info("Run failed: %s :: %s %s", self, status)
+                _LOG.info("Run failed: %s :: %s", self, status)
                 return (status, None)
             joint_metrics.update(metrics or {})
 

--- a/mlos_bench/mlos_bench/environments/local/local_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_env.py
@@ -31,6 +31,7 @@ _LOG = logging.getLogger(__name__)
 
 
 class LocalEnv(ScriptEnv):
+    # pylint: disable=too-many-instance-attributes
     """
     Scheduler-side Environment that runs scripts locally.
     """
@@ -70,11 +71,13 @@ class LocalEnv(ScriptEnv):
         assert self._service is not None and isinstance(self._service, SupportsLocalExec), \
             "LocalEnv requires a service that supports local execution"
         self._local_exec_service: SupportsLocalExec = self._service
+
         self._temp_dir: Optional[str] = None
         self._temp_dir_context: Union[TemporaryDirectory, nullcontext, None] = None
 
         self._dump_params_file: Optional[str] = self.config.get("dump_params_file")
         self._dump_meta_file: Optional[str] = self.config.get("dump_meta_file")
+
         self._read_results_file: Optional[str] = self.config.get("read_results_file")
         self._read_telemetry_file: Optional[str] = self.config.get("read_telemetry_file")
 
@@ -202,7 +205,7 @@ class LocalEnv(ScriptEnv):
                 self._config_loader_service.resolve_path(
                     self._read_telemetry_file, extra_paths=[self._temp_dir]))
         except FileNotFoundError as ex:
-            _LOG.warning("Telemetry CSV file not found: %s", self._read_telemetry_file)
+            _LOG.warning("Telemetry CSV file not found: %s :: %s", self._read_telemetry_file, ex)
             return (status, [])
 
         _LOG.debug("Read telemetry data:\n%s", data)

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -154,7 +154,7 @@ def _run(env_context: Environment, opt: Optimizer,
 
     # In async mode (TODO), poll the environment for status and telemetry
     # and update the storage with the intermediate results.
-    (status, telemetry) = env_context.status()
+    (_status, telemetry) = env_context.status()
     trial.update_telemetry(status, telemetry)
 
     # FIXME: Use the actual timestamp from the benchmark.

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -145,13 +145,14 @@ def _run(env: Environment, opt: Optimizer,
             opt.register(trial.tunables, Status.FAILED)
             return
 
+        (status, results) = env_context.run()  # Block and wait for the final result.
+        _LOG.info("Results: %s :: %s\n%s", trial.tunables, status, results)
+
         # In async mode (TODO), poll the environment for status and telemetry
         # and update the storage with the intermediate results.
         (status, telemetry) = env_context.status()
         trial.update_telemetry(status, telemetry)
 
-        (status, results) = env_context.run()  # Block and wait for the final result.
-        _LOG.info("Results: %s :: %s\n%s", trial.tunables, status, results)
         # FIXME: Use the actual timestamp from the benchmark.
         trial.update(status, datetime.utcnow(), results)
         opt.register(trial.tunables, status, results)

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -154,7 +154,7 @@ def _run(env_context: Environment, opt: Optimizer,
 
     # In async mode (TODO), poll the environment for status and telemetry
     # and update the storage with the intermediate results.
-    (_status, telemetry) = env_context.status()
+    (_, telemetry) = env_context.status()
     trial.update_telemetry(status, telemetry)
 
     # FIXME: Use the actual timestamp from the benchmark.

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -155,6 +155,8 @@ def _run(env_context: Environment, opt: Optimizer,
     # In async mode (TODO), poll the environment for status and telemetry
     # and update the storage with the intermediate results.
     (_, telemetry) = env_context.status()
+    # Use the status from `.run()` as it is the final status of the experiment.
+    # TODO: Use the `.status()` output in async mode.
     trial.update_telemetry(status, telemetry)
 
     # FIXME: Use the actual timestamp from the benchmark.

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -306,4 +306,4 @@ class Storage(metaclass=ABCMeta):
             metrics : List[Tuple[datetime, str, Any]]
                 Telemetry data.
             """
-            _LOG.info("Store telemetry: %s :: %s %s", self, status, metrics)
+            _LOG.info("Store telemetry: %s :: %s %d records", self, status, len(metrics))

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_env-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_env-full.jsonc
@@ -26,9 +26,11 @@
             "/bin/bash -c true"
         ],
 
-        "read_results_file": "/tmp/results.csv",
         "dump_params_file": "/tmp/dump_params.json",
         "dump_meta_file": "/tmp/dump_params_meta.json",
+
+        "read_results_file": "/tmp/results.csv",
+        "read_telemetry_file": "/tmp/telemetry.csv",
 
         "shell_env_params_match": [
             "^MLOS_[a-zA-Z0-9_]+$"

--- a/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_fileshare_env-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/environments/test-cases/good/full/local_fileshare_env-full.jsonc
@@ -25,9 +25,13 @@
         "teardown": [
             "/bin/bash -c true"
         ],
-        "read_results_file": "/tmp/results.csv",
+
         "dump_params_file": "/tmp/dump_params.json",
         "dump_meta_file": "/tmp/dump_params_meta.json",
+
+        "read_results_file": "/tmp/results.csv",
+        "read_telemetry_file": "/tmp/telemetry.csv",
+
         "download": [
             {
                 "from": "https://some-host/some-path/some-file.tar.gz",


### PR DESCRIPTION
Summary of changes:
* Add `"read_telemetry_file"` parameter to `LocalEnv` implement the telemetry reading functionality
* Allow failures when downloading (intermediate) files in `LocalFileShareEnv`
* Translate Azure-specific exceptions in `AzureFileShareService` to the generic ones to keep Environment classes cloud-agnostic
* Bugfix: implement `CompositeEnv.status()` properly

**TODO:**
* [x] Fix the JSON schema to support `"read_telemetry_file"`