### PR TITLE
Fix the nested service inclusion issue + add unit tests

### DIFF
--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -119,6 +119,10 @@ class Environment(metaclass=abc.ABCMeta):
         self._in_context = False
         self._const_args: Dict[str, TunableValue] = config.get("const_args", {})
 
+        if _LOG.isEnabledFor(logging.DEBUG):
+            _LOG.debug("Environment: '%s' Service: %s", name,
+                       self._service.pprint() if self._service else None)
+
         if tunables is None:
             _LOG.warning("No tunables provided for %s. Tunable inheritance across composite environments may be broken.", name)
             tunables = TunableGroups()

--- a/mlos_bench/mlos_bench/services/base_fileshare.py
+++ b/mlos_bench/mlos_bench/services/base_fileshare.py
@@ -39,12 +39,10 @@ class FileShareService(Service, SupportsFileShareOps, metaclass=ABCMeta):
         parent : Service
             Parent service that can provide mixin functions.
         """
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.upload, self.download]
         super().__init__(config, global_config, parent)
-
-        self.register([
-            self.download,
-            self.upload,
-        ])
+        self.register(local_methods)
 
     @abstractmethod
     def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:

--- a/mlos_bench/mlos_bench/services/base_service.py
+++ b/mlos_bench/mlos_bench/services/base_service.py
@@ -143,10 +143,8 @@ class Service:
         if not isinstance(services, dict):
             services = {svc.__name__: svc for svc in services}
 
-        for (key, val) in services.items():
-            if key not in self._services:
-                self._services[key] = val
-                self.__dict__[key] = val
+        self._services.update(services)
+        self.__dict__.update(self._services)
 
         if _LOG.isEnabledFor(logging.DEBUG):
             _LOG.debug("Added methods to: %s", self.pprint())

--- a/mlos_bench/mlos_bench/services/base_service.py
+++ b/mlos_bench/mlos_bench/services/base_service.py
@@ -136,8 +136,7 @@ class Service:
             services = {svc.__name__: svc for svc in services}
 
         if _LOG.isEnabledFor(logging.DEBUG):
-            _LOG.debug("Service: %s Add methods: %s",
-                       self.__class__.__name__, list(services.keys()))
+            _LOG.debug("Service: %s Add methods: %s", self, list(services.keys()))
 
         # TODO? Throw a warning when an existing method is being overwritten?
 

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -380,8 +380,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
                 config, global_config, service).export())
 
         if _LOG.isEnabledFor(logging.DEBUG):
-            _LOG.debug("Created mix-in service:\n%s", "\n".join(
-                f'  "{key}": {val}' for (key, val) in service.export().items()))
+            _LOG.debug("Created mix-in service: %s", service)
 
         return service
 

--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -85,9 +85,11 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
         parent : Service
             An optional parent service that can provide mixin functions.
         """
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.local_exec]
         super().__init__(config, global_config, parent)
         self.abort_on_error = self.config.get("abort_on_error", True)
-        self.register([self.local_exec])
+        self.register(local_methods)
 
     def local_exec(self, script_lines: Iterable[str],
                    env: Optional[Mapping[str, "TunableValue"]] = None,

--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -14,7 +14,9 @@ import subprocess
 import sys
 
 from string import Template
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING
+from typing import (
+    Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING, Union
+)
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.local.temp_dir_context import TempDirContextService
@@ -71,7 +73,8 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
     def __init__(self,
                  config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
         """
         Create a new instance of a service to run scripts locally.
 
@@ -84,12 +87,14 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
             Free-format dictionary of global parameters.
         parent : Service
             An optional parent service that can provide mixin functions.
+        methods : Union[Dict[str, Callable], List[Callable], None]
+            New methods to register with the service.
         """
-        # IMPORTANT: Save the local methods before invoking the base class constructor
-        local_methods = [self.local_exec]
-        super().__init__(config, global_config, parent)
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, [self.local_exec])
+        )
         self.abort_on_error = self.config.get("abort_on_error", True)
