### PR TITLE
Clean-up temp directories created in unit tests

### DIFF
--- a/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_2.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_2.jsonc
@@ -2,6 +2,6 @@
     "class": "mlos_bench.tests.services.local.mock.mock_local_exec_service.MockLocalExecService",
 
     "config": {
-        "temp_dir": "tmp_other_2"
+        "temp_dir": "_test_tmp_other_2"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_3.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/services/local/mock/mock_local_exec_service_3.jsonc
@@ -2,6 +2,6 @@
     "class": "mlos_bench.tests.services.local.mock.mock_local_exec_service.MockLocalExecService",
 
     "config": {
-        "temp_dir": "tmp_other_3"
+        "temp_dir": "_test_tmp_other_3"
     }
 }

--- a/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/composite_env_service_test.py
@@ -46,7 +46,7 @@ def composite_env(tunable_groups: TunableGroups) -> CompositeEnv:
         tunables=tunable_groups,
         service=LocalExecService(
             config={
-                "temp_dir": "tmp_global"
+                "temp_dir": "_test_tmp_global"
             },
             parent=ConfigPersistenceService({
                 "config_path": [
@@ -61,9 +61,9 @@ def test_composite_services(composite_env: CompositeEnv) -> None:
     """
     Check that each environment gets its own instance of the services.
     """
-    # pylint: disable=protected-access
-    for (i, path) in ((0, "tmp_global"), (1, "tmp_other_2"), (2, "tmp_other_3")):
-        service = composite_env.children[i]._service
+    for (i, path) in ((0, "_test_tmp_global"), (1, "_test_tmp_other_2"), (2, "_test_tmp_other_3")):
+        service = composite_env.children[i]._service  # pylint: disable=protected-access
         assert service is not None and hasattr(service, "temp_dir_context")
         with service.temp_dir_context() as temp_dir:
             assert os.path.samefile(temp_dir, path)
+        os.rmdir(path)


### PR DESCRIPTION
also, make the temp directory names a bit more unique to avoid clashes. P.S. we cannot use paths like `/tmp/...` because it won't work on Windows