### PR TITLE
Expand dollar variables in the globals

### DIFF
--- a/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
+++ b/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
@@ -2,8 +2,8 @@
     "experiment_id": "RedisBench",
     "trial_id": 1,
 
-    // TODO: Generate these names from $experiment_id
-    "deploymentName": "RedisBench",
+    // Any global parameter can be used as a dollar variable in the global config:
+    "deploymentName": "$experiment_id",
     "vmName": "os-autotune-linux-vm",
 
     "resourceGroup": "os-autotune",

--- a/mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc
@@ -18,10 +18,7 @@
         "tunable-values/tunable-values-example.jsonc"
     ],
 
-    // "globals": ["global_config.json"],
-
-    "experiment_id": "MockExperiment",
-    "trial_id": 1,
+    "globals": ["globals/global_test_config.jsonc"],
 
     "teardown": true,
 

--- a/mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc
@@ -18,9 +18,6 @@
 
     "globals": ["globals/global_test_config.jsonc"],
 
-    "experiment_id": "MockExperiment",
-    "trial_id": 1,
-
     "teardown": true,
 
     // "log_file": "mock-opt.log",

--- a/mlos_bench/mlos_bench/tests/config/globals/global_test_config.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/globals/global_test_config.jsonc
@@ -1,5 +1,14 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+// *** DO *NOT* CHANGE! This config is used for tests! ***
 {
-    // override the default value of the "max_iterations" parameter for the
-    // optimizer when running local tests
+    "experiment_id": "MockExperiment",
+    "trial_id": 1,
+
+    // Override the default value of the "max_iterations" parameter
+    // of the optimizer when running local tests:
     "max_iterations": 5
 }


### PR DESCRIPTION
This feature greatly simplifies our configs for complex multi-VM setups.

P.S. I cannot come up with any simple and elegant unit tests for this feature. Technically, we can define some dollar variables in `global_test_config.jsonc` and check their values in the log in `launcher_test.py`, but we don't have that many parameters in `MockEnv` and `MockOptimizer` that we can expand. I'll think about it and do it in the next PR.