### PR TITLE
Add params support to upload/download ops for fileshare service types

### DIFF
--- a/mlos_bench/mlos_bench/environments/local/local_fileshare_env.py
+++ b/mlos_bench/mlos_bench/environments/local/local_fileshare_env.py
@@ -121,7 +121,7 @@ class LocalFileShareEnv(LocalEnv):
             params = self._get_env_params()
             params["PWD"] = self._temp_dir
             for (path_from, path_to) in self._expand(self._upload, params):
-                self._file_share_service.upload(self._config_loader_service.resolve_path(
+                self._file_share_service.upload(self.config, self._config_loader_service.resolve_path(
                     path_from, extra_paths=[self._temp_dir]), path_to)
         return self._is_ready
 
@@ -140,9 +140,9 @@ class LocalFileShareEnv(LocalEnv):
         params["PWD"] = self._temp_dir
         for (path_from, path_to) in self._expand(self._download, params):
             try:
-                self._file_share_service.download(
-                    path_from, self._config_loader_service.resolve_path(
-                        path_to, extra_paths=[self._temp_dir]))
+                self._file_share_service.download(self.config,
+                                                  path_from, self._config_loader_service.resolve_path(
+                                                      path_to, extra_paths=[self._temp_dir]))
             except FileNotFoundError as ex:
                 _LOG.warning("Cannot download: %s", path_from)
                 if not ignore_missing:

--- a/mlos_bench/mlos_bench/services/base_fileshare.py
+++ b/mlos_bench/mlos_bench/services/base_fileshare.py
@@ -47,12 +47,14 @@ class FileShareService(Service, SupportsFileShareOps, metaclass=ABCMeta):
         ])
 
     @abstractmethod
-    def download(self, remote_path: str, local_path: str, recursive: bool = True) -> None:
+    def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:
         """
         Downloads contents from a remote share path to a local path.
 
         Parameters
         ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of (optional) connection details.
         remote_path : str
             Path to download from the remote file share, a file if recursive=False
             or a directory if recursive=True.
@@ -62,16 +64,19 @@ class FileShareService(Service, SupportsFileShareOps, metaclass=ABCMeta):
             If False, ignore the subdirectories;
             if True (the default), download the entire directory tree.
         """
-        _LOG.info("Download from File Share %s recursively: %s -> %s",
-                  "" if recursive else "non", remote_path, local_path)
+        params = params or {}
+        _LOG.info("Download from File Share %s recursively: %s -> %s (%s)",
+                  "" if recursive else "non", remote_path, local_path, params)
 
     @abstractmethod
-    def upload(self, local_path: str, remote_path: str, recursive: bool = True) -> None:
+    def upload(self, params: dict, local_path: str, remote_path: str, recursive: bool = True) -> None:
         """
         Uploads contents from a local path to remote share path.
 
         Parameters
         ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of (optional) connection details.
         local_path : str
             Path to the local directory to upload contents from.
         remote_path : str
@@ -80,5 +85,6 @@ class FileShareService(Service, SupportsFileShareOps, metaclass=ABCMeta):
             If False, ignore the subdirectories;
             if True (the default), upload the entire directory tree.
         """
-        _LOG.info("Upload to File Share %s recursively: %s -> %s",
-                  "" if recursive else "non", local_path, remote_path)
+        params = params or {}
+        _LOG.info("Upload to File Share %s recursively: %s -> %s (%s)",
+                  "" if recursive else "non", local_path, remote_path, params)

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_fileshare.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_fileshare.py
@@ -64,8 +64,8 @@ class AzureFileShareService(FileShareService):
             credential=self.config["storageAccountKey"],
         )
 
-    def download(self, remote_path: str, local_path: str, recursive: bool = True) -> None:
-        super().download(remote_path, local_path, recursive)
+    def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:
+        super().download(params, remote_path, local_path, recursive)
         dir_client = self._share_client.get_directory_client(remote_path)
         if dir_client.exists():
             os.makedirs(local_path, exist_ok=True)
@@ -74,7 +74,7 @@ class AzureFileShareService(FileShareService):
                 local_target = f"{local_path}/{name}"
                 remote_target = f"{remote_path}/{name}"
                 if recursive or not content["is_directory"]:
-                    self.download(remote_target, local_target, recursive)
+                    self.download(params, remote_target, local_target, recursive)
         else:  # Must be a file
             # Ensure parent folders exist
             folder, _ = os.path.split(local_path)
@@ -89,8 +89,8 @@ class AzureFileShareService(FileShareService):
                 # Translate into non-Azure exception:
                 raise FileNotFoundError(f"Cannot download: {remote_path}") from ex
 
-    def upload(self, local_path: str, remote_path: str, recursive: bool = True) -> None:
-        super().upload(local_path, remote_path, recursive)
+    def upload(self, params: dict, local_path: str, remote_path: str, recursive: bool = True) -> None:
+        super().upload(params, local_path, remote_path, recursive)
         self._upload(local_path, remote_path, recursive, set())
 
     def _upload(self, local_path: str, remote_path: str, recursive: bool, seen: Set[str]) -> None:

--- a/mlos_bench/mlos_bench/services/types/fileshare_type.py
+++ b/mlos_bench/mlos_bench/services/types/fileshare_type.py
@@ -15,12 +15,14 @@ class SupportsFileShareOps(Protocol):
     Protocol interface for file share operations.
     """
 
-    def download(self, remote_path: str, local_path: str, recursive: bool = True) -> None:
+    def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:
         """
         Downloads contents from a remote share path to a local path.
 
         Parameters
         ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of (optional) connection details.
         remote_path : str
             Path to download from the remote file share, a file if recursive=False
             or a directory if recursive=True.
