### PR TITLE
CI fixups

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,7 +31,8 @@ jobs:
       id: get-commit-messages
       run: |
         # Only look at the last 10 commits, to avoid getting too much data.
-        git log --format="%B" -10 ${{ github.event.before }}..${{ github.event.after }} > /tmp/commit_messages.txt
+        git fetch --deepen=50
+        git log --format="%B" -10 ${{ github.event.before }}..${{ github.event.after }} > /tmp/commit_messages.txt || true
         echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
 
     - name: Set NO_CACHE variable based on commit messages and for nightly builds

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -33,7 +33,7 @@ jobs:
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
     - name: Set NO_CACHE variable based on commit message
-      if: contains(github.event.commits.message, 'NO_CACHE=true')
+      if: contains(github.event.commits[0].message, 'NO_CACHE=true')
       run: |
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
@@ -42,10 +42,10 @@ jobs:
         set -x
         printenv
         echo "NO_CACHE: ${NO_CACHE:-}"
-        echo "commit messages: ${{ github.event.commits.message }}"
+        echo "commit messages: ${{ github.event.commits[0].message }}"
         echo "COMMIT_SHA: ${{ github.sha }}"
         echo "git log: $(git log -1 ${{ github.sha }})"
-        echo "COMMIT_MESSAGE: ${{ github.event.head_commit.message }}"
+        echo "COMMIT_MESSAGE: ${{ github.event.commits[0].message }}"
 
     - name: Build the devcontainer image
       timeout-minutes: 15

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,7 +31,7 @@ jobs:
       id: get-commit-messages
       run: |
         # Only look at the last 10 commits, to avoid getting too much data.
-        git log --format "%B" -10 ${{ github.event.before }}...${{ github.sha }} > /tmp/commit_messages.txt
+        git log --format="%B" -10 ${{ github.event.before }}...${{ github.sha }} > /tmp/commit_messages.txt
         echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
 
     - name: Set NO_CACHE variable based on commit messages and for nightly builds

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -27,13 +27,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set NO_CACHE variable for nightly builds
-      if: github.event_name == 'schedule'
+    - name: Get commit messages
+      id: get-commit-messages
       run: |
-        echo "NO_CACHE=true" >> $GITHUB_ENV
+        # Only look at the last 10 commits, to avoid getting too much data.
+        git log --format "%B" -10 ${{ github.event.before }}...${{ github.sha }} > /tmp/commit_messages.txt
+        echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
 
-    - name: Set NO_CACHE variable based on commit message
-      if: contains(github.event.commits[0].message, 'NO_CACHE=true')
+    - name: Set NO_CACHE variable based on commit messages and for nightly builds
+      if: github.event_name == 'schedule' || contains(steps.get-commit-messages.outputs.COMMIT_MESSAGES, 'NO_CACHE=true')
       run: |
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
@@ -42,11 +44,11 @@ jobs:
         set -x
         printenv
         echo "NO_CACHE: ${NO_CACHE:-}"
-        echo "commit messages: ${{ github.event.commits[0].message }}"
+        echo "COMMIT_MESSAGES: ${COMMIT_MESSAGES:-}"
         echo "COMMIT_SHA: ${{ github.sha }}"
-        echo "git log: $(git log -1 ${{ github.sha }})"
-        echo "COMMIT_MESSAGE: ${{ github.event.commits[0].message }}"
-        cat ${{ github.event_path }}
+        echo "git log -1 ${{ github.sha }}: $(git log -1 ${{ github.sha }})"
+        # Output the full event json for debugging.
+        # cat ${{ github.event_path }}
 
     - name: Build the devcontainer image
       timeout-minutes: 15

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,7 +31,7 @@ jobs:
       id: get-commit-messages
       run: |
         # Only look at the last 10 commits, to avoid getting too much data.
-        git log --format="%B" -10 ${{ github.event.before }}...${{ github.event.after }} > /tmp/commit_messages.txt
+        git log --format="%B" -10 ${{ github.event.before }}..${{ github.event.after }} > /tmp/commit_messages.txt
         echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
 
     - name: Set NO_CACHE variable based on commit messages and for nightly builds

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -32,6 +32,11 @@ jobs:
       run: |
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
+    - name: Set NO_CACHE variable based on commit message
+      if: contains(github.event.head_commit.message, 'NO_CACHE=true')
+      run: |
+        echo "NO_CACHE=true" >> $GITHUB_ENV
+
     - name: Log some environment variables for debugging
       run: |
         set -x

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,7 +31,7 @@ jobs:
       id: get-commit-messages
       run: |
         # Only look at the last 10 commits, to avoid getting too much data.
-        git log --format="%B" -10 ${{ github.event.before }}...${{ github.sha }} > /tmp/commit_messages.txt
+        git log --format="%B" -10 ${{ github.event.before }}...${{ github.event.after }} > /tmp/commit_messages.txt
         echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
 
     - name: Set NO_CACHE variable based on commit messages and for nightly builds

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -31,7 +31,8 @@ jobs:
       id: get-commit-messages
       run: |
         # Only look at the last 10 commits, to avoid getting too much data.
-        git fetch --deepen=50
+        # If the message wasn't in there (e.g. because the push was a merge and too large), then we just ignore it.
+        git fetch --deepen=10
         git log --format="%B" -10 ${{ github.event.before }}..${{ github.event.after }} > /tmp/commit_messages.txt || true
         echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
 
@@ -45,7 +46,7 @@ jobs:
         set -x
         printenv
         echo "NO_CACHE: ${NO_CACHE:-}"
