### PR TITLE
Fix asyncio issues

### DIFF
--- a/mlos_bench/mlos_bench/event_loop_context.py
+++ b/mlos_bench/mlos_bench/event_loop_context.py
@@ -14,7 +14,6 @@ from threading import Lock as ThreadLock, Thread
 import asyncio
 import logging
 import sys
-import time
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -82,17 +81,9 @@ class EventLoopContext:
             if self._event_loop_thread_refcnt == 0:
                 assert self._event_loop is not None
                 self._event_loop.call_soon_threadsafe(self._event_loop.stop)
-                timeout = 3
-                sleep_interval = 0.1
-                for i in range(0, int(timeout / sleep_interval)):
-                    if not self._event_loop.is_running():
-                        break
-                    if i == 0:
-                        _LOG.info("Waiting for event loop thread to stop...")
-                    time.sleep(sleep_interval)
-                assert not self._event_loop.is_running()
+                _LOG.info("Waiting for event loop thread to stop...")
                 assert self._event_loop_thread is not None
-                self._event_loop_thread.join(timeout=1)
+                self._event_loop_thread.join(timeout=3)
                 if self._event_loop_thread.is_alive():
                     raise RuntimeError("Failed to stop event loop thread.")
                 self._event_loop.close()

--- a/mlos_bench/mlos_bench/event_loop_context.py
+++ b/mlos_bench/mlos_bench/event_loop_context.py
@@ -86,7 +86,6 @@ class EventLoopContext:
                 self._event_loop_thread.join(timeout=3)
                 if self._event_loop_thread.is_alive():
                     raise RuntimeError("Failed to stop event loop thread.")
-                self._event_loop.close()
                 self._event_loop_thread = None
 
     def run_coroutine(self, coro: Coroutine[Any, Any, CoroReturnType]) -> FutureReturnType:

--- a/mlos_bench/mlos_bench/event_loop_context.py
+++ b/mlos_bench/mlos_bench/event_loop_context.py
@@ -65,6 +65,8 @@ class EventLoopContext:
             if not self._event_loop_thread:
                 assert self._event_loop_thread_refcnt == 0
                 if self._event_loop is None:
+                    if sys.platform == "win32":
+                        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
                     self._event_loop = asyncio.new_event_loop()
                 assert not self._event_loop.is_running()
                 self._event_loop_thread = Thread(target=self._run_event_loop, daemon=True)

--- a/mlos_bench/mlos_bench/services/remote/ssh/ssh_service.py
+++ b/mlos_bench/mlos_bench/services/remote/ssh/ssh_service.py
@@ -8,6 +8,7 @@ A collection functions for interacting with SSH servers as file shares.
 
 from abc import ABCMeta
 from asyncio import Event as CoroEvent, Lock as CoroLock
+from warnings import warn
 from types import TracebackType
 from typing import Any, Callable, Coroutine, Dict, List, Literal, Optional, Tuple, Type, Union
 from threading import current_thread
@@ -124,6 +125,9 @@ class SshClientCache:
         self._refcnt -= 1
         if self._refcnt <= 0:
             self.cleanup()
+            if self._cache_lock.locked():
+                warn(RuntimeWarning("SshClientCache lock was still held on exit."))
+                self._cache_lock.release()
 
     async def get_client_connection(self, connect_params: dict) -> Tuple[SSHClientConnection, SshClient]:
         """
@@ -263,8 +267,8 @@ class SshService(Service, metaclass=ABCMeta):
         # Stop the background thread if it's not needed anymore and potentially
         # cleanup the cache as well.
         assert self._in_context
-        SshService._EVENT_LOOP_THREAD_SSH_CLIENT_CACHE.exit()
         SshService._EVENT_LOOP_CONTEXT.exit()
+        SshService._EVENT_LOOP_THREAD_SSH_CLIENT_CACHE.exit()
         return super()._exit_context(ex_type, ex_val, ex_tb)
 
     @classmethod

--- a/mlos_bench/mlos_bench/services/remote/ssh/ssh_service.py
+++ b/mlos_bench/mlos_bench/services/remote/ssh/ssh_service.py
@@ -267,8 +267,8 @@ class SshService(Service, metaclass=ABCMeta):
         # Stop the background thread if it's not needed anymore and potentially
         # cleanup the cache as well.
         assert self._in_context
-        SshService._EVENT_LOOP_CONTEXT.exit()
         SshService._EVENT_LOOP_THREAD_SSH_CLIENT_CACHE.exit()
+        SshService._EVENT_LOOP_CONTEXT.exit()
         return super()._exit_context(ex_type, ex_val, ex_tb)
 
     @classmethod

--- a/mlos_bench/mlos_bench/tests/event_loop_context_test.py
+++ b/mlos_bench/mlos_bench/tests/event_loop_context_test.py
@@ -7,6 +7,7 @@ Tests for mlos_bench.event_loop_context background thread logic.
 """
 
 import asyncio
