### PR TITLE
Fix intermittent MagickMock response unit test error

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -51,6 +51,11 @@ jobs:
       run: |
         echo "NO_CACHE=true" >> $GITHUB_ENV
 
+    - name: Run pytest with debug logging enabled for nightly runs
+      if: github.event_name == 'schedule'
+      run: |
+        echo "PYTEST_EXTRA_OPTIONS=--log-level=DEBUG" >> $GITHUB_ENV
+
     - name: Log some environment variables for debugging
       run: |
         set -x
@@ -83,6 +88,7 @@ jobs:
           --volume $(pwd):/workspaces/MLOS \
           --env CONTAINER_WORKSPACE_FOLDER=/workspaces/MLOS \
           --env LOCAL_WORKSPACE_FOLDER=$(pwd) \
+          --env PYTEST_EXTRA_OPTIONS=$PYTEST_EXTRA_OPTIONS \
           --workdir /workspaces/MLOS \
           --name mlos-devcontainer mlos-devcontainer sleep infinity
     - name: Fixup vscode uid/gid in the running container

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -134,6 +134,7 @@
     },
     "python.testing.pytestArgs": [
         "-n1",  // don't run tests in parallel inside vscode - makes attaching the debugger more cumbersome
+        "--log-level=DEBUG",
         "."
     ],
     "python.testing.unittestEnabled": false

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ build/pytest.${CONDA_ENV_NAME}.build-stamp: build/pytest.mlos_core.${CONDA_ENV_N
 	for pytest_module in $(PYTEST_MODULES); do rm -f build/pytest.$${pytest_module}.${CONDA_ENV_NAME}.needs-build-stamp; done
 	# Run pytest for the modules: $(PYTEST_MODULES)
 	mkdir -p doc/source/badges/
-	conda run -n ${CONDA_ENV_NAME} pytest $(PYTEST_OPTIONS) $(PYTEST_MODULES)
+	conda run -n ${CONDA_ENV_NAME} pytest $(PYTEST_OPTIONS) $(PYTEST_EXTRA_OPTIONS) $(PYTEST_MODULES)
 	# Mark those as done again.
 	for pytest_module in $(PYTEST_MODULES); do touch build/pytest.$${pytest_module}.${CONDA_ENV_NAME}.needs-build-stamp; done
 	touch $@

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -149,6 +149,9 @@ def test_remote_exec_status(mock_requests: MagicMock, azure_vm_service: AzureVMS
 
     mock_response = MagicMock()
     mock_response.status_code = http_status_code
+    mock_response.json = MagicMock(return_value={
+        "fake response": "body as json to dict",
+    })
     mock_requests.post.return_value = mock_response
 
     status, _ = azure_vm_service.remote_exec(script, config={}, env_params={})
@@ -171,6 +174,9 @@ def test_remote_exec_headers_output(mock_requests: MagicMock,
     mock_response.headers = {
         "Azure-AsyncOperation": async_url_value
     }
+    mock_response.json = MagicMock(return_value={
+        "fake response": "body as json to dict",
+    })
     mock_requests.post.return_value = mock_response
 
     _, cmd_output = azure_vm_service.remote_exec(script, config={}, env_params={

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ addopts =
     -vv
     -svl --ff --nf
     -n auto
+#   --log-level=DEBUG
 # Moved these to Makefile (coverage is expensive and we only need it in the pipelines generally).
 #--cov=mlos_core --cov-report=xml
 testpaths = mlos_core mlos_bench


### PR DESCRIPTION
Fixes a bug with mock responses not providing a `json()` method which is only called during debug logging.

This was somewhat randomly showing up based I think upon the order of the tests running.
One of them, seemed to be enabling `_LOG.setLevel(logging.DEBUG)` so that future tests (for that worker) would also have the level set.

Once done, additional paths would be followed inside the `AzureServices` code that caused it to try and do something like the following `_LOG.debug(response.json())` which would fail because the mocked response object didn't provide a `json()` method response.

This fixes that error, but doesn't address the `debug` log ordering.
I'm not certain we should switch all of our unit tests over to running in DEBUG mode by default since it might cause us to depend on that behavior.
As a compromise, for now I've enabled it only inside `.vscode/settings.json` so that when we run `pytest` interactively (e.g., during dev cycle or while debugging a single unit test), then those code paths will be followed.

We can also run the following on demand and incorporate it to our `Makefile` or nightly runs to do it at least some of the time:

```sh
pytest --log-level=DEBUG
```

or

```sh
export PYTEST_EXTRA_OPTIONS=--log-level=DEBUG
make test
```