### PR TITLE
Add unit tests for multi-score updates. Allow non-numeric metrics in storage type annotations.

### DIFF
--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -294,8 +294,8 @@ class Storage(metaclass=ABCMeta):
 
         @abstractmethod
         def update(self, status: Status, timestamp: datetime,
-                   metrics: Optional[Union[Dict[str, float], float]] = None
-                   ) -> Optional[Dict[str, float]]:
+                   metrics: Optional[Union[Dict[str, Any], float]] = None
+                   ) -> Optional[Dict[str, Any]]:
             """
             Update the storage with the results of the experiment.
 
@@ -305,13 +305,13 @@ class Storage(metaclass=ABCMeta):
                 Status of the experiment run.
             timestamp: datetime
                 Timestamp of the status and metrics.
-            metrics : Optional[Union[Dict[str, float], float]]
+            metrics : Optional[Union[Dict[str, Any], float]]
                 One or several metrics of the experiment run.
-                Must contain the optimization target if the status is SUCCEEDED.
+                Must contain the (float) optimization target if the status is SUCCEEDED.
 
             Returns
             -------
-            metrics : Optional[Dict[str, float]]
+            metrics : Optional[Dict[str, Any]]
                 Same as `metrics`, but always in the dict format.
             """
             _LOG.info("Store trial: %s :: %s %s", self, status, metrics)

--- a/mlos_bench/mlos_bench/storage/sql/trial.py
+++ b/mlos_bench/mlos_bench/storage/sql/trial.py
@@ -42,8 +42,8 @@ class Trial(Storage.Trial):
         self._schema = schema
 
     def update(self, status: Status, timestamp: datetime,
-               metrics: Optional[Union[Dict[str, float], float]] = None
-               ) -> Optional[Dict[str, float]]:
+               metrics: Optional[Union[Dict[str, Any], float]] = None
+               ) -> Optional[Dict[str, Any]]:
         metrics = super().update(status, timestamp, metrics)
         with self._engine.begin() as conn:
             try:

--- a/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
@@ -82,6 +82,25 @@ def test_exp_trial_success(exp_storage_memory_sql: Storage.Experiment,
     assert not trials
 
 
+def test_exp_trial_update_categ(exp_storage_memory_sql: Storage.Experiment,
+                                tunable_groups: TunableGroups) -> None:
+    """
+    Update the trial with multiple metrics, some of which are categorical.
+    """
+    trial = exp_storage_memory_sql.new_trial(tunable_groups)
+    trial.update(Status.SUCCEEDED, datetime.utcnow(), {"score": 99.9, "benchmark": "test"})
+    assert exp_storage_memory_sql.load() == (
+        [{
+            'idle': 'halt',
+            'kernel_sched_latency_ns': '2000000',
+            'kernel_sched_migration_cost_ns': '-1',
+            'vmSize': 'Standard_B4ms'
+        }],
+        [99.9],
+        [Status.SUCCEEDED]
+    )
+
+
 def test_exp_trial_update_twice(exp_storage_memory_sql: Storage.Experiment,
                                 tunable_groups: TunableGroups) -> None:
     """


### PR DESCRIPTION
This is for basic functionality only. We'll have more tests in the next PR where we test the the new `storage.experiments[]` API

Closes #539 