### PR TITLE
Explicitly add the project root to pytest arguments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -137,7 +137,8 @@
     // See Also .vscode/launch.json for environment variable args to pytest during debug sessions.
     // For the rest, see setup.cfg
     "python.testing.pytestArgs": [
-        "--log-level=DEBUG"
+        "--log-level=DEBUG",
+        "."
     ],
     "python.testing.unittestEnabled": false
 }


### PR DESCRIPTION
My VSCode adds `"."` to pytest arguments in config every time I rebuild the container - and deletes the `--log-level=DEBUG` argument at teh same time. With this small fix, vscode can accept the project config as we have it in git without modifying it