### PR TITLE
Workaround an upstream conda vs. base devcontainer image dependency mismatches

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,11 +36,17 @@ RUN mkdir -p ${CONDA_PKGS_DIRS} \
 
 USER vscode
 
+# Upgrade conda and use strict priorities
 # Use the mamba solver (necessary for some quality of life speedups due to
 # required packages to support Windows)
 RUN umask 0002 \
+    && /opt/conda/bin/conda config --set channel_priority strict \
+    && /opt/conda/bin/conda info \
+    && /opt/conda/bin/conda update -v -y -n base -c defaults --all \
+    && /opt/conda/bin/conda list -n base \
     && /opt/conda/bin/conda install -v -y -n base conda-libmamba-solver \
-    && /opt/conda/bin/conda config --set solver libmamba
+    && /opt/conda/bin/conda config --set solver libmamba \
+    && /opt/conda/bin/conda list -n base
 
 # Update the base. This helps save space by making sure the same version
 # python is used for both the base env and mlos env.


### PR DESCRIPTION
Also brings devcontainer inline with rules for Linux Github Actions and adds some debugging output for future.

Addresses NO_CACHE build issues that were failing in local rebuilds and nightly scheduled actions.