-        self.register(local_methods)
 
     def local_exec(self, script_lines: Iterable[str],
                    env: Optional[Mapping[str, "TunableValue"]] = None,

--- a/mlos_bench/mlos_bench/services/local/temp_dir_context.py
+++ b/mlos_bench/mlos_bench/services/local/temp_dir_context.py
@@ -46,6 +46,8 @@ class TempDirContextService(Service, metaclass=abc.ABCMeta):
         parent : Service
             An optional parent service that can provide mixin functions.
         """
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.temp_dir_context]
         super().__init__(config, global_config, parent)
         self._temp_dir = self.config.get("temp_dir")
         if self._temp_dir:
@@ -54,7 +56,7 @@ class TempDirContextService(Service, metaclass=abc.ABCMeta):
             # and resolve the path to absolute path
             self._temp_dir = self._config_loader_service.resolve_path(self._temp_dir)
         _LOG.info("%s: temp dir: %s", self, self._temp_dir)
-        self.register([self.temp_dir_context])
+        self.register(local_methods)
 
     def temp_dir_context(self, path: Optional[str] = None) -> Union[TemporaryDirectory, nullcontext]:
         """

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_auth.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_auth.py
@@ -45,10 +45,12 @@ class AzureAuthService(Service, SupportsAuth):
         parent : Service
             Parent service that can provide mixin functions.
         """
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.get_access_token]
         super().__init__(config, global_config, parent)
 
         # Register methods that we want to expose to the Environment objects.
-        self.register([self.get_access_token])
+        self.register(local_methods)
 
         # This parameter can come from command line as strings, so conversion is needed.
         self._req_interval = float(self.config.get("tokenRequestInterval", self._REQ_INTERVAL))

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_fileshare.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_fileshare.py
@@ -9,7 +9,7 @@ A collection FileShare functions for interacting with Azure File Shares.
 import os
 import logging
 
-from typing import Any, Dict, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from azure.storage.fileshare import ShareClient
 from azure.core.exceptions import ResourceNotFoundError
@@ -31,7 +31,8 @@ class AzureFileShareService(FileShareService):
     def __init__(self,
                  config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
         """
         Create a new file share Service for Azure environments with a given config.
 
@@ -45,8 +46,13 @@ class AzureFileShareService(FileShareService):
             Free-format dictionary of global parameters.
         parent : Service
             Parent service that can provide mixin functions.
+        methods : Union[Dict[str, Callable], List[Callable], None]
+            New methods to register with the service.
         """
-        super().__init__(config, global_config, parent)
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, [self.upload, self.download])
+        )
 
         check_required_params(
             self.config, {

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -139,20 +139,8 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
         parent : Service
             Parent service that can provide mixin functions.
         """
-        super().__init__(config, global_config, parent)
-
-        check_required_params(
-            self.config, {
-                "subscription",
-                "resourceGroup",
-                "deploymentName",
-                "deploymentTemplatePath",
-                "deploymentTemplateParameters",
-            }
-        )
-
-        # Register methods that we want to expose to the Environment objects.
-        self.register([
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [
             # SupportsHostProvisioning
             self.provision_host,
             self.deprovision_host,
@@ -170,7 +158,22 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
             # SupportsRemoteExec
             self.remote_exec,
             self.get_remote_exec_results,
-        ])
+        ]
+
+        super().__init__(config, global_config, parent)
+
+        check_required_params(
+            self.config, {
+                "subscription",
+                "resourceGroup",
+                "deploymentName",
+                "deploymentTemplatePath",
+                "deploymentTemplateParameters",
+            }
+        )
+
+        # Register methods that we want to expose to the Environment objects.
+        self.register(local_methods)
 
         # These parameters can come from command line as strings, so conversion is needed.
         self._poll_interval = float(self.config.get("pollInterval", self._POLL_INTERVAL))

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -10,7 +10,7 @@ import json
 import time
 import logging
 
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
 
@@ -125,7 +125,8 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
     def __init__(self,
                  config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
         """
         Create a new instance of Azure services proxy.
 
@@ -138,29 +139,31 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
             Free-format dictionary of global parameters.
         parent : Service
             Parent service that can provide mixin functions.
+        methods : Union[Dict[str, Callable], List[Callable], None]
+            New methods to register with the service.
         """
-        # IMPORTANT: Save the local methods before invoking the base class constructor
-        local_methods = [
-            # SupportsHostProvisioning
-            self.provision_host,
-            self.deprovision_host,
-            self.deallocate_host,
-            self.wait_host_deployment,
-            # SupportsHostOps
-            self.start_host,
-            self.stop_host,
-            self.restart_host,
-            self.wait_host_operation,
-            # SupportsOSOps
-            self.shutdown,
-            self.reboot,
-            self.wait_os_operation,
-            # SupportsRemoteExec
-            self.remote_exec,
-            self.get_remote_exec_results,
-        ]
-
-        super().__init__(config, global_config, parent)
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, [
+                # SupportsHostProvisioning
+                self.provision_host,
+                self.deprovision_host,
+                self.deallocate_host,
+                self.wait_host_deployment,
+                # SupportsHostOps
+                self.start_host,
+                self.stop_host,
+                self.restart_host,
+                self.wait_host_operation,
+                # SupportsOSOps
+                self.shutdown,
+                self.reboot,
+                self.wait_os_operation,
+                # SupportsRemoteExec
+                self.remote_exec,
+                self.get_remote_exec_results,
+            ])
+        )
 
         check_required_params(
             self.config, {
@@ -171,9 +174,6 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
                 "deploymentTemplateParameters",
             }
         )
