### PR TITLE
Fixup issues with VSCode and pytest working directory paths in different environments

### DIFF
--- a/mlos_bench/mlos_bench/tests/config/globals/global_test_config.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/globals/global_test_config.jsonc
@@ -13,9 +13,13 @@
     "testVnetName": "$testVmName-vnet",
 
     // Note: $PWD generally also works, but has issues in vscode unit test
-    // runner vs. CLI due to the way its wrapper starts in one directory vs.
-    // moves to the code directory without changing the environment variables.
-    "pathVarWithEnvVarRef": "$PWD/foo",
+    // runner vs. CLI due to the way its wrapper sometimes starts in one
+    // directory vs. moves to the code directory without changing the
+    // environment variables.
+    // So, for this reason we set an environment variable explicitly in the
+    // test setup, and ensure that the launcher properly propagates it through
+    // here when expanding variables.
+    "pathVarWithEnvVarRef": "$CUSTOM_PATH_FROM_ENV/foo",
     "varWithEnvVarRef": "user:$USER",
 
     // Override the default value of the "max_iterations" parameter

--- a/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
@@ -52,11 +52,11 @@ def test_launcher_args_parse_1(config_paths: List[str]) -> None:
     """
     # The VSCode pytest wrapper actually starts in a different directory before
     # changing into the code directory, but doesn't update the PWD environment
-    # variable.
-    expected_root_pwd = os.environ.get('VSCODE_CWD', os.getcwd())
+    # variable so we use a separate variable.
+    # See global_test_config.jsonc for more details.
+    os.environ["CUSTOM_PATH_FROM_ENV"] = os.getcwd()
     if sys.platform == 'win32':
         # Some env tweaks for platform compatibility.
-        os.environ['PWD'] = expected_root_pwd
         os.environ['USER'] = os.environ['USERNAME']
 
     # This is part of the minimal required args by the Launcher.
@@ -78,7 +78,7 @@ def test_launcher_args_parse_1(config_paths: List[str]) -> None:
     assert launcher.global_config['test_global_value_2'] == 'from-args'
     # Check that we can expand a $var in a config file that references an environment variable.
     assert path_join(launcher.global_config["pathVarWithEnvVarRef"], abs_path=True) \
-        == path_join(expected_root_pwd, "foo", abs_path=True)
+        == path_join(os.getcwd(), "foo", abs_path=True)
     assert launcher.global_config["varWithEnvVarRef"] == f'user:{getuser()}'
     assert launcher.teardown
     # Check that the environment that got loaded looks to be of the right type.
@@ -97,11 +97,11 @@ def test_launcher_args_parse_2(config_paths: List[str]) -> None:
     """
     # The VSCode pytest wrapper actually starts in a different directory before
     # changing into the code directory, but doesn't update the PWD environment
-    # variable.
-    expected_root_pwd = os.environ.get('VSCODE_CWD', os.getcwd())
+    # variable so we use a separate variable.
+    # See global_test_config.jsonc for more details.
+    os.environ["CUSTOM_PATH_FROM_ENV"] = os.getcwd()
     if sys.platform == 'win32':
         # Some env tweaks for platform compatibility.
-        os.environ['PWD'] = expected_root_pwd
         os.environ['USER'] = os.environ['USERNAME']
 
     config_file = 'cli/test-cli-config.jsonc'
@@ -121,7 +121,7 @@ def test_launcher_args_parse_2(config_paths: List[str]) -> None:
     assert launcher.global_config['testVnetName'] == 'MockeryExperiment-vm-vnet'
     # Check that we can expand a $var in a config file that references an environment variable.
     assert path_join(launcher.global_config["pathVarWithEnvVarRef"], abs_path=True) \
-        == path_join(expected_root_pwd, "foo", abs_path=True)
+        == path_join(os.getcwd(), "foo", abs_path=True)
     assert launcher.global_config["varWithEnvVarRef"] == f'user:{getuser()}'
     assert not launcher.teardown
 


### PR DESCRIPTION
Previously #553 solved this for pytest inside VSCode for WSL, devcontainer within WSL, and Windows directly dev environments by looking at the `$VSCODE_CWD` environment variable that the Pytest VSCode extension sets to note the difference between the expected environment variable `$PWD` and the result of `os.getcwd()`.

However, when the devcontainer is launched from Windows, the VSCode pytest plugin takes a different approach and launches a proxy server in WSL to run the tests. In that mode, `$VSCODE_CWD` is still set but is no longer the path used.

To avoid fighting with all these different scenarios, we change the test to set `$CUSTOM_PATH_FROM_ENV` via `os.environ` prior to the start of the test, and then make sure that it's expanded when we use it inside `global_test_config.jsonc`

Closed #575