### PR TITLE
Retries for HTTP requests

### DIFF
--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -214,8 +214,9 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
         retry = Retry(total=total, backoff_factor=backoff_factor)
         adapter = HTTPAdapter(max_retries=retry)
 
-        session.mount("http://", adapter)
         session.mount("https://", adapter)
+
+        session.headers.update(self._get_headers())
 
         return session
 
@@ -311,10 +312,9 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
 
         session = self._get_session(params)
         try:
-            response = session.get(url, headers=self._get_headers(), timeout=self._request_timeout)
+            response = session.get(url, timeout=self._request_timeout)
         except requests.exceptions.ReadTimeout:
             _LOG.warning("Request timed out: %s", url)
-            # return Status.TIMED_OUT, {}
             return Status.RUNNING, {}
         except requests.exceptions.RequestException as ex:
             _LOG.exception("Error in request checking operation status", exc_info=ex)
@@ -472,7 +472,7 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
 
         session = self._get_session(params)
         try:
-            response = session.get(url, headers=self._get_headers(), timeout=self._request_timeout)
+            response = session.get(url, timeout=self._request_timeout)
         except requests.exceptions.ReadTimeout:
             _LOG.warning("Request timed out: %s", url)
             return Status.RUNNING, {}

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_services.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 from mlos_bench.environments.status import Status
 from mlos_bench.services.base_service import Service
@@ -34,6 +35,8 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
     _POLL_INTERVAL = 4     # seconds
     _POLL_TIMEOUT = 300    # seconds
     _REQUEST_TIMEOUT = 5   # seconds
+    _REQUEST_TOTAL_RETRIES = 10  # Total number retries for each request
+    _REQUEST_RETRY_BACKOFF_FACTOR = 0.3  # Delay (seconds) between retries: {backoff factor} * (2 ** ({number of previous retries}))
 
     # Azure Resources Deployment REST API as described in
     # https://docs.microsoft.com/en-us/rest/api/resources/deployments
@@ -179,6 +182,8 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
         self._poll_interval = float(self.config.get("pollInterval", self._POLL_INTERVAL))
         self._poll_timeout = float(self.config.get("pollTimeout", self._POLL_TIMEOUT))
         self._request_timeout = float(self.config.get("requestTimeout", self._REQUEST_TIMEOUT))
