### PR TITLE
Support customData file to pass to ARM templates

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -60,6 +60,15 @@
                                 }
                             },
                             "minProperties": 1
+                        },
+                        "customDataFile": {
+                            "description": "Path to a custom data file whose contents should be base64 encoded and passed to the VM template as customDataBase64 in the template parameters.",
+                            "type": "string",
+                            "examples": [
+                                "customData.txt",
+                                "cloud-init.config.yml",
+                                "cloud-init.script.sh"
+                            ]
                         }
                     },
                     "required": [

--- a/mlos_bench/mlos_bench/config/services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc
@@ -20,6 +20,13 @@
         "description": "OS Autotune Linux VM"
       }
     },
+    "customData": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Custom data for the VM (e.g., for cloud-init)."
+      },
+    },
     "vmPorts": {
       "type": "array",
       "defaultValue": [
@@ -207,6 +214,7 @@
         },
         "osProfile": {
           "computerName": "[parameters('vmName')]",
+          "customData": "[base64(parameters('customData'))]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPasswordOrKey')]",
           "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), null(), variables('linuxConfiguration'))]"

--- a/mlos_bench/mlos_bench/config/services/remote/azure/cloud-init/alt-ssh.yml
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/cloud-init/alt-ssh.yml
@@ -1,0 +1,13 @@
+#cloud-config
+package_upgrade: true
+packages:
+  - openssh-server
+write_files:
+  # Instruct SSH to listen on additional alternative port.
+  - owner: root:root
+    path: /etc/ssh/sshd_config.d/99-ssh-ports.conf
+    content: |
+      Port 22
+      Port 2222
+runcmd:
+  - service ssh restart

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -10,6 +10,7 @@ import json
 import time
 import logging
 
+from base64 import b64encode
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 import requests
@@ -158,6 +159,16 @@ class AzureVMService(Service, SupportsVMOps, SupportsRemoteExec):
 
         self._deploy_params = merge_parameters(
             dest=self.config['deploymentTemplateParameters'].copy(), source=global_config)
+
+        self._custom_data_file = self.config.get("customDataFile", None)
+        self._custom_data_base64_str = None
+        if self._custom_data_file is not None:
+            self._custom_data_file = self.config_loader_service.resolve_path(self._custom_data_file)
+            with open(self._custom_data_file, "r", encoding='utf-8') as f:
+                self._custom_data_base64_str = ''
+                while buf := f.read():
+                    self._custom_data_base64_str += b64encode(buf.encode()).decode()
+        self._deploy_params["customDataBase64"] = self._custom_data_base64_str
 
     def _get_headers(self) -> dict:
         """

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -9,6 +9,7 @@
         "resourceGroup": "rg",
         "deploymentName": "deployment",
 
+        "customDataPath": "some/path/to/custom/data.yml",
         "deploymentTemplateParameters": {
             "location": "westus2",
             "adminUsername": "admin",

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -9,7 +9,7 @@
         "resourceGroup": "rg",
         "deploymentName": "deployment",
 
-        "customDataPath": "some/path/to/custom/data.yml",
+        "customDataFile": "some/path/to/custom/data.yml",
         "deploymentTemplateParameters": {
             "location": "westus2",
             "adminUsername": "admin",

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -45,6 +45,7 @@ def test_azure_vm_service_custom_data(azure_auth_service: AzureAuthService) -> N
     # pylint: disable=protected-access
     assert azure_vm_service._deploy_params['customData']
 
+
 @pytest.mark.parametrize(
     ("operation_name", "accepts_params"), [
         ("vm_start", True),


### PR DESCRIPTION
Adds support to allow reading `customData` out of a file to pass to the ARM templates.
This way we can code `cloud-init` files (for example) separately with all the usual syntax help, rather than embed them in JSON configs.