### PR TITLE
Smac optimizer bugfixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Unit Test",
+            "type": "python",
+            "request": "test",
+            "justMyCode": false
+        }
+    ]
+}

--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -63,11 +63,11 @@ class MlosCoreOptimizer(Optimizer):
             else:
                 _LOG.warning("SMAC optimizer output_directory was null. SMAC will use a temporary directory.")
 
-            # Set max_trials == max_iterations.
+            # Make sure max_trials >= max_iterations.
             if 'max_trials' not in self._config:
                 self._config['max_trials'] = self._max_iter
-            assert self._config.get('max_trials') == self._max_iter, \
-                f"max_trials {self._config.get('max_trials')} != max_iterations {self._max_iter}"
+            assert int(self._config['max_trials']) >= self._max_iter, \
+                f"max_trials {self._config.get('max_trials')} <= max_iterations {self._max_iter}"
 
             if 'run_name' not in self._config and self.experiment_id:
                 self._config['run_name'] = self.experiment_id

--- a/mlos_bench/mlos_bench/tests/optimizers/conftest.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/conftest.py
@@ -78,7 +78,7 @@ def flaml_opt(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
         config={
             "optimization_target": "score",
             "optimization_direction": "min",
-            "max_iterations": 5,
+            "max_iterations": 15,
             "optimizer_type": "FLAML",
             "seed": SEED,
         },
@@ -96,7 +96,7 @@ def flaml_opt_max(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
         config={
             "optimization_target": "score",
             "optimization_direction": "max",
-            "max_iterations": 5,
+            "max_iterations": 15,
             "optimizer_type": "FLAML",
             "seed": SEED,
         },

--- a/mlos_bench/mlos_bench/tests/optimizers/conftest.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/conftest.py
@@ -102,15 +102,13 @@ def flaml_opt_max(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
         },
     )
 
-# Note: SMAC's RF model can be non-deterministic at low iterations, which are
+# FIXME: SMAC's RF model can be non-deterministic at low iterations, which are
 # normally calculated as a percentage of the max_iterations and number of
-# tunable dimensions.
-# As a workaround we can either set the initial random samples equal to the
-# number of iterations and control them with a seed, or else increase the
-# number of samples a bit.
+# tunable dimensions, so for now we set the initial random samples equal to the
+# number of iterations and control them with a seed.
 
 
-SMAC_ITERATIONS = 30
+SMAC_ITERATIONS = 10
 
 
 @pytest.fixture
@@ -129,8 +127,8 @@ def smac_opt(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
             "seed": SEED,
             "output_directory": None,
             # See Above
-            # "n_random_init": SMAC_ITERATIONS,
-            # "max_ratio": 1.0,
+            "n_random_init": SMAC_ITERATIONS,
+            "max_ratio": 1.0,
         },
     )
 
@@ -151,7 +149,7 @@ def smac_opt_max(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
             "seed": SEED,
             "output_directory": None,
             # See Above
-            # "n_random_init": SMAC_ITERATIONS,
-            # "max_ratio": 1.0,
+            "n_random_init": SMAC_ITERATIONS,
+            "max_ratio": 1.0,
         },
     )

--- a/mlos_bench/mlos_bench/tests/optimizers/conftest.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/conftest.py
@@ -102,13 +102,15 @@ def flaml_opt_max(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
         },
     )
 
-# FIXME: SMAC's RF model can be non-deterministic at low iterations, which are
+# Note: SMAC's RF model can be non-deterministic at low iterations, which are
 # normally calculated as a percentage of the max_iterations and number of
-# tunable dimensions, so for now we set the initial random samples equal to the
-# number of iterations and control them with a seed.
+# tunable dimensions.
+# As a workaround we can either set the initial random samples equal to the
+# number of iterations and control them with a seed, or else increase the
+# number of samples a bit.
 
 
-SMAC_ITERATIONS = 10
+SMAC_ITERATIONS = 30
 
 
 @pytest.fixture
@@ -127,8 +129,8 @@ def smac_opt(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
             "seed": SEED,
             "output_directory": None,
             # See Above
-            "n_random_init": SMAC_ITERATIONS,
-            "max_ratio": 1.0,
+            # "n_random_init": SMAC_ITERATIONS,
+            # "max_ratio": 1.0,
         },
     )
 