-
-        # Register methods that we want to expose to the Environment objects.
-        self.register(local_methods)
 
         # These parameters can come from command line as strings, so conversion is needed.
         self._poll_interval = float(self.config.get("pollInterval", self._POLL_INTERVAL))

--- a/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_2.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_2.jsonc
@@ -1,0 +1,7 @@
+{
+    "class": "mlos_bench.tests.services.local.mock.mock_local_exec_service.MockLocalExecService",
+
+    "config": {
+        "temp_dir": "tmp_other_2"
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_3.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_3.jsonc
@@ -1,0 +1,7 @@
+{
+    "class": "mlos_bench.tests.services.local.mock.mock_local_exec_service.MockLocalExecService",
+
+    "config": {
+        "temp_dir": "tmp_other_3"
+    }
+}

--- a/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Check how the services get inherited and overridden in child environments.
+"""
+import os
+
+import pytest
+
+from mlos_bench.environments.composite_env import CompositeEnv
+from mlos_bench.tunables.tunable_groups import TunableGroups
+from mlos_bench.services.config_persistence import ConfigPersistenceService
+from mlos_bench.services.local.local_exec import LocalExecService
+from mlos_bench.util import path_join
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def composite_env(tunable_groups: TunableGroups) -> CompositeEnv:
+    """
+    Test fixture for CompositeEnv with services included on multiple levels.
+    """
+    return CompositeEnv(
+        name="Root",
+        config={
+            "children": [
+                {
+                    "name": "Mock Client Environment 1",
+                    "class": "mlos_bench.environments.mock_env.MockEnv",
+                },
+                {
+                    "name": "Mock Server Environment 2",
+                    "class": "mlos_bench.environments.mock_env.MockEnv",
+                    "include_services": ["services/local/mock/mock_local_exec_service_2.jsonc"],
+                },
+                {
+                    "name": "Mock Control Environment 3",
+                    "class": "mlos_bench.environments.mock_env.MockEnv",
+                    "include_services": ["services/local/mock/mock_local_exec_service_3.jsonc"],
+                }
+            ]
+        },
+        tunables=tunable_groups,
+        service=LocalExecService(
+            config={
+                "temp_dir": "tmp_global"
+            },
+            parent=ConfigPersistenceService({
+                "config_path": [
+                    path_join(os.path.dirname(__file__), "../config", abs_path=True),
+                ]
+            })
+        )
+    )
+
+
+def test_composite_services(composite_env: CompositeEnv) -> None:
+    """
+    Check that each environment gets its own instance of the services.
+    """
+    # pylint: disable=protected-access
+    with composite_env.children[0]._service.temp_dir_context() as temp_dir:
+        assert temp_dir == "tmp_global"
+
+    with composite_env.children[1]._service.temp_dir_context() as temp_dir:
+        assert temp_dir == "tmp_other_2"
+
+    with composite_env.children[2]._service.temp_dir_context() as temp_dir:
+        assert temp_dir == "tmp_other_3"

--- a/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
@@ -63,10 +63,10 @@ def test_composite_services(composite_env: CompositeEnv) -> None:
     """
     # pylint: disable=protected-access
     with composite_env.children[0]._service.temp_dir_context() as temp_dir:
-        assert temp_dir == "tmp_global"
+        assert os.path.samefile(temp_dir, "tmp_global")
 
     with composite_env.children[1]._service.temp_dir_context() as temp_dir:
-        assert temp_dir == "tmp_other_2"
+        assert os.path.samefile(temp_dir, "tmp_other_2")
 
     with composite_env.children[2]._service.temp_dir_context() as temp_dir:
-        assert temp_dir == "tmp_other_3"
+        assert os.path.samefile(temp_dir, "tmp_other_3")

--- a/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
@@ -62,11 +62,8 @@ def test_composite_services(composite_env: CompositeEnv) -> None:
     Check that each environment gets its own instance of the services.
     """
     # pylint: disable=protected-access
-    with composite_env.children[0]._service.temp_dir_context() as temp_dir:
-        assert os.path.samefile(temp_dir, "tmp_global")
-
-    with composite_env.children[1]._service.temp_dir_context() as temp_dir:
-        assert os.path.samefile(temp_dir, "tmp_other_2")
-
-    with composite_env.children[2]._service.temp_dir_context() as temp_dir:
-        assert os.path.samefile(temp_dir, "tmp_other_3")
+    for (i, path) in ((0, "tmp_global"), (1, "tmp_other_2"), (2, "tmp_other_3")):
+        service = composite_env.children[i]._service
+        assert service is not None and hasattr(service, "temp_dir_context")
+        with service.temp_dir_context() as temp_dir:
+            assert os.path.samefile(temp_dir, path)

--- a/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
@@ -28,16 +28,16 @@ def composite_env(tunable_groups: TunableGroups) -> CompositeEnv:
         config={
             "children": [
                 {
-                    "name": "Mock Client Environment 1",
+                    "name": "Env 1 :: tmp_global",
                     "class": "mlos_bench.environments.mock_env.MockEnv",
                 },
                 {
-                    "name": "Mock Server Environment 2",
+                    "name": "Env 2 :: tmp_other_2",
                     "class": "mlos_bench.environments.mock_env.MockEnv",
                     "include_services": ["services/local/mock/mock_local_exec_service_2.jsonc"],
                 },
                 {
-                    "name": "Mock Control Environment 3",
+                    "name": "Env 3 :: tmp_other_3",
                     "class": "mlos_bench.environments.mock_env.MockEnv",
                     "include_services": ["services/local/mock/mock_local_exec_service_3.jsonc"],
                 }

--- a/mlos_bench/mlos_bench/tests/services/local/mock/mock_local_exec_service.py
+++ b/mlos_bench/mlos_bench/tests/services/local/mock/mock_local_exec_service.py
@@ -27,8 +27,10 @@ class MockLocalExecService(TempDirContextService, SupportsLocalExec):
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
                  parent: Optional[Service] = None):
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.local_exec]
         super().__init__(config, global_config, parent)
-        self.register([self.local_exec])
+        self.register(local_methods)
 
     def local_exec(self, script_lines: Iterable[str],
                    env: Optional[Mapping[str, "TunableValue"]] = None,

--- a/mlos_bench/mlos_bench/tests/services/local/mock/mock_local_exec_service.py
+++ b/mlos_bench/mlos_bench/tests/services/local/mock/mock_local_exec_service.py
@@ -7,7 +7,9 @@ A collection Service functions for mocking local exec.
 """
 
 import logging
-from typing import Any, Dict, Iterable, Mapping, Optional, Tuple, TYPE_CHECKING
+from typing import (
+    Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING, Union
+)
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.local.temp_dir_context import TempDirContextService
@@ -26,11 +28,12 @@ class MockLocalExecService(TempDirContextService, SupportsLocalExec):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
-        # IMPORTANT: Save the local methods before invoking the base class constructor
-        local_methods = [self.local_exec]
-        super().__init__(config, global_config, parent)
-        self.register(local_methods)
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, [self.local_exec])
+        )
 
     def local_exec(self, script_lines: Iterable[str],
                    env: Optional[Mapping[str, "TunableValue"]] = None,

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_auth_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_auth_service.py
@@ -7,7 +7,7 @@ A collection Service functions for mocking authentication.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.authenticator_type import SupportsAuth
@@ -22,11 +22,12 @@ class MockAuthService(Service, SupportsAuth):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
-        # IMPORTANT: Save the local methods before invoking the base class constructor
-        local_methods = [self.get_access_token]
-        super().__init__(config, global_config, parent)
-        self.register(local_methods)
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, [self.get_access_token])
+        )
 
     def get_access_token(self) -> str:
         return "TOKEN"

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_auth_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_auth_service.py
@@ -23,11 +23,10 @@ class MockAuthService(Service, SupportsAuth):
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
                  parent: Optional[Service] = None):
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.get_access_token]
         super().__init__(config, global_config, parent)