+        self._total_retries = int(self.config.get("requestTotalRetries", self._REQUEST_TOTAL_RETRIES))
+        self._backoff_factor = float(self.config.get("requestBackoffFactor", self._REQUEST_RETRY_BACKOFF_FACTOR))
 
         # TODO: Provide external schema validation?
         template = self.config_loader_service.load_config(
@@ -200,6 +205,19 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
             self._custom_data_file = self.config_loader_service.resolve_path(self._custom_data_file)
             with open(self._custom_data_file, 'r', encoding='utf-8') as custom_data_fh:
                 self._deploy_params["customData"] = custom_data_fh.read()
+
+    def _get_session(self, params: dict) -> requests.Session:
+        total = params.get("requestTotalRetries", self._total_retries)
+        backoff_factor = params.get("requestBackoffFactor", self._backoff_factor)
+
+        session = requests.Session()
+        retry = Retry(total=total, backoff_factor=backoff_factor)
+        adapter = HTTPAdapter(max_retries=retry)
+
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
+        return session
 
     def _get_headers(self) -> dict:
         """
@@ -291,12 +309,16 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
         if url is None:
             return Status.PENDING, {}
 
+        session = self._get_session(params)
         try:
-            response = requests.get(url, headers=self._get_headers(), timeout=self._request_timeout)
+            response = session.get(url, headers=self._get_headers(), timeout=self._request_timeout)
         except requests.exceptions.ReadTimeout:
             _LOG.warning("Request timed out: %s", url)
             # return Status.TIMED_OUT, {}
             return Status.RUNNING, {}
+        except requests.exceptions.RequestException as ex:
+            _LOG.exception("Error in request checking operation status", exc_info=ex)
+            return (Status.FAILED, {})
 
         if _LOG.isEnabledFor(logging.DEBUG):
             _LOG.debug("Response: %s\n%s", response,
@@ -448,7 +470,16 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
             deployment_name=config["deploymentName"],
         )
 
-        response = requests.get(url, headers=self._get_headers(), timeout=self._request_timeout)
+        session = self._get_session(params)
+        try:
+            response = session.get(url, headers=self._get_headers(), timeout=self._request_timeout)
+        except requests.exceptions.ReadTimeout:
+            _LOG.warning("Request timed out: %s", url)
+            return Status.RUNNING, {}
+        except requests.exceptions.RequestException as ex:
+            _LOG.exception("Error in request checking deployment", exc_info=ex)
+            return (Status.FAILED, {})
+
         _LOG.debug("Response: %s", response)
 
         if response.status_code == 200:

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -6,15 +6,73 @@
 Tests for mlos_bench.services.remote.azure.azure_services
 """
 
+import http
+import json
+import tempfile
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests.exceptions as requests_ex
 
 from mlos_bench.environments.status import Status
 
 from mlos_bench.services.remote.azure.azure_auth import AzureAuthService
 from mlos_bench.services.remote.azure.azure_services import AzureVMService
+
+
+def make_httplib_json_response(status: int, json_data: dict):
+    """
+    Prepare a json response object for use with urllib3
+    Inspired by: https://stackoverflow.com/questions/66497627/how-to-test-retry-attempts-in-python-using-the-request-library
+    """
+    data = json.dumps(json_data).encode("utf-8")
+    f = tempfile.TemporaryFile("wb+")
+    f.write(data)
+    f.seek(0)
+    f.status = status
+    f.msg = http.client.HTTPMessage()
+    f.length_remaining = len(data)
+    f.headers = {}
+    f.version = ""
+    f.reason = ""
+    f.isclosed = lambda: f.closed
+    return f
+
+
+@pytest.mark.parametrize(
+    ("total_retries", "operation_status"), [
+        (2, Status.SUCCEEDED),
+        (1, Status.FAILED),
+        (0, Status.FAILED),
+    ])
+@patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+def test_wait_host_deployment_retry(mock_getconn: MagicMock,
+                                    total_retries: int,
+                                    operation_status: Status,
+                                    azure_vm_service: AzureVMService) -> None:
+    """
+    Test retries of the host deployment operation.
+    """
+    params = {
+        "pollInterval": 0.1,
+        "requestTotalRetries": total_retries,
+        "deploymentName": "TEST_DEPLOYMENT1",
+        "subscription": "TEST_SUB1",
+        "resourceGroup": "TEST_RG1",
+    }
+
+    # Simulate intermittent connection issues
+    mock_getconn.return_value.getresponse.side_effect = [
+        make_httplib_json_response(200, {"properties": {"provisioningState": "Running"}}),
+        requests_ex.ConnectionError("Connection aborted", OSError(107, "Transport endpoint is not connected")),
+        requests_ex.ConnectionError("Connection aborted", OSError(107, "Transport endpoint is not connected")),
+        make_httplib_json_response(200, {"properties": {"provisioningState": "Running"}}),
+        make_httplib_json_response(200, {"properties": {"provisioningState": "Succeeded"}}),
+    ]
+
+    (status, _) = azure_vm_service.wait_host_deployment(params, is_setup=True)
+    assert status == operation_status
 
 
 def test_azure_vm_service_custom_data(azure_auth_service: AzureAuthService) -> None:
@@ -81,8 +139,8 @@ def test_vm_operation_status(mock_requests: MagicMock,
 
 
 @patch("mlos_bench.services.remote.azure.azure_services.time.sleep")
-@patch("mlos_bench.services.remote.azure.azure_services.requests")
-def test_wait_vm_operation_ready(mock_requests: MagicMock, mock_sleep: MagicMock,
+@patch("mlos_bench.services.remote.azure.azure_services.requests.Session")
+def test_wait_vm_operation_ready(mock_session: MagicMock, mock_sleep: MagicMock,
                                  azure_vm_service: AzureVMService) -> None:
     """
     Test waiting for the completion of the remote VM operation.
@@ -100,17 +158,17 @@ def test_wait_vm_operation_ready(mock_requests: MagicMock, mock_sleep: MagicMock
     mock_status_response.json.return_value = {
         "status": "Succeeded",
     }
-    mock_requests.get.return_value = mock_status_response
+    mock_session.return_value.get.return_value = mock_status_response
 
     status, _ = azure_vm_service.wait_host_operation(params)
 
-    assert (async_url, ) == mock_requests.get.call_args[0]
+    assert (async_url, ) == mock_session.return_value.get.call_args[0]
     assert (retry_after, ) == mock_sleep.call_args[0]
     assert status.is_succeeded()
 
 
-@patch("mlos_bench.services.remote.azure.azure_services.requests")
-def test_wait_vm_operation_timeout(mock_requests: MagicMock,
+@patch("mlos_bench.services.remote.azure.azure_services.requests.Session")
+def test_wait_vm_operation_timeout(mock_session: MagicMock,
                                    azure_vm_service: AzureVMService) -> None:
     """
     Test the time out of the remote VM operation.
@@ -126,10 +184,44 @@ def test_wait_vm_operation_timeout(mock_requests: MagicMock,
     mock_status_response.json.return_value = {
         "status": "InProgress",
     }
-    mock_requests.get.return_value = mock_status_response
+    mock_session.return_value.get.return_value = mock_status_response
 
     (status, _) = azure_vm_service.wait_host_operation(params)
     assert status == Status.TIMED_OUT
+
+
+@pytest.mark.parametrize(
+    ("total_retries", "operation_status"), [
+        (2, Status.SUCCEEDED),
+        (1, Status.FAILED),
+        (0, Status.FAILED),
+    ])
+@patch("urllib3.connectionpool.HTTPConnectionPool._get_conn")
+def test_wait_vm_operation_retry(mock_getconn: MagicMock,
+                                 total_retries: int,
+                                 operation_status: Status,
+                                 azure_vm_service: AzureVMService) -> None:
+    """
+    Test the retries of the remote VM operation.
+    """
+    params = {
+        "pollInterval": 0.1,
+        "requestTotalRetries": total_retries,
+        "asyncResultsUrl": "https://DUMMY_ASYNC_URL",
+        "vmName": "test-vm",
+    }
+
+    # Simulate intermittent connection issues
+    mock_getconn.return_value.getresponse.side_effect = [
+        make_httplib_json_response(200, {"status": "InProgress"}),
+        requests_ex.ConnectionError("Connection aborted", OSError(107, "Transport endpoint is not connected")),
+        requests_ex.ConnectionError("Connection aborted", OSError(107, "Transport endpoint is not connected")),
+        make_httplib_json_response(200, {"status": "InProgress"}),
+        make_httplib_json_response(200, {"status": "Succeeded"}),
+    ]
+
+    (status, _) = azure_vm_service.wait_host_operation(params)
+    assert status == operation_status
 
 
 @pytest.mark.parametrize(

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_services_test.py
@@ -6,13 +6,13 @@
 Tests for mlos_bench.services.remote.azure.azure_services
 """
 
-import http
 import json
-import tempfile
 from copy import deepcopy
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+import urllib3
 import requests.exceptions as requests_ex
 
 from mlos_bench.environments.status import Status
@@ -21,23 +21,17 @@ from mlos_bench.services.remote.azure.azure_auth import AzureAuthService
 from mlos_bench.services.remote.azure.azure_services import AzureVMService
 
 
-def make_httplib_json_response(status: int, json_data: dict):
+def make_httplib_json_response(status: int, json_data: dict) -> urllib3.HTTPResponse:
     """
     Prepare a json response object for use with urllib3
-    Inspired by: https://stackoverflow.com/questions/66497627/how-to-test-retry-attempts-in-python-using-the-request-library
     """
     data = json.dumps(json_data).encode("utf-8")
-    f = tempfile.TemporaryFile("wb+")
-    f.write(data)
-    f.seek(0)
-    f.status = status
-    f.msg = http.client.HTTPMessage()
-    f.length_remaining = len(data)
-    f.headers = {}
-    f.version = ""
-    f.reason = ""
-    f.isclosed = lambda: f.closed
-    return f
+    response = urllib3.HTTPResponse(
+        status=status,
+        body=BytesIO(data),
+        preload_content=False,
+    )
+    return response
 
 
 @pytest.mark.parametrize(

--- a/scripts/generate-azure-credentials-config.sh
+++ b/scripts/generate-azure-credentials-config.sh
@@ -8,12 +8,13 @@ set -eu
 set -x
 
 AZURE_DEFAULTS_GROUP=${AZURE_DEFAULTS_GROUP:-$(az config get --local defaults.group --query value -o tsv)}
+AZURE_STORAGE_ACCOUNT_RG=${AZURE_STORAGE_ACCOUNT_RG:-$AZURE_DEFAULTS_GROUP}
 AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME:-$(az config get --local storage.account --query value -o tsv)}
 
 az account get-access-token \
     --query "{tenant:tenant,subscription:subscription}" |
     jq ".storageAccountKey = `
         az storage account keys list \
-            --resource-group $AZURE_DEFAULTS_GROUP \
+            --resource-group $AZURE_STORAGE_ACCOUNT_RG \
             --account-name $AZURE_STORAGE_ACCOUNT_NAME \
             --query '[0].value'`"


### PR DESCRIPTION
This PR enables automatic retry and backoffs for HTTP requests made using requests, mainly targeting GETs.
This is to address intermittent connection issues observed during long-running operations such as polling, which would have resulted in OSErrors crashing MLOS and ending experiments prematurely.

The main patterns used are:
- https://docs.python-requests.org/en/latest/user/advanced/#example-automatic-retries
- https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry 