### PR TITLE
Unit tests for combining the results of several `LocalEnv`s in one `CompositeEnv`

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -29,12 +29,17 @@ jobs:
 
     - name: Get commit messages
       id: get-commit-messages
+      if: github.event_name == 'pull_request'
       run: |
         # Only look at the last 10 commits, to avoid getting too much data.
         # If the message wasn't in there (e.g. because the push was a merge and too large), then we just ignore it.
         git fetch --deepen=10
-        git log --format="%B" -10 ${{ github.event.before }}..${{ github.event.after }} > /tmp/commit_messages.txt || true
-        echo "COMMIT_MESSAGES=$(cat /tmp/commit_messages.txt)" >> $GITHUB_OUTPUT
+        # Handle multiline output:
+        {
+          echo 'COMMIT_MESSAGES<<COMMIT_MESSAGES_EOF'
+          git log --format="%B" -10 ${{ github.event.before }}..${{ github.event.after }} | tee /tmp/commit_messages.txt
+          echo COMMIT_MESSAGES_EOF
+        } >> $GITHUB_OUTPUT
 
     - name: Set NO_CACHE variable based on commit messages and for nightly builds
       if: github.event_name == 'schedule' || contains(steps.get-commit-messages.outputs.COMMIT_MESSAGES, 'NO_CACHE=true')
@@ -46,6 +51,9 @@ jobs:
         set -x
         printenv
         echo "NO_CACHE: ${NO_CACHE:-}"
+        echo "EVENT_NAME: ${{ github.event_name }}"
+        echo "BEFORE: ${{ github.event.before }}"
+        echo "AFTER: ${{ github.event.after }}"
         echo "COMMIT_MESSAGES: ${{ steps.get-commit-messages.outputs.COMMIT_MESSAGES }}"
         echo "COMMIT_SHA: ${{ github.sha }}"
         echo "git log -1 ${{ github.sha }}: $(git log -1 ${{ github.sha }})"

--- a/mlos_bench/mlos_bench/tests/environments/local/__init__.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/__init__.py
@@ -40,6 +40,7 @@ def create_local_env(tunable_groups: TunableGroups, config: Dict[str, Any]) -> L
 
 
 def create_composite_local_env(tunable_groups: TunableGroups,
+                               params: Dict[str, Any],
                                local_configs: List[Dict[str, Any]]) -> CompositeEnv:
     """
     Create a CompositeEnv with several LocalEnv instances.
@@ -48,6 +49,8 @@ def create_composite_local_env(tunable_groups: TunableGroups,
     ----------
     tunable_groups : TunableGroups
         Tunable parameters (usually come from a fixture).
+    params: Dict[str, Any]
+        Additional config params for the CompositeEnv.
     local_configs: List[Dict[str, Any]]
         Configurations of the local environments.
 
@@ -59,6 +62,7 @@ def create_composite_local_env(tunable_groups: TunableGroups,
     return CompositeEnv(
         name="TestCompositeEnv",
         config={
+            **params,
             "children": [
                 {
                     "name": f"TestLocalEnv{i}",

--- a/mlos_bench/mlos_bench/tests/environments/local/__init__.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/__init__.py
@@ -40,6 +40,7 @@ def create_local_env(tunable_groups: TunableGroups, config: Dict[str, Any]) -> L
 
 
 def create_composite_local_env(tunable_groups: TunableGroups,
+                               global_config: Dict[str, Any],
                                params: Dict[str, Any],
                                local_configs: List[Dict[str, Any]]) -> CompositeEnv:
     """
@@ -49,6 +50,8 @@ def create_composite_local_env(tunable_groups: TunableGroups,
     ----------
     tunable_groups : TunableGroups
         Tunable parameters (usually come from a fixture).
+    global_config : Dict[str, Any]
+        Global configuration parameters.
     params: Dict[str, Any]
         Additional config params for the CompositeEnv.
     local_configs: List[Dict[str, Any]]
@@ -73,6 +76,7 @@ def create_composite_local_env(tunable_groups: TunableGroups,
             ]
         },
         tunables=tunable_groups,
+        global_config=global_config,
         service=LocalExecService(parent=ConfigPersistenceService()),
     )
 

--- a/mlos_bench/mlos_bench/tests/environments/local/__init__.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/__init__.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Tuple
 
 import pytest
 
+from mlos_bench.environments.base_environment import Environment
+from mlos_bench.environments.composite_env import CompositeEnv
 from mlos_bench.environments.local.local_env import LocalEnv
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.services.local.local_exec import LocalExecService
@@ -30,17 +32,51 @@ def create_local_env(tunable_groups: TunableGroups, config: Dict[str, Any]) -> L
 
     Returns
     -------