+import sys
 import time
 
 from asyncio import AbstractEventLoop
@@ -116,8 +117,13 @@ def test_event_loop_context() -> None:
     assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop_thread_refcnt == 0
     assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop is event_loop is not None
     assert not EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop.is_running()
+    # Check that the event loop has no more tasks.
     assert hasattr(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop, '_ready')
-    assert len(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop._ready) == 0
+    # Windows ProactorEventLoopPolicy adds a dummy task.
+    if sys.platform == 'win32' and isinstance(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop, asyncio.ProactorEventLoop):
+        assert len(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop._ready) == 1
+    else:
+        assert len(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop._ready) == 0
     assert hasattr(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop, '_scheduled')
     assert len(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop._scheduled) == 0
 

--- a/mlos_bench/mlos_bench/tests/event_loop_context_test.py
+++ b/mlos_bench/mlos_bench/tests/event_loop_context_test.py
@@ -9,6 +9,7 @@ Tests for mlos_bench.event_loop_context background thread logic.
 import asyncio
 import time
 
+from asyncio import AbstractEventLoop
 from threading import Thread
 from types import TracebackType
 from typing import Optional, Type
@@ -62,6 +63,8 @@ def test_event_loop_context() -> None:
     assert not event_loop_caller_instance_1._in_context
     assert event_loop_caller_instance_1.EVENT_LOOP_CONTEXT._event_loop_thread is None
 
+    event_loop: Optional[AbstractEventLoop] = None
+
     # After we enter the instance context, we should have a background thread.
     with event_loop_caller_instance_1:
         assert event_loop_caller_instance_1._in_context
@@ -73,6 +76,7 @@ def test_event_loop_context() -> None:
         assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop_thread_refcnt == 1
         assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop is not None
         assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop.is_running()
+        event_loop = EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop
 
         event_loop_caller_instance_2 = EventLoopContextCaller(instance_id=2)
         assert event_loop_caller_instance_2
@@ -110,11 +114,29 @@ def test_event_loop_context() -> None:
 
     assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop_thread is None    # type: ignore[unreachable] # (false positives)
     assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop_thread_refcnt == 0
-    assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop is None
+    assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop is event_loop is not None
+    assert not EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop.is_running()
+    assert hasattr(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop, '_ready')
+    assert len(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop._ready) == 0
+    assert hasattr(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop, '_scheduled')
+    assert len(EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop._scheduled) == 0
 
     with pytest.raises(AssertionError), pytest.warns(RuntimeWarning, match=r".*coroutine 'sleep' was never awaited"):
         future = event_loop_caller_instance_1.EVENT_LOOP_CONTEXT.run_coroutine(asyncio.sleep(0.1, result='foo'))
         raise ValueError(f"Future should not have been available to wait on {future.result()}")
+
+    # Test that when re-entering the context we have the same event loop.
+    with event_loop_caller_instance_1:
+        assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop is not None
+        assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop.is_running()
+        assert EventLoopContextCaller.EVENT_LOOP_CONTEXT._event_loop is event_loop
+
+        # Test running again.
+        start = time.time()
+        future = event_loop_caller_instance_1.EVENT_LOOP_CONTEXT.run_coroutine(asyncio.sleep(0.1, result='foo'))
+        assert 0.0 <= time.time() - start < 0.1
+        assert future.result(timeout=0.2) == 'foo'
+        assert 0.1 <= time.time() - start <= 0.2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tries to handle a few issues we've seen with the event loop code.

In particular, Windows sometimes hangs and seems to have lingering coroutines (sometimes added by it's default ProactorEventLoopPolicy).

This change adds some additional tests and debug code and switches to the SelectorEventLoopPolicy for Windows.

Note: this comes with some drawbacks like not being able to handle subprocesses in async code, which could prove to be a problem for us with parallel executors in the future:
https://docs.python.org/3/library/asyncio-platforms.html#windows