### PR TITLE
Don't require empty config element in service json schemas

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,4 +24,4 @@ def pytest_configure(config: pytest.Config) -> None:   # pylint: disable=unused-
         import matplotlib   # pylint: disable=import-outside-toplevel
         matplotlib.rcParams['backend'] = 'agg'
         warn(UserWarning('DISPLAY environment variable is set, which can cause problems in some setups (e.g. WSL). '
-            + f'Adjusting matplotlib backend to "{matplotlib.rcParams["backend"]}" to compensate.'))
+                         + f'Adjusting matplotlib backend to "{matplotlib.rcParams["backend"]}" to compensate.'))

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-auth-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-auth-service-subschema.json
@@ -55,5 +55,5 @@
             "unevaluatedProperties": false
         }
     },
-    "required": ["class", "config"]
+    "required": ["class"]
 }

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/mock/mock-auth-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/mock/mock-auth-service-subschema.json
@@ -14,8 +14,9 @@
             "type": "object",
             "properties": {},
             "required": [],
+            "minProperties": 1,
             "unevaluatedProperties": false
         }
     },
-    "required": ["class", "config"]
+    "required": ["class"]
 }

--- a/mlos_bench/mlos_bench/config/schemas/services/service-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/service-schema.json
@@ -7,41 +7,52 @@
         "service_config": {
             "type": "object",
             "$comment": "additional service types should be added here",
-            "oneOf": [
+            "allOf": [
                 {
-                    "$ref": "./local/local-exec-service-subschema.json"
+                    "oneOf": [
+                        {
+                            "$ref": "./local/local-exec-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./local/temp-dir-context-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./local/mock/mock-local-exec-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/mock/mock-fileshare-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/mock/mock-vm-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/mock/mock-remote-exec-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/mock/mock-auth-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/azure/azure-auth-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/azure/azure-vm-service-subschema.json"
+                        },
+                        {
+                            "$ref": "./remote/azure/azure-fileshare-service-subschema.json"
+                        }
+                    ],
+                    "required": ["class"]
                 },
                 {
-                    "$ref": "./local/temp-dir-context-service-subschema.json"
-                },
-                {
-                    "$ref": "./local/mock/mock-local-exec-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/mock/mock-fileshare-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/mock/mock-vm-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/mock/mock-remote-exec-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/mock/mock-auth-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/azure/azure-auth-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/azure/azure-vm-service-subschema.json"
-                },
-                {
-                    "$ref": "./remote/azure/azure-fileshare-service-subschema.json"
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "$comment": "Service-specific config.",
+                            "minProperties": 1
+                        }
+                    }
                 }
-            ],
-            "required": [
-                "class",
-                "config"
             ]
         },
         "top_level_items": {
@@ -72,10 +83,7 @@
                     "$ref": "#/$defs/service_config"
                 }
             ],
-            "required": [
-                "class",
-                "config"
-            ]
+            "required": ["class"]
         },
         {
             "$comment": "We no longer accept a flat list of Service objects.",

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_auth_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_auth_service-config-missing.jsonc
@@ -1,3 +1,6 @@
 {
-    "class": "mlos_bench.services.remote.azure.AzureAuthService"
+    "class": "mlos_bench.services.remote.azure.AzureAuthService",
+    "config": {
+        // should be omitted if empty
+    }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_auth_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_auth_service-partial.jsonc
@@ -1,4 +1,3 @@
 {
-    "class": "mlos_bench.services.remote.azure.AzureAuthService",
-    "config": {}
+    "class": "mlos_bench.services.remote.azure.AzureAuthService"
 }

--- a/mlos_bench/mlos_bench/tests/config/services/remote/mock/mock_auth_service.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/services/remote/mock/mock_auth_service.jsonc
@@ -1,4 +1,3 @@
 {
-    "class": "mlos_bench.tests.services.remote.mock.mock_auth_service.MockAuthService",
-    "config": {}
+    "class": "mlos_bench.tests.services.remote.mock.mock_auth_service.MockAuthService"
 }


### PR DESCRIPTION
Adjusts service schema's to not require an empty `"config": {}` element, and instead only include it if there's some other property in it.

Split out from #510