@@ -31,12 +33,14 @@ class SupportsFileShareOps(Protocol):
             if True (the default), download the entire directory tree.
         """
 
-    def upload(self, local_path: str, remote_path: str, recursive: bool = True) -> None:
+    def upload(self, params: dict, local_path: str, remote_path: str, recursive: bool = True) -> None:
         """
         Uploads contents from a local path to remote share path.
 
         Parameters
         ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of (optional) connection details.
         local_path : str
             Path to the local directory to upload contents from.
         remote_path : str

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_fileshare_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_fileshare_test.py
@@ -25,11 +25,12 @@ def test_download_file(mock_makedirs: MagicMock, mock_open: MagicMock, azure_fil
     remote_path = f"{remote_folder}/{filename}"
     local_path = f"{local_folder}/{filename}"
     mock_share_client = azure_fileshare._share_client  # pylint: disable=protected-access
+    config: dict = {}
     with patch.object(mock_share_client, "get_file_client") as mock_get_file_client, \
          patch.object(mock_share_client, "get_directory_client") as mock_get_directory_client:
         mock_get_directory_client.return_value = Mock(exists=Mock(return_value=False))
 
-        azure_fileshare.download(remote_path, local_path)
+        azure_fileshare.download(config, remote_path, local_path)
 
         mock_get_file_client.assert_called_with(remote_path)
 
@@ -75,12 +76,13 @@ def test_download_folder_non_recursive(mock_makedirs: MagicMock,
     local_folder = "some/local/folder"
     dir_client_returns = make_dir_client_returns(remote_folder)
     mock_share_client = azure_fileshare._share_client   # pylint: disable=protected-access
+    config: dict = {}
     with patch.object(mock_share_client, "get_directory_client") as mock_get_directory_client, \
          patch.object(mock_share_client, "get_file_client") as mock_get_file_client:
 
         mock_get_directory_client.side_effect = lambda x: dir_client_returns[x]
 
-        azure_fileshare.download(remote_folder, local_folder, recursive=False)
+        azure_fileshare.download(config, remote_folder, local_folder, recursive=False)
 
     mock_get_file_client.assert_called_with(
         f"{remote_folder}/a_file_1.csv",
@@ -98,11 +100,12 @@ def test_download_folder_recursive(mock_makedirs: MagicMock, mock_open: MagicMoc
     local_folder = "some/local/folder"
     dir_client_returns = make_dir_client_returns(remote_folder)
     mock_share_client = azure_fileshare._share_client   # pylint: disable=protected-access
+    config: dict = {}
     with patch.object(mock_share_client, "get_directory_client") as mock_get_directory_client, \
          patch.object(mock_share_client, "get_file_client") as mock_get_file_client:
         mock_get_directory_client.side_effect = lambda x: dir_client_returns[x]
 
-        azure_fileshare.download(remote_folder, local_folder, recursive=True)
+        azure_fileshare.download(config, remote_folder, local_folder, recursive=True)
 
     mock_get_file_client.assert_has_calls([
         call(f"{remote_folder}/a_file_1.csv"),
@@ -126,9 +129,10 @@ def test_upload_file(mock_isdir: MagicMock, mock_open: MagicMock, azure_fileshar
     local_path = f"{local_folder}/{filename}"
     mock_share_client = azure_fileshare._share_client   # pylint: disable=protected-access
     mock_isdir.return_value = False
+    config: dict = {}
 
     with patch.object(mock_share_client, "get_file_client") as mock_get_file_client:
-        azure_fileshare.upload(local_path, remote_path)
+        azure_fileshare.upload(config, local_path, remote_path)
 
     mock_get_file_client.assert_called_with(remote_path)
     open_path, open_mode = mock_open.call_args.args
@@ -193,9 +197,10 @@ def test_upload_directory_non_recursive(mock_scandir: MagicMock,
     mock_scandir.side_effect = lambda x: scandir_returns[process_paths(x)]
     mock_isdir.side_effect = lambda x: isdir_returns[process_paths(x)]
     mock_share_client = azure_fileshare._share_client   # pylint: disable=protected-access
+    config: dict = {}
 
     with patch.object(mock_share_client, "get_file_client") as mock_get_file_client:
-        azure_fileshare.upload(local_folder, remote_folder, recursive=False)
+        azure_fileshare.upload(config, local_folder, remote_folder, recursive=False)
 
     mock_get_file_client.assert_called_with(f"{remote_folder}/a_file_1.csv")
 
@@ -214,9 +219,10 @@ def test_upload_directory_recursive(mock_scandir: MagicMock,
     mock_scandir.side_effect = lambda x: scandir_returns[process_paths(x)]
     mock_isdir.side_effect = lambda x: isdir_returns[process_paths(x)]
     mock_share_client = azure_fileshare._share_client   # pylint: disable=protected-access
+    config: dict = {}
 
     with patch.object(mock_share_client, "get_file_client") as mock_get_file_client:
-        azure_fileshare.upload(local_folder, remote_folder, recursive=True)
+        azure_fileshare.upload(config, local_folder, remote_folder, recursive=True)
 
     mock_get_file_client.assert_has_calls([
         call(f"{remote_folder}/a_file_1.csv"),

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_fileshare_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_fileshare_service.py
@@ -31,8 +31,8 @@ class MockFileShareService(FileShareService, SupportsFileShareOps):
             self.upload,
         ])
 
-    def download(self, remote_path: str, local_path: str, recursive: bool = True) -> None:
+    def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:
         pass
 
-    def upload(self, local_path: str, remote_path: str, recursive: bool = True) -> None:
+    def upload(self, params: dict, local_path: str, remote_path: str, recursive: bool = True) -> None:
         pass


### PR DESCRIPTION
Required for SshFileShareService to know which host to connect to.

See Also: #510