-        echo "COMMIT_MESSAGES: ${COMMIT_MESSAGES:-}"
+        echo "COMMIT_MESSAGES: ${{ steps.get-commit-messages.outputs.COMMIT_MESSAGES }}"
         echo "COMMIT_SHA: ${{ github.sha }}"
         echo "git log -1 ${{ github.sha }}: $(git log -1 ${{ github.sha }})"
         # Output the full event json for debugging.

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -46,6 +46,7 @@ jobs:
         echo "COMMIT_SHA: ${{ github.sha }}"
         echo "git log: $(git log -1 ${{ github.sha }})"
         echo "COMMIT_MESSAGE: ${{ github.event.commits[0].message }}"
+        cat ${{ github.event_path }}
 
     - name: Build the devcontainer image
       timeout-minutes: 15

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -65,6 +65,7 @@ jobs:
         docker exec --user root mlos-devcontainer chown -R vscode:vscode /home/vscode
         docker exec --user root mlos-devcontainer mkdir -p /opt/conda/pkgs/cache /var/cache/pip
         docker exec --user root mlos-devcontainer chown -R vscode /opt/conda/pkgs/cache /var/cache/pip
+        docker exec --user root mlos-devcontainer chown -R vscode /opt/conda/envs/mlos
 
     - name: Update the conda env in the devcontainer
       timeout-minutes: 10

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -42,6 +42,9 @@ jobs:
         set -x
         printenv
         echo "NO_CACHE: ${NO_CACHE:-}"
+        echo "COMMIT_SHA: ${{ github.sha }}"
+        echo "git log: $(git log -1 ${{ github.sha }})"
+        echo "COMMIT_MESSAGE: ${{ github.event.head_commit.message }}"
 
     - name: Build the devcontainer image
       timeout-minutes: 15

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -33,7 +33,7 @@ jobs:
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
     - name: Set NO_CACHE variable based on commit message
-      if: contains(github.event.head_commit.message, 'NO_CACHE=true')
+      if: contains(github.event.commits.message, 'NO_CACHE=true')
       run: |
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
@@ -42,6 +42,7 @@ jobs:
         set -x
         printenv
         echo "NO_CACHE: ${NO_CACHE:-}"
+        echo "commit messages: ${{ github.event.commits.message }}"
         echo "COMMIT_SHA: ${{ github.sha }}"
         echo "git log: $(git log -1 ${{ github.sha }})"
         echo "COMMIT_MESSAGE: ${{ github.event.head_commit.message }}"

--- a/Makefile
+++ b/Makefile
@@ -74,10 +74,7 @@ licenseheaders: build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
 
 build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: $(PYTHON_FILES) $(SCRIPT_FILES) $(SQL_FILES) doc/mit-license.tmpl
 	# Note: to avoid makefile dependency loops, we don't touch the setup.py files as that would force the conda-env to be rebuilt.
-	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl \
-	    -E .py .sh .ps1 .sql \
-	    -x mlos_bench/setup.py mlos_core/setup.py \
-	    -f $(PYTHON_FILES) $(SCRIPT_FILES) $(SQL_FILES)
+	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 .sql .cmd -x mlos_bench/setup.py mlos_core/setup.py
 	touch $@
 
 .PHONY: cspell

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ ENV_YML := conda-envs/${CONDA_ENV_NAME}.yml
 PYTHON_FILES := $(shell find ./ -type f -name '*.py' 2>/dev/null | egrep -v -e '^./((mlos_core|mlos_bench)/)?build/' -e '^./doc/source/')
 MLOS_CORE_PYTHON_FILES := $(shell find ./mlos_core/ -type f -name '*.py' 2>/dev/null | egrep -v -e '^./mlos_core/build/')
 MLOS_BENCH_PYTHON_FILES := $(shell find ./mlos_bench/ -type f -name '*.py' 2>/dev/null | egrep -v -e '^./mlos_bench/build/')
+SCRIPT_FILES := $(shell find ./ -name '*.sh' -or -name '*.ps1' -or -name '*.cmd')
+SQL_FILES := $(shell find ./ -name '*.sql')
 
 DOCKER := $(shell which docker)
 # Make sure the build directory exists.
@@ -70,9 +72,12 @@ build/pydocstyle.%.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NA
 .PHONY: licenseheaders
 licenseheaders: build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
 
-build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: $(PYTHON_FILES) doc/mit-license.tmpl
+build/licenseheaders.${CONDA_ENV_NAME}.build-stamp: $(PYTHON_FILES) $(SCRIPT_FILES) $(SQL_FILES) doc/mit-license.tmpl
 	# Note: to avoid makefile dependency loops, we don't touch the setup.py files as that would force the conda-env to be rebuilt.
-	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl -E .py .sh .ps1 -x mlos_bench/setup.py mlos_core/setup.py
+	conda run -n ${CONDA_ENV_NAME} licenseheaders -t doc/mit-license.tmpl \
+	    -E .py .sh .ps1 .sql \
+	    -x mlos_bench/setup.py mlos_core/setup.py \
+	    -f $(PYTHON_FILES) $(SCRIPT_FILES) $(SQL_FILES)
 	touch $@
 
 .PHONY: cspell


### PR DESCRIPTION
- Permissions fixup for recent CI issues.
  See Also: https://github.com/microsoft/MLOS/actions/runs/6179287329
- Add support to run an uncached devcontainer build by including `NO_CACHE=true` in one of the last 10 commit messages being pushed.
- Slight modification to `licenseheaders` rule for more file types.
  See Also: https://github.com/johann-petrak/licenseheaders/pull/78