-    local_env : LocalEnv
+    env : LocalEnv
         A new instance of the local environment.
     """
     return LocalEnv(name="TestLocalEnv", config=config, tunables=tunable_groups,
                     service=LocalExecService(parent=ConfigPersistenceService()))
 
 
-def check_local_env_success(local_env: LocalEnv,
-                            tunable_groups: TunableGroups,
-                            expected_results: Dict[str, float],
-                            expected_telemetry: List[Tuple[datetime, str, Any]]) -> None:
+def create_composite_local_env(tunable_groups: TunableGroups,
+                               local_configs: List[Dict[str, Any]]) -> CompositeEnv:
+    """
+    Create a CompositeEnv with several LocalEnv instances.
+
+    Parameters
+    ----------
+    tunable_groups : TunableGroups
+        Tunable parameters (usually come from a fixture).
+    local_configs: List[Dict[str, Any]]
+        Configurations of the local environments.
+
+    Returns
+    -------
+    env : CompositeEnv
+        A new instance of the local environment.
+    """
+    return CompositeEnv(
+        name="TestCompositeEnv",
+        config={
+            "children": [
+                {
+                    "name": f"TestLocalEnv{i}",
+                    "class": "mlos_bench.environments.local.local_env.LocalEnv",
+                    "config": config,
+                }
+                for (i, config) in enumerate(local_configs)
+            ]
+        },
+        tunables=tunable_groups,
+        service=LocalExecService(parent=ConfigPersistenceService()),
+    )
+
+
+def check_env_success(env: Environment,
+                      tunable_groups: TunableGroups,
+                      expected_results: Dict[str, float],
+                      expected_telemetry: List[Tuple[datetime, str, Any]]) -> None:
     """
     Set up a local environment and run a test experiment there.
 