@@ -149,7 +151,7 @@ def smac_opt_max(tunable_groups: TunableGroups) -> MlosCoreOptimizer:
             "seed": SEED,
             "output_directory": None,
             # See Above
-            "n_random_init": SMAC_ITERATIONS,
-            "max_ratio": 1.0,
+            # "n_random_init": SMAC_ITERATIONS,
+            # "max_ratio": 1.0,
         },
     )

--- a/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
@@ -106,12 +106,12 @@ def test_flaml_optimization_loop(mock_env_no_noise: MockEnv,
     Toy optimization loop with mock environment and FLAML optimizer.
     """
     (score, tunables) = _optimize(mock_env_no_noise, flaml_opt)
-    assert score == pytest.approx(75.0, 0.01)
+    assert score == pytest.approx(60.15, 0.01)
     assert tunables.get_param_values() == {
-        "vmSize": "Standard_B4ms",
+        "vmSize": "Standard_B2s",
         "idle": "halt",
-        "kernel_sched_migration_cost_ns": -1,
-        "kernel_sched_latency_ns": 2000000,
+        "kernel_sched_migration_cost_ns": 50132,
+        "kernel_sched_latency_ns": 22674895,
     }
 
 

--- a/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
@@ -9,9 +9,7 @@ Toy optimization loop to test the optimizers on mock benchmark environment.
 from typing import Tuple
 
 import logging
-import sys
 
-import numpy as np
 import pytest
 
 from mlos_core import config_to_dataframe
@@ -25,7 +23,6 @@ from mlos_bench.optimizers.base_optimizer import Optimizer
 from mlos_bench.optimizers.mock_optimizer import MockOptimizer
 from mlos_bench.optimizers.mlos_core_optimizer import MlosCoreOptimizer
 
-from mlos_bench.tests import SEED
 
 # For debugging purposes output some warnings which are captured with failed tests.
 DEBUG = True
@@ -124,24 +121,13 @@ def test_smac_optimization_loop(mock_env_no_noise: MockEnv,
     """
     Toy optimization loop with mock environment and SMAC optimizer.
     """
-    np.random.seed(SEED)
     (score, tunables) = _optimize(mock_env_no_noise, smac_opt)
-    # FIXME: For some reason the optimizer is not deterministic across platforms.
-    if sys.platform == "win32":
-        expected_score = 60.00
-        expected_tunable_values = {
-            "vmSize": "Standard_B2s",
-            "idle": "halt",
-            "kernel_sched_migration_cost_ns": 2633,
-            "kernel_sched_latency_ns": 379297,
-        }
-    else:
-        expected_score = 65.10
-        expected_tunable_values = {
-            "vmSize": "Standard_B2s",
-            "idle": "halt",
-            "kernel_sched_migration_cost_ns": 274881,
-            "kernel_sched_latency_ns": 194964253,
-        }
+    expected_score = 73.59
+    expected_tunable_values = {
+        "vmSize": "Standard_B2s",
+        "idle": "mwait",
+        "kernel_sched_migration_cost_ns": 319025,
+        "kernel_sched_latency_ns": 499339615,
+    }
     assert score == pytest.approx(expected_score, 0.01)
     assert tunables.get_param_values() == expected_tunable_values

--- a/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
+++ b/mlos_bench/mlos_bench/tests/optimizers/toy_optimization_loop_test.py
@@ -122,12 +122,12 @@ def test_smac_optimization_loop(mock_env_no_noise: MockEnv,
     Toy optimization loop with mock environment and SMAC optimizer.
     """
     (score, tunables) = _optimize(mock_env_no_noise, smac_opt)
-    expected_score = 65.24
+    expected_score = 65.10
     expected_tunable_values = {
-        "vmSize": "Standard_B2ms",
+        "vmSize": "Standard_B2s",
         "idle": "halt",
-        "kernel_sched_migration_cost_ns": 132525,
-        "kernel_sched_latency_ns": 172229834,
+        "kernel_sched_migration_cost_ns": 274881,
+        "kernel_sched_latency_ns": 194964253,
     }
     assert score == pytest.approx(expected_score, 0.01)
     assert tunables.get_param_values() == expected_tunable_values

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -241,22 +241,12 @@ class SmacOptimizer(BaseBayesianOptimizer):
         if context is not None:
             raise NotImplementedError()
 
-        for i in range(2):
-            try:
-                trial: TrialInfo = self.base_optimizer.ask()
-                trial.config.is_valid_configuration()
-                self.optimizer_parameter_space.check_configuration(trial.config)
-                assert trial.config.config_space == self.optimizer_parameter_space
-                self.trial_info_map[trial.config] = trial
-                config_df = pd.DataFrame([trial.config], columns=list(self.optimizer_parameter_space.keys()))
-                if config_df.isnull().values.any():
-                    raise RuntimeError('SMAC optimizer returned a NaN configuration')
-            except (RuntimeError, IndexError, ValueError) as ex:
-                if i:   # only support one retry attempt
-                    raise ex
-                # else
-                warning('SMAC optimizer returned a bad configuration. Retrying...\n%s\n%s', ex, config_df)
-                # TODO: retrain model?
+        trial: TrialInfo = self.base_optimizer.ask()
+        trial.config.is_valid_configuration()
+        self.optimizer_parameter_space.check_configuration(trial.config)
+        assert trial.config.config_space == self.optimizer_parameter_space
+        self.trial_info_map[trial.config] = trial
+        config_df = pd.DataFrame([trial.config], columns=list(self.optimizer_parameter_space.keys()))
         return config_df
 
     def register_pending(self, configurations: pd.DataFrame, context: Optional[pd.DataFrame] = None) -> None:

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -49,7 +49,10 @@ class SmacOptimizer(BaseBayesianOptimizer):
 
     n_random_init : Optional[int]
         Number of points evaluated at start to bootstrap the optimizer.
-        Default depends on max_trials and number of parameters.
+        Default depends on max_trials and number of parameters and max_ratio.
+        Note: it can sometimes be useful to set this to 1 when pre-warming the
+        optimizer from historical data.
+        See Also: mlos_bench.optimizer.bulk_register
 
     max_ratio : Optional[int]
         Maximum ratio of max_trials to be random configurations to be evaluated
@@ -186,6 +189,22 @@ class SmacOptimizer(BaseBayesianOptimizer):
     def __del__(self) -> None:
         # Best-effort attempt to clean up, in case the user forgets to call .cleanup()
         self.cleanup()
+
+    @property
+    def n_random_init(self) -> int:
+        """
+        Gets the number of random samples to use to initialize the optimizer's search space sampling.
+
+        Note: This may not be equal to the value passed to the initializer, due to logic present in the SMAC.
+        See Also: max_ratio
+
+        Returns
+        -------
+        int
+            The number of random samples used to initialize the optimizer's search space sampling.
+        """
+        # pylint: disable=protected-access
+        return self.base_optimizer._initial_design._n_configs
 
     @staticmethod
     def _dummy_target_func(config: ConfigSpace.Configuration, seed: int = 0) -> None:

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -48,7 +48,8 @@ class SmacOptimizer(BaseBayesianOptimizer):
         Note that modifying this value directly affects the value of `n_random_init`, if latter is set to `None`.
 
     n_random_init : Optional[int]
-        Number of points evaluated at start to bootstrap the optimizer. Defaults to 10.
+        Number of points evaluated at start to bootstrap the optimizer.
+        Default depends on max_trials and number of parameters.
 
     max_ratio : Optional[int]
         Maximum ratio of max_trials to be random configurations to be evaluated
@@ -57,7 +58,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
         configurations evaluated at start.
 
     use_default_config: bool
-        Whether to use the default config for the first trial.
+        Whether to use the default config for the first trial after random initialization.
 
     n_random_probability: float
         Probability of choosing to evaluate a random configuration during optimization.
@@ -131,6 +132,10 @@ class SmacOptimizer(BaseBayesianOptimizer):
         # TODO: When bulk registering prior configs to rewarm the optimizer,
         # there is a way to inform SMAC's initial design that we have
         # additional_configs and can set n_configs == 0.
+        # Additionally, we may want to consider encoding those values into the
+        # runhistory when prewarming the optimizer so that the initial design
+        # doesn't reperform random init.
+        # See Also: #488
 
         initial_design_args: Dict[str, Union[list, int, float, Scenario]] = {
             'scenario': scenario,

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -126,7 +126,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
             n_workers=1,  # Use a single thread for evaluating trials
         )
         intensifier: AbstractIntensifier = Optimizer_Smac.get_intensifier(scenario, max_config_calls=1)
-        config_selector: ConfigSelector = ConfigSelector(scenario, retrain_after=1)
+        config_selector: ConfigSelector = Optimizer_Smac.get_config_selector(scenario, retrain_after=1)
 
         # TODO: When bulk registering prior configs to rewarm the optimizer,
         # there is a way to inform SMAC's initial design that we have
@@ -155,7 +155,10 @@ class SmacOptimizer(BaseBayesianOptimizer):
                 assert isinstance(max_ratio, float) and 0.0 <= max_ratio <= 1.0
                 initial_design_args['max_ratio'] = max_ratio
 
-            initial_design = LatinHypercubeInitialDesign(**initial_design_args)  # type: ignore[arg-type]
+        # Use the default InitialDesign from SMAC.
+        # (currently SBOL instead of LatinHypercube due to better uniformity
+        # for initial sampling which results in lower overall samples required)
+        initial_design = Optimizer_Smac.get_initial_design(**initial_design_args)  # type: ignore[arg-type]
 
         # Workaround a bug in SMAC that doesn't pass the seed to the random
         # design when generated a random_design for itself via the

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -159,6 +159,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
         # (currently SBOL instead of LatinHypercube due to better uniformity
         # for initial sampling which results in lower overall samples required)
         initial_design = Optimizer_Smac.get_initial_design(**initial_design_args)  # type: ignore[arg-type]
+        # initial_design = LatinHypercubeInitialDesign(**initial_design_args)  # type: ignore[arg-type]
 
         # Workaround a bug in SMAC that doesn't pass the seed to the random
         # design when generated a random_design for itself via the

--- a/mlos_core/mlos_core/optimizers/optimizer.py
+++ b/mlos_core/mlos_core/optimizers/optimizer.py
@@ -49,7 +49,7 @@ class BaseOptimizer(metaclass=ABCMeta):
         self._pending_observations: List[Tuple[pd.DataFrame, Optional[pd.DataFrame]]] = []
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(parameter_space={self.parameter_space})"
+        return f"{self.__class__.__name__}(space_adapter={self.space_adapter})"
 
     @property
     def space_adapter(self) -> Optional[BaseSpaceAdapter]:

--- a/mlos_core/mlos_core/optimizers/optimizer.py
+++ b/mlos_core/mlos_core/optimizers/optimizer.py
@@ -76,14 +76,14 @@ class BaseOptimizer(metaclass=ABCMeta):
         assert len(configurations) == len(scores), "Mismatched number of configurations and scores."
         if context:
             assert len(configurations) == len(context), "Mismatched number of configurations and context."
-        assert configurations.shape[1] == len(self.parameter_space.get_hyperparameters())
+        assert configurations.shape[1] == len(self.parameter_space.values())
         self._observations.append((configurations, scores, context))
         if context:
             self._has_context = True
 
         if self._space_adapter:
             configurations = self._space_adapter.inverse_transform(configurations)
-            assert configurations.shape[1] == len(self.optimizer_parameter_space.get_hyperparameters())
+            assert configurations.shape[1] == len(self.optimizer_parameter_space.values())
         return self._register(configurations, scores, context)
 
     @abstractmethod
@@ -127,11 +127,11 @@ class BaseOptimizer(metaclass=ABCMeta):
         else:
             configuration = self._suggest(context)
             assert len(configuration) == 1, "Suggest must return a single configuration."
-            assert len(configuration.columns) == len(self.optimizer_parameter_space.get_hyperparameters()), \
+            assert len(configuration.columns) == len(self.optimizer_parameter_space.values()), \
                 "Suggest returned a configuration with the wrong number of parameters."
         if self._space_adapter:
             configuration = self._space_adapter.transform(configuration)
-            assert len(configuration.columns) == len(self.parameter_space.get_hyperparameters()), \
+            assert len(configuration.columns) == len(self.parameter_space.values()), \
                 "Space adapter transformed configuration with the wrong number of parameters."
         return configuration
 

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -244,9 +244,9 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     for i in range(num_iters):
         # Place to set a breakpoint for when the optimizer is done with random init.
         if llamatune_n_random_init and i > llamatune_n_random_init:
-            print("LlamaTuned Optimizer is done with random init.")
+            _LOG.debug("LlamaTuned Optimizer is done with random init.")
         if opt_n_random_init and i >= opt_n_random_init:
-            print("Optimizer is done with random init.")
+            _LOG.debug("Optimizer is done with random init.")
 
         # loop for optimizer
         suggestion = optimizer.suggest()

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -238,9 +238,8 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     if optimizer_type == OptimizerType.SMAC:
         assert isinstance(optimizer, SmacOptimizer)
         assert isinstance(llamatune_optimizer, SmacOptimizer)
-        # pylint: disable=protected-access
-        opt_n_random_init = optimizer.base_optimizer._initial_design._n_configs
-        llamatune_n_random_init = llamatune_optimizer.base_optimizer._initial_design._n_configs
+        opt_n_random_init = optimizer.n_random_init
+        llamatune_n_random_init = llamatune_optimizer.n_random_init
 
     for i in range(num_iters):
         # Place to set a breakpoint for when the optimizer is done with random init.

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -244,7 +244,7 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
 
     for i in range(num_iters):
         # Place to set a breakpoint for when the optimizer is done with random init.
-        if llamatune_n_random_init and i + 1 >= llamatune_n_random_init:
+        if llamatune_n_random_init and i > llamatune_n_random_init:
             print("LlamaTuned Optimizer is done with random init.")
         if opt_n_random_init and i >= opt_n_random_init:
             print("Optimizer is done with random init.")

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -182,7 +182,7 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     # pylint: disable=too-complex
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-locals
-    num_iters = 50
+    num_iters = 65
     if kwargs is None:
         kwargs = {}
 

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -182,7 +182,7 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     # pylint: disable=too-complex
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-locals
-    num_iters = 75
+    num_iters = 50
     if kwargs is None:
         kwargs = {}
 
@@ -216,18 +216,18 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     #    optimizer_kwargs['n_random_init'] = 20
     #    llamatune_optimizer_kwargs['n_random_init'] = 10
 
-    # Initialize an optimizer that uses the original space
-    optimizer: BaseOptimizer = OptimizerFactory.create(
-        parameter_space=input_space,
-        optimizer_type=optimizer_type,
-        optimizer_kwargs=optimizer_kwargs,
-    )
     llamatune_optimizer: BaseOptimizer = OptimizerFactory.create(
         parameter_space=input_space,
         optimizer_type=optimizer_type,
         optimizer_kwargs=llamatune_optimizer_kwargs,
         space_adapter_type=SpaceAdapterType.LLAMATUNE,
         space_adapter_kwargs=space_adapter_kwargs,
+    )
+    # Initialize an optimizer that uses the original space
+    optimizer: BaseOptimizer = OptimizerFactory.create(
+        parameter_space=input_space,
+        optimizer_type=optimizer_type,
+        optimizer_kwargs=optimizer_kwargs,
     )
     assert optimizer is not None
     assert llamatune_optimizer is not None

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -171,10 +171,8 @@ def test_create_optimizer_with_factory_method(configuration_space: CS.Configurat
     # *[(member, {}) for member in OptimizerType],
     # Optimizer with non-empty kwargs argument
     (OptimizerType.SMAC, {
+        # Test with default config.
         'use_default_config': True,
-        # 'max_trials': 100,
-        # 'n_random_init': 5,
-        'max_ratio': 1.0
     }),
 ])
 def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optional[dict]) -> None:
@@ -185,9 +183,6 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     num_iters = 20
     if kwargs is None:
         kwargs = {}
-    max_trials = kwargs.get('max_trials')
-    if max_trials and False:
-        num_iters = max_trials
 
     def objective(point: pd.DataFrame) -> pd.Series:
         # Best value can be reached by tuning an 1-dimensional search space
@@ -206,17 +201,19 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
         "special_param_values": None,
         "max_unique_values_per_param": None,
     }
-    # FIXME: Somewhere in here is where the problem is - the two optimizers are
-    # not independent unless we set the n_random_init value similarly for some
-    # reason.
-    if optimizer_type == OptimizerType.SMAC:
-        # Allow us to override the number of random init samples.
-        kwargs['max_ratio'] = 1.0
+
+    # Make some adjustments to the kwargs for the optimizer and LlamaTuned
+    # optimizer for debug/testing.
+
+    # if optimizer_type == OptimizerType.SMAC:
+    #    # Allow us to override the number of random init samples.
+    #    kwargs['max_ratio'] = 1.0
     optimizer_kwargs = deepcopy(kwargs)
     llamatune_optimizer_kwargs = deepcopy(kwargs)
-    if optimizer_type == OptimizerType.SMAC:
-        optimizer_kwargs['n_random_init'] = 10
-        llamatune_optimizer_kwargs['n_random_init'] = 10
+    # if optimizer_type == OptimizerType.SMAC:
+    #    optimizer_kwargs['n_random_init'] = 20
+    #    llamatune_optimizer_kwargs['n_random_init'] = 10
+
     # Initialize an optimizer that uses the original space
     optimizer: BaseOptimizer = OptimizerFactory.create(
         parameter_space=input_space,

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -7,7 +7,6 @@ Tests for Bayesian Optimizers.
 """
 
 from copy import deepcopy
-from logging import warning
 from typing import List, Optional, Type
 
 import logging
@@ -173,6 +172,7 @@ def test_create_optimizer_with_factory_method(configuration_space: CS.Configurat
     (OptimizerType.SMAC, {
         # Test with default config.
         'use_default_config': True,
+        # 'n_random_init': 10,
     }),
 ])
 def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optional[dict]) -> None:
@@ -243,10 +243,6 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
         # pylint: disable=protected-access
         opt_n_random_init = optimizer.base_optimizer._initial_design._n_configs
         llamatune_n_random_init = llamatune_optimizer.base_optimizer._initial_design._n_configs
-    if opt_n_random_init != llamatune_n_random_init:
-        warning("Optimizer (%d) and LlamaTuned Optimizer (%d) have different n_random_init values. " +
-                "This has caused problems in some cases.",
-                opt_n_random_init, llamatune_n_random_init)
 
     for i in range(num_iters):
         # Place to set a breakpoint for when the optimizer is done with random init.

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -179,6 +179,8 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     """
     Toy problem to test the optimizers with llamatune space adapter.
     """
+    # pylint: disable=too-complex
+    # pylint: disable=too-many-statements
     # pylint: disable=too-many-locals
     num_iters = 50
     if kwargs is None:

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -168,7 +168,7 @@ def test_create_optimizer_with_factory_method(configuration_space: CS.Configurat
 
 @pytest.mark.parametrize(('optimizer_type', 'kwargs'), [
     # Enumerate all supported Optimizers
-    # *[(member, {}) for member in OptimizerType],
+    *[(member, {}) for member in OptimizerType],
     # Optimizer with non-empty kwargs argument
     (OptimizerType.SMAC, {
         # Test with default config.
@@ -180,7 +180,7 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     Toy problem to test the optimizers with llamatune space adapter.
     """
     # pylint: disable=too-many-locals
-    num_iters = 20
+    num_iters = 50
     if kwargs is None:
         kwargs = {}
 

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -182,7 +182,7 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     # pylint: disable=too-complex
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-locals
-    num_iters = 65
+    num_iters = 75
     if kwargs is None:
         kwargs = {}
 

--- a/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/optimizer_test.py
@@ -233,10 +233,8 @@ def test_optimizer_with_llamatune(optimizer_type: OptimizerType, kwargs: Optiona
     assert llamatune_optimizer is not None
     assert optimizer.optimizer_parameter_space != llamatune_optimizer.optimizer_parameter_space
 
-    opt_n_random_init = 0
     llamatune_n_random_init = 0
-    if 'n_random_init' in kwargs:
-        opt_n_random_init = int(kwargs['n_random_init'])
+    opt_n_random_init = int(kwargs.get('n_random_init', 0))
     if optimizer_type == OptimizerType.SMAC:
         assert isinstance(optimizer, SmacOptimizer)
         assert isinstance(llamatune_optimizer, SmacOptimizer)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ minversion = 7.1
 # Run all tests to completion on multiple processes.
 # Run failed and new tests first by default.
 addopts =
+    -vv
     -svl --ff --nf
     -n auto
 # Moved these to Makefile (coverage is expensive and we only need it in the pipelines generally).


### PR DESCRIPTION
- Workaround a bug in SMAC that builds additional_configs across instantiations.
  - [ ] Look for more of these cases (maybe that's where the non-determinism is coming from?)
  - [x] Report it upstream: https://github.com/automl/SMAC3/pull/1067
- Adds more assertions to help check for related issues
- Addresses a TODO sanity check
- Adds some test code for FLAML's surrogate model by increasing iterations
- Updates tests for easier tracing

Note: This still doesn't address all of the non-determinism across platforms/python versions we've noticed recently (#482), and there's some question yet about how much runhistory and some other features are being handled correctly, but this still handles a few small improvements of other issues I've noticed.
For the rest I've filed issues: 
- #487  
- #488 