-
-        self.register([
-            self.get_access_token
-        ])
+        self.register(local_methods)
 
     def get_access_token(self) -> str:
         return "TOKEN"

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_fileshare_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_fileshare_service.py
@@ -7,7 +7,7 @@ A collection Service functions for mocking file share ops.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.base_fileshare import FileShareService
@@ -23,11 +23,12 @@ class MockFileShareService(FileShareService, SupportsFileShareOps):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
-        # IMPORTANT: Save the local methods before invoking the base class constructor
-        local_methods = [self.upload, self.download]
-        super().__init__(config, global_config, parent)
-        self.register(local_methods)
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, [self.upload, self.download])
+        )
 
     def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:
         pass

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_fileshare_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_fileshare_service.py
@@ -24,12 +24,10 @@ class MockFileShareService(FileShareService, SupportsFileShareOps):
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
                  parent: Optional[Service] = None):
+        # IMPORTANT: Save the local methods before invoking the base class constructor
+        local_methods = [self.upload, self.download]
         super().__init__(config, global_config, parent)
-
-        self.register([
-            self.download,
-            self.upload,
-        ])
+        self.register(local_methods)
 
     def download(self, params: dict, remote_path: str, local_path: str, recursive: bool = True) -> None:
         pass

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_remote_exec_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_remote_exec_service.py
@@ -6,7 +6,7 @@
 A collection Service functions for mocking remote script execution.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.remote_exec_type import SupportsRemoteExec