@@ -48,14 +84,14 @@ def check_local_env_success(local_env: LocalEnv,
     ----------
     tunable_groups : TunableGroups
         Tunable parameters (usually come from a fixture).
-    local_env : LocalEnv
-        A local environment to query for the results.
+    env : Environment
+        An environment to query for the results.
     expected_results : Dict[str, float]
         Expected results of the benchmark.
     expected_telemetry : List[Tuple[datetime, str, Any]]
         Expected telemetry data of the benchmark.
     """
-    with local_env as env_context:
+    with env as env_context:
 
         assert env_context.setup(tunable_groups)
 
@@ -68,7 +104,7 @@ def check_local_env_success(local_env: LocalEnv,
         assert telemetry == pytest.approx(expected_telemetry, nan_ok=True)
 
 
-def check_local_env_fail_telemetry(local_env: LocalEnv, tunable_groups: TunableGroups) -> None:
+def check_env_fail_telemetry(env: Environment, tunable_groups: TunableGroups) -> None:
     """
     Set up a local environment and run a test experiment there;
     Make sure the environment `.status()` call fails.
@@ -77,10 +113,10 @@ def check_local_env_fail_telemetry(local_env: LocalEnv, tunable_groups: TunableG
     ----------
     tunable_groups : TunableGroups
         Tunable parameters (usually come from a fixture).
-    local_env : LocalEnv
-        A local environment to query for the results.
+    env : Environment
+        An environment to query for the results.
     """
-    with local_env as env_context:
+    with env as env_context:
 
         assert env_context.setup(tunable_groups)
         (status, _data) = env_context.run()

--- a/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
@@ -16,6 +16,10 @@ def test_composite_env(tunable_groups: TunableGroups) -> None:
     """
     Produce benchmark and telemetry data in TWO local environments
     and combine the results.
+    Also checks that global configs flow down at least one level of CompositeEnv
+    to its children without being explicitly specified in the CompositeEnv so they
+    can be used in the shell_envs by its children.
+    See Also: http://github.com/microsoft/MLOS/issues/501
     """
     ts1 = datetime.utcnow()
     ts1 -= timedelta(microseconds=ts1.microsecond)  # Round to a second

--- a/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
@@ -33,8 +33,8 @@ def test_composite_env(tunable_groups: TunableGroups) -> None:
                 f"echo {time_str1},cpu_load,0.64 >> telemetry.csv",
                 f"echo {time_str1},mem_usage,5120 >> telemetry.csv",
             ],
-            "read_results_file": "output1.csv",
-            "read_telemetry_file": "telemetry1.csv",
+            "read_results_file": "output.csv",
+            "read_telemetry_file": "telemetry.csv",
         },
         {
             "run": [

--- a/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
@@ -1,0 +1,67 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests for the composition of several LocalEnv benchmark environments.
+"""
+from datetime import datetime, timedelta
+
+from mlos_bench.tunables.tunable_groups import TunableGroups
+from mlos_bench.tests.environments.local import create_composite_local_env, check_env_success
+
+
+def test_composite_env(tunable_groups: TunableGroups) -> None:
+    """
+    Produce benchmark and telemetry data in TWO local environments
+    and combine the results.
+    """
+    ts1 = datetime.utcnow()
+    ts1 -= timedelta(microseconds=ts1.microsecond)  # Round to a second
+    ts2 = ts1 + timedelta(minutes=1)
+
+    time_str1 = ts1.strftime("%Y-%m-%d %H:%M:%S")
+    time_str2 = ts2.strftime("%Y-%m-%d %H:%M:%S")
+
+    env = create_composite_local_env(tunable_groups, [
+        {
+            "run": [
+                "echo 'metric,value' > output.csv",
+                "echo 'latency,4.2' >> output.csv",
+                "echo '-------------------'",  # This output does not go anywhere
+                "echo 'timestamp,metric,value' > telemetry.csv",
+                f"echo {time_str1},cpu_load,0.64 >> telemetry.csv",
+                f"echo {time_str1},mem_usage,5120 >> telemetry.csv",
+            ],
+            "read_results_file": "output1.csv",
+            "read_telemetry_file": "telemetry1.csv",
+        },
+        {
+            "run": [
+                "echo 'metric,value' > output.csv",
+                "echo 'throughput,768' >> output.csv",
+                "echo 'score,0.97' >> output.csv",
+                "echo '-------------------'",  # This output does not go anywhere
+                "echo 'timestamp,metric,value' > telemetry.csv",
+                f"echo {time_str2},cpu_load,0.79 >> telemetry.csv",
+                f"echo {time_str2},mem_usage,40960 >> telemetry.csv",
+            ],
+            "read_results_file": "output.csv",
+            "read_telemetry_file": "telemetry.csv",
+        }
+    ])
+
+    check_env_success(
+        env, tunable_groups,
+        expected_results={
+            "latency": 4.2,
+            "throughput": 768.0,
+            "score": 0.97,
+        },
+        expected_telemetry=[
+            (ts1, "cpu_load", 0.64),
+            (ts1, "mem_usage", 5120.0),
+            (ts2, "cpu_load", 0.79),
+            (ts2, "mem_usage", 40960.0),
+        ],
+    )

--- a/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
@@ -18,7 +18,7 @@ def test_composite_env(tunable_groups: TunableGroups) -> None:
     """
     ts1 = datetime.utcnow()
     ts1 -= timedelta(microseconds=ts1.microsecond)  # Round to a second
-    ts2 = ts1 + timedelta(minutes=1)
+    ts2 = ts1 + timedelta(minutes=2)
 
     time_str1 = ts1.strftime("%Y-%m-%d %H:%M:%S")
     time_str2 = ts2.strftime("%Y-%m-%d %H:%M:%S")

--- a/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/composite_local_env_test.py
@@ -43,12 +43,13 @@ def test_composite_env(tunable_groups: TunableGroups) -> None:
             {
                 "const_args": {
                     "latency": 3.3,
+                    "reads": 0,
                 },
                 "required_args": ["errors", "reads"],
                 "shell_env_params": [
                     "latency",  # const_args overridden by the composite env
-                    "errors",   # Comes from the composite env const_args
-                    "reads"     # Comes straight from the global config
+                    "errors",   # Comes from the parent const_args
+                    "reads"     # const_args overridden by the global config
                 ],
                 "run": [
                     "echo 'metric,value' > output.csv",

--- a/mlos_bench/mlos_bench/tests/environments/local/local_env_stdout_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/local_env_stdout_test.py
@@ -7,7 +7,7 @@ Unit tests for extracting data from LocalEnv stdout.
 """
 
 from mlos_bench.tunables.tunable_groups import TunableGroups
-from mlos_bench.tests.environments.local import create_local_env, check_local_env_success
+from mlos_bench.tests.environments.local import create_local_env, check_env_success
 
 
 def test_local_env_stdout(tunable_groups: TunableGroups) -> None:
@@ -24,7 +24,7 @@ def test_local_env_stdout(tunable_groups: TunableGroups) -> None:
         "results_stdout_pattern": r"(\w+),([0-9.]+)",
     })
 
