### PR TITLE
Canonicalize the path for test comparison purposes

### DIFF
--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -69,7 +69,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
             if path not in self._config_path:
                 self._config_path.append(path_join(path, abs_path=True))
         # Prepend the cwd if not already on the list.
-        cwd = os.path.abspath(os.getcwd())
+        cwd = path_join(os.getcwd(), abs_path=True)
         if cwd not in self._config_path:
             self._config_path.insert(0, cwd)
         # Append the built-in config path if not already on the list.

--- a/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
@@ -70,7 +70,7 @@ def test_launcher_args_parse_1(config_paths: List[str]) -> None:
     # Check overriding values in a file from the command line.
     assert launcher.global_config['test_global_value_2'] == 'from-args'
     # Check that we can expand a $var in a config file that references an environment variable.
-    assert launcher.global_config["varWithEnvVarRef"] == path_join(os.getcwd(), "foo", abs_path=True)
+    assert path_join(launcher.global_config["varWithEnvVarRef"], abs_path=True) == path_join(os.getcwd(), "foo", abs_path=True)
     assert launcher.teardown
     # Check that the environment that got loaded looks to be of the right type.
     env_config = launcher.config_loader.load_config(env_conf_path, ConfigSchema.ENVIRONMENT)
@@ -105,7 +105,7 @@ def test_launcher_args_parse_2(config_paths: List[str]) -> None:
     # Check that secondary expansion also works.
     assert launcher.global_config['testVnetName'] == 'MockeryExperiment-vm-vnet'
     # Check that we can expand a $var in a config file that references an environment variable.
-    assert launcher.global_config["varWithEnvVarRef"] == path_join(os.getcwd(), "foo", abs_path=True)
+    assert path_join(launcher.global_config["varWithEnvVarRef"], abs_path=True) == path_join(os.getcwd(), "foo", abs_path=True)
     assert not launcher.teardown
 
     config = launcher.config_loader.load_config(config_file, ConfigSchema.CLI)

--- a/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
@@ -136,4 +136,4 @@ def test_launcher_args_parse_2(config_paths: List[str]) -> None:
 
 
 if __name__ == '__main__':
-    pytest.main([__file__, "-n1", "-k", "test_launcher_args_parse_2"])
+    pytest.main([__file__, "-n1"])

--- a/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
@@ -133,3 +133,7 @@ def test_launcher_args_parse_2(config_paths: List[str]) -> None:
     # applies to a temporary Optimizer used to populate the initial values via
     # random sampling.
     # assert launcher.optimizer.seed == 1234
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, "-n1", "-k", "test_launcher_args_parse_2"])

--- a/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
+++ b/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
@@ -222,4 +222,5 @@ def test_temp_dir_path_expansion() -> None:
         }
         local_exec_service = LocalExecService(config, global_config, parent=ConfigPersistenceService())
         # pylint: disable=protected-access
-        assert path_join(local_exec_service._temp_dir, abs_path=True) == path_join(temp_dir, "temp")
+        assert isinstance(local_exec_service._temp_dir, str)
+        assert path_join(local_exec_service._temp_dir, abs_path=True) == path_join(temp_dir, "temp", abs_path=True)

--- a/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
+++ b/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
@@ -222,4 +222,4 @@ def test_temp_dir_path_expansion() -> None:
         }
         local_exec_service = LocalExecService(config, global_config, parent=ConfigPersistenceService())
         # pylint: disable=protected-access
-        assert local_exec_service._temp_dir == path_join(temp_dir, "temp")
+        assert path_join(local_exec_service._temp_dir, abs_path=True) == path_join(temp_dir, "temp")


### PR DESCRIPTION
Fixup to Windows test for bug introduced by #529

Need to canonicalize paths to use `/` instead of `\\` when doing comparisons.