@@ -20,7 +20,8 @@ class MockRemoteExecService(Service, SupportsRemoteExec):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
         """
         Create a new instance of mock remote exec service.
 
@@ -34,8 +35,10 @@ class MockRemoteExecService(Service, SupportsRemoteExec):
         parent : Service
             Parent service that can provide mixin functions.
         """
-        super().__init__(config, global_config, parent)
-        self.register({
-            "remote_exec": mock_operation,
-            "get_remote_exec_results": mock_operation,
-        })
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, {
+                "remote_exec": mock_operation,
+                "get_remote_exec_results": mock_operation,
+            })
+        )

--- a/mlos_bench/mlos_bench/tests/services/remote/mock/mock_vm_service.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/mock/mock_vm_service.py
@@ -6,7 +6,7 @@
 A collection Service functions for mocking managing VMs.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.host_provisioner_type import SupportsHostProvisioning
@@ -22,7 +22,8 @@ class MockVMService(Service, SupportsHostProvisioning, SupportsHostOps, Supports
 
     def __init__(self, config: Optional[Dict[str, Any]] = None,
                  global_config: Optional[Dict[str, Any]] = None,
-                 parent: Optional[Service] = None):
+                 parent: Optional[Service] = None,
+                 methods: Union[Dict[str, Callable], List[Callable], None] = None):
         """
         Create a new instance of mock VM services proxy.
 
@@ -36,22 +37,24 @@ class MockVMService(Service, SupportsHostProvisioning, SupportsHostOps, Supports
         parent : Service
             Parent service that can provide mixin functions.
         """
-        super().__init__(config, global_config, parent)
-        self.register({
-            name: mock_operation for name in (
-                # SupportsHostProvisioning:
-                "wait_host_deployment",
-                "provision_host",
-                "deprovision_host",
-                "deallocate_host",
-                # SupportsHostOps:
-                "start_host",
-                "stop_host",
-                "restart_host",
-                "wait_host_operation",
-                # SupportsOsOps:
-                "shutdown",
-                "reboot",
-                "wait_os_operation",
-            )
-        })
+        super().__init__(
+            config, global_config, parent,
+            self.merge_methods(methods, {
+                name: mock_operation for name in (
+                    # SupportsHostProvisioning:
+                    "wait_host_deployment",
+                    "provision_host",
+                    "deprovision_host",
+                    "deallocate_host",
+                    # SupportsHostOps:
+                    "start_host",
+                    "stop_host",
+                    "restart_host",
+                    "wait_host_operation",
+                    # SupportsOsOps:
+                    "shutdown",
+                    "reboot",
+                    "wait_os_operation",
+                )
+            })
+        )


### PR DESCRIPTION
**UPDATE:** Fixed! The problem was with the `.register()` method invocation in the base class constructor, so the service can inherit methods from the parent service. That call overrode methods of the service object being created with references to the parent's methods. As a result, we were losing references to the local methods before we could register them. This PR is a workaround for the issue. We will think of a more elegant way of doing it later.

-------------------

Debugging and fixing the issue described in #530

**TODO:**
* [x] Fix the original issue from #530
* [x] Add unit tests to verify the problem
* [x] ~Fix the JSON schema to accept the `CompositeEnv` fixture from unit tests~
* [x] Resolve `mypy` issues with accessing `.temp_dir_context()`