### PR TITLE
Tweaks to debug vs. batch run testing in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,11 @@
             "name": "Debug Unit Test",
             "type": "python",
             "request": "test",
-            "justMyCode": false
+            "justMyCode": false,
+            "env": {
+                // When debugging tests, only run a single pytest worker instance.
+                "PYTEST_ADDOPTS": "-n1 --no-cov --dist=no --log-level=DEBUG"
+            }
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -132,11 +132,10 @@
         "editor.formatOnSave": true,
         "editor.formatOnSaveMode": "modifications"
     },
+    // See Also .vscode/launch.json for environment variable args to pytest during debug sessions.
+    // For the rest, see setup.cfg
     "python.testing.pytestArgs": [
-        "-n1",  // don't run tests in parallel inside vscode - makes attaching the debugger more cumbersome
-        "--dist=no",
-        "--log-level=DEBUG",
-        "."
+        "--log-level=DEBUG"
     ],
     "python.testing.unittestEnabled": false
 }


### PR DESCRIPTION
This change makes it so that running tests via VSCode's pytest plugin by default runs them in parallel (respecting the setup.cfg args for pytest), but when using the "Debug Test" option, parallel workers are disabled so we can more quickly trace through code in debug mode without additional processes to attach to.
Unfortunately, there is a [bug with the pytest-xdist loadgroup output processing in the vscode](https://github.com/microsoft/vscode-python/issues/19374) that prevents a few tests that use that (namely the recently added ssh test) from displaying as "completed successfully", even though they did.