### PR TITLE
bugfix: allow non-numeric values in trial results data

### DIFF
--- a/mlos_bench/mlos_bench/storage/sql/experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment_data.py
@@ -107,12 +107,12 @@ class ExperimentSqlData(ExperimentData):
                 )
             )
             results_df = pandas.DataFrame(
-                [(row.trial_id, "result." + row.metric_id, float(row.metric_value))
+                [(row.trial_id, "result." + row.metric_id, row.metric_value)
                  for row in cur_results.fetchall()],
                 columns=['trial_id', 'metric', 'value']
             ).pivot(
                 index="trial_id", columns="metric", values="value",
-            )
+            ).apply(pandas.to_numeric, errors='ignore')
 
             return trials_df.merge(configs_df, on=["trial_id", "config_id"], how="left") \
                             .merge(results_df, on="trial_id", how="left")


### PR DESCRIPTION
without this fix, our Jupyter notebook for ADU SQLite optimization demo would fail