### PR TITLE
Switch back to FLAML as the default optimizer

### DIFF
--- a/mlos_core/mlos_core/optimizers/__init__.py
+++ b/mlos_core/mlos_core/optimizers/__init__.py
@@ -51,7 +51,7 @@ ConcreteOptimizer = TypeVar(
     SmacOptimizer,
 )
 
-DEFAULT_OPTIMIZER_TYPE = OptimizerType.SMAC
+DEFAULT_OPTIMIZER_TYPE = OptimizerType.FLAML
 
 
 class OptimizerFactory:


### PR DESCRIPTION
We've found that SMAC has some non-determinism and incomplete integration, which causes some issues with our pipelines and experiment results, so for now we switch back to FLAML as the default.