### PR TITLE
Allow storage RG override for separate control plane RG vs experiment RG

### DIFF
--- a/scripts/generate-azure-credentials-config.sh
+++ b/scripts/generate-azure-credentials-config.sh
@@ -8,12 +8,13 @@ set -eu
 set -x
 
 AZURE_DEFAULTS_GROUP=${AZURE_DEFAULTS_GROUP:-$(az config get --local defaults.group --query value -o tsv)}
+AZURE_STORAGE_ACCOUNT_RG=${AZURE_STORAGE_ACCOUNT_RG:-$AZURE_DEFAULTS_GROUP}
 AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME:-$(az config get --local storage.account --query value -o tsv)}
 
 az account get-access-token \
     --query "{tenant:tenant,subscription:subscription}" |
     jq ".storageAccountKey = `
         az storage account keys list \
-            --resource-group $AZURE_DEFAULTS_GROUP \
+            --resource-group $AZURE_STORAGE_ACCOUNT_RG \
             --account-name $AZURE_STORAGE_ACCOUNT_NAME \
             --query '[0].value'`"


### PR DESCRIPTION
Allow overriding which RG to look for the storage account in when separating experiment RG from control plane RG