### PR TITLE
Reverse order of preference for environment variable expansion.

### DIFF
--- a/mlos_bench/mlos_bench/launcher.py
+++ b/mlos_bench/mlos_bench/launcher.py
@@ -257,8 +257,8 @@ class Launcher:
             # new set of params explicitly.
             # Since this operates by updating the global_config along the way,
             # we need to continually update the set of params to use for substitution.
-            params = dict(os.environ)
-            params.update(self.global_config)
+            params = self.global_config.copy()
+            params.update(dict(os.environ))
             return Template(value).safe_substitute(params)
         if isinstance(value, dict):
             # Note: we use a loop instead of dict comprehension in order to

--- a/mlos_core/mlos_core/optimizers/__init__.py
+++ b/mlos_core/mlos_core/optimizers/__init__.py
@@ -65,7 +65,7 @@ class OptimizerFactory:
                optimizer_type: OptimizerType = DEFAULT_OPTIMIZER_TYPE,
                optimizer_kwargs: Optional[dict] = None,
                space_adapter_type: SpaceAdapterType = SpaceAdapterType.IDENTITY,
-               space_adapter_kwargs: Optional[dict] = None) -> ConcreteOptimizer:
+               space_adapter_kwargs: Optional[dict] = None) -> ConcreteOptimizer:   # type: ignore[type-var]
         """
         Create a new optimizer instance, given the parameter space, optimizer type,
         and potential optimizer options.

--- a/mlos_core/mlos_core/spaces/adapters/__init__.py
+++ b/mlos_core/mlos_core/spaces/adapters/__init__.py
@@ -50,7 +50,7 @@ class SpaceAdapterFactory:
     def create(*,
                parameter_space: ConfigSpace.ConfigurationSpace,
                space_adapter_type: SpaceAdapterType = SpaceAdapterType.IDENTITY,
-               space_adapter_kwargs: Optional[dict] = None) -> ConcreteSpaceAdapter:
+               space_adapter_kwargs: Optional[dict] = None) -> ConcreteSpaceAdapter:    # type: ignore[type-var]
         """
         Create a new space adapter instance, given the parameter space and potential
         space adapter options.


### PR DESCRIPTION
Follow on to #529 

Allows for environment variables to be used in the globals config file like so:

```json
"CONTAINER_WORKSPACE_FOLDER": "$CONTAINER_WORKSPACE_FOLDER",
"LOCAL_WORKSPACE_FOLDER": "$LOCAL_WORKSPACE_FOLDER",
```

So that the value can be pulled directly from the shell environment without having to invoke `mlos_bench` with those values explicitly like this:

~`mlos_bench --config ... --globals ... --CONTAINER_WORKSPACE_FOLDER=$CONTAINER_WORKSPACE_FOLDER --LOCAL_WORKSPACE_FOLDER=$LOCAL_WORKSPACE_FOLDER`~