-    check_local_env_success(
+    check_env_success(
         local_env, tunable_groups,
         expected_results={
             "latency": 111.0,
@@ -53,7 +53,7 @@ def test_local_env_file_stdout(tunable_groups: TunableGroups) -> None:
         "read_results_file": "output.csv",
     })
 
-    check_local_env_success(
+    check_env_success(
         local_env, tunable_groups,
         expected_results={
             "latency": 111.0,

--- a/mlos_bench/mlos_bench/tests/environments/local/local_env_telemetry_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/local_env_telemetry_test.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 
 from mlos_bench.tunables.tunable_groups import TunableGroups
 from mlos_bench.tests.environments.local import (
-    create_local_env, check_local_env_success, check_local_env_fail_telemetry
+    create_local_env, check_env_success, check_env_fail_telemetry
 )
 
 
@@ -41,7 +41,7 @@ def test_local_env_telemetry(tunable_groups: TunableGroups) -> None:
         "read_telemetry_file": "telemetry.csv",
     })
 
-    check_local_env_success(
+    check_env_success(
         local_env, tunable_groups,
         expected_results={
             "latency": 4.1,
@@ -78,7 +78,7 @@ def test_local_env_telemetry_no_header(tunable_groups: TunableGroups) -> None:
         "read_telemetry_file": "telemetry.csv",
     })
 
-    check_local_env_success(
+    check_env_success(
         local_env, tunable_groups,
         expected_results={},
         expected_telemetry=[
@@ -113,7 +113,7 @@ def test_local_env_telemetry_wrong_header(tunable_groups: TunableGroups) -> None
         "read_telemetry_file": "telemetry.csv",
     })
 
-    check_local_env_fail_telemetry(local_env, tunable_groups)
+    check_env_fail_telemetry(local_env, tunable_groups)
 
 
 def test_local_env_telemetry_invalid(tunable_groups: TunableGroups) -> None:
@@ -138,7 +138,7 @@ def test_local_env_telemetry_invalid(tunable_groups: TunableGroups) -> None:
         "read_telemetry_file": "telemetry.csv",
     })
 
-    check_local_env_fail_telemetry(local_env, tunable_groups)
+    check_env_fail_telemetry(local_env, tunable_groups)
 
 
 def test_local_env_telemetry_invalid_ts(tunable_groups: TunableGroups) -> None:
@@ -156,4 +156,4 @@ def test_local_env_telemetry_invalid_ts(tunable_groups: TunableGroups) -> None:
         "read_telemetry_file": "telemetry.csv",
     })
 
-    check_local_env_fail_telemetry(local_env, tunable_groups)
+    check_env_fail_telemetry(local_env, tunable_groups)

--- a/mlos_bench/mlos_bench/tests/environments/local/local_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/local_env_test.py
@@ -8,7 +8,7 @@ Unit tests for LocalEnv benchmark environment.
 import pytest
 
 from mlos_bench.tunables.tunable_groups import TunableGroups
-from mlos_bench.tests.environments.local import create_local_env, check_local_env_success
+from mlos_bench.tests.environments.local import create_local_env, check_env_success
 
 
 def test_local_env(tunable_groups: TunableGroups) -> None:
@@ -25,7 +25,7 @@ def test_local_env(tunable_groups: TunableGroups) -> None:
         "read_results_file": "output.csv",
     })
 
-    check_local_env_success(
+    check_env_success(
         local_env, tunable_groups,
         expected_results={
             "latency": 10.0,
@@ -68,7 +68,7 @@ def test_local_env_wide(tunable_groups: TunableGroups) -> None:
         "read_results_file": "output.csv",
     })
 
-    check_local_env_success(
+    check_env_success(
         local_env, tunable_groups,
         expected_results={
             "latency": 10,

--- a/mlos_bench/mlos_bench/tests/environments/local/local_env_vars_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/local/local_env_vars_test.py
@@ -10,7 +10,7 @@ import sys
 import pytest
 
 from mlos_bench.tunables.tunable_groups import TunableGroups
-from mlos_bench.tests.environments.local import create_local_env, check_local_env_success
+from mlos_bench.tests.environments.local import create_local_env, check_env_success
 
 
 def _run_local_env(tunable_groups: TunableGroups, shell_subcmd: str, expected: dict) -> None:
@@ -34,7 +34,7 @@ def _run_local_env(tunable_groups: TunableGroups, shell_subcmd: str, expected: d
         "read_results_file": "output.csv",
     })
 
-    check_local_env_success(local_env, tunable_groups, expected, [])
+    check_env_success(local_env, tunable_groups, expected, [])
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason="sh-like shell only")


### PR DESCRIPTION
Also, rename some local functions to reflect the fact that the environment may not necessarily be an instance of `LocalEnv` and change the docstrings and annotations accordingly.

Closes #501 