### PR TITLE
Workaround a devcontainer uid/gid conflict in the Github CI pipelines

### DIFF
--- a/.devcontainer/build/Dockerfile
+++ b/.devcontainer/build/Dockerfile
@@ -34,8 +34,8 @@ RUN npm install -g markdown-link-check
 ARG NODE_UID=1000
 ARG NODE_GID=1000
 ARG DOCKER_GID=999
-RUN groupmod --gid $NODE_GID node \
-    && usermod --uid $NODE_UID --gid $NODE_GID node \
+RUN groupmod --non-unique --gid $NODE_GID node \
+    && usermod --non-unique --uid $NODE_UID --gid $NODE_GID node \
     && chown -R $NODE_UID:$NODE_GID /home/node \
     && groupadd --non-unique --gid $DOCKER_GID docker \
     && adduser node docker

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -60,8 +60,8 @@ jobs:
       timeout-minutes: 3
       run: |
         set -x
-        docker exec --user root mlos-devcontainer groupmod -g `id -g` vscode
-        docker exec --user root mlos-devcontainer usermod -u `id -u` -g `id -g` vscode
+        docker exec --user root mlos-devcontainer groupmod --non-unique -g `id -g` vscode
+        docker exec --user root mlos-devcontainer usermod --non-unique -u `id -u` -g `id -g` vscode
         docker exec --user root mlos-devcontainer chown -R vscode:vscode /home/vscode
         docker exec --user root mlos-devcontainer mkdir -p /opt/conda/pkgs/cache /var/cache/pip
         docker exec --user root mlos-devcontainer chown -R vscode /opt/conda/pkgs/cache /var/cache/pip


### PR DESCRIPTION
Something changed in the baseimage and now the uid/gid that the github runners use already exists in the base image of the devcontainer-cli.
To workaround that we just allow for `--non-unique`ness