### PR TITLE
Add support for recursive dictionary templating to more places

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -73,6 +73,8 @@
         "subcmd",
         "subschema",
         "subschemas",
+        "Templater",
+        "templating",
         "tolist",
         "tunables",
         "workerinput",

--- a/mlos_bench/mlos_bench/dict_templater.py
+++ b/mlos_bench/mlos_bench/dict_templater.py
@@ -30,8 +30,6 @@ class DictTemplater:    # pylint: disable=too-few-public-methods
         self._template_dict = source_dict.copy()
         # The source/target dictionary to expand.
         self._dict: Dict[str, Any] = {}
-        # An additional source dictionary to use for expansion.
-        self._extra_source_dict: Dict[str, Any] = {}
 
     def expand_vars(self, *,
                     extra_source_dict: Optional[Dict[str, Any]] = None,

--- a/mlos_bench/mlos_bench/dict_templater.py
+++ b/mlos_bench/mlos_bench/dict_templater.py
@@ -6,6 +6,7 @@
 Simple class to help with nested dictionary $var templating.
 """
 
+from copy import deepcopy
 from string import Template
 from typing import Any, Dict, Optional
 
@@ -27,7 +28,7 @@ class DictTemplater:    # pylint: disable=too-few-public-methods
             The template dict to use for source variables.
         """
         # A copy of the initial data structure we were given with templates intact.
-        self._template_dict = source_dict.copy()
+        self._template_dict = deepcopy(source_dict)
         # The source/target dictionary to expand.
         self._dict: Dict[str, Any] = {}
 
@@ -49,7 +50,7 @@ class DictTemplater:    # pylint: disable=too-few-public-methods
         Dict[str, Any]
             The expanded dictionary.
         """
-        self._dict = self._template_dict.copy()
+        self._dict = deepcopy(self._template_dict)
         extra_source_dict = {} if extra_source_dict is None else extra_source_dict
         self._dict = self._expand_vars(self._dict, extra_source_dict, use_os_env)
         assert isinstance(self._dict, dict)

--- a/mlos_bench/mlos_bench/dict_templater.py
+++ b/mlos_bench/mlos_bench/dict_templater.py
@@ -75,6 +75,8 @@ class DictTemplater:    # pylint: disable=too-few-public-methods
                 value[key] = self._expand_vars(val, extra_source_dict, use_os_env)
         elif isinstance(value, list):
             value = [self._expand_vars(val, extra_source_dict, use_os_env) for val in value]
+        elif isinstance(value, (int, float, bool)) or value is None:
+            return value
         else:
             raise ValueError(f"Unexpected type {type(value)} for value {value}")
         return value

--- a/mlos_bench/mlos_bench/dict_templater.py
+++ b/mlos_bench/mlos_bench/dict_templater.py
@@ -1,0 +1,81 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Simple class to help with nested dictionary $var templating.
+"""
+
+from string import Template
+from typing import Any, Dict, Optional
+
+import os
+
+
+class DictTemplater:    # pylint: disable=too-few-public-methods
+    """
+    Simple class to help with nested dictionary $var templating.
+    """
+
+    def __init__(self, source_dict: Dict[str, Any]):
+        """
+        Initialize the templater.
+
+        Parameters
+        ----------
+        source_dict : Dict[str, Any]
+            The template dict to use for source variables.
+        """
+        # A copy of the initial data structure we were given with templates intact.
+        self._template_dict = source_dict.copy()
+        # The source/target dictionary to expand.
+        self._dict: Dict[str, Any] = {}
+        # An additional source dictionary to use for expansion.
+        self._extra_source_dict: Dict[str, Any] = {}
+
+    def expand_vars(self, *,
+                    extra_source_dict: Optional[Dict[str, Any]] = None,
+                    use_os_env: bool = False) -> Dict[str, Any]:
+        """
+        Expand the template variables in the destination dictionary.
+
+        Parameters
+        ----------
+        extra_source_dict : Dict[str, Any]
+            An optional extra source dictionary to use for expansion.
+        use_os_env : bool
+            Whether to use the os environment variables a final fallback for expansion.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The expanded dictionary.
+        """
+        self._dict = self._template_dict.copy()
+        extra_source_dict = {} if extra_source_dict is None else extra_source_dict
+        self._dict = self._expand_vars(self._dict, extra_source_dict, use_os_env)
+        assert isinstance(self._dict, dict)
+        return self._dict
+
+    def _expand_vars(self, value: Any, extra_source_dict: Dict[str, Any], use_os_env: bool) -> Any:
+        """
+        Recursively expand $var strings in the currently operating dictionary.
+        """
+        if isinstance(value, str):
+            # First try to expand all $vars internally.
+            value = Template(value).safe_substitute(self._dict)
+            # Next, if there are any left, try to expand them from the extra source dict.
+            if extra_source_dict:
+                value = Template(value).safe_substitute(extra_source_dict)
+            # Finally, fallback to the os environment.
+            if use_os_env:
+                value = Template(value).safe_substitute(dict(os.environ))
+            return value
+        if isinstance(value, dict):
+            # Note: we use a loop instead of dict comprehension in order to
+            # allow secondary expansion of subsequent values immediately.
+            for (key, val) in value.items():
+                value[key] = self._expand_vars(val, extra_source_dict, use_os_env)
+        if isinstance(value, list):
+            return [self._expand_vars(val, extra_source_dict, use_os_env) for val in value]
+        return value

--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -10,12 +10,12 @@ import abc
 import json
 import logging
 from datetime import datetime
-from string import Template
 from types import TracebackType
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, TYPE_CHECKING, Union
 from typing_extensions import Literal
 
 from mlos_bench.config.schemas import ConfigSchema
+from mlos_bench.dict_templater import DictTemplater
 from mlos_bench.environments.status import Status
 from mlos_bench.services.base_service import Service
 from mlos_bench.tunables.tunable import TunableValue
@@ -201,10 +201,7 @@ class Environment(metaclass=abc.ABCMeta):
         """
         Expand `$var` into actual values of the variables.
         """
-        return {
-            key: Template(val).safe_substitute(global_config) if isinstance(val, str) else val
-            for key, val in params.items()
-        }
+        return DictTemplater(params).expand_vars(extra_source_dict=global_config)
 
     @property
     def _config_loader_service(self) -> "SupportsConfigLoading":

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
@@ -210,6 +210,13 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
             with open(self._custom_data_file, 'r', encoding='utf-8') as custom_data_fh:
                 self._deploy_params["customData"] = custom_data_fh.read()
 
+    @property
+    def deploy_params(self) -> dict:
+        """
+        Get the deployment parameters.
+        """
+        return self._deploy_params
+
     def _get_session(self, params: dict) -> requests.Session:
         """
         Get a session object that includes automatic retries and headers for REST API calls.

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+from mlos_bench.dict_templater import DictTemplater
 from mlos_bench.environments.status import Status
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.types.authenticator_type import SupportsAuth
@@ -191,8 +192,11 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
         assert template is not None and isinstance(template, dict)
         self._deploy_template = template
 
-        self._deploy_params = merge_parameters(
-            dest=self.config['deploymentTemplateParameters'].copy(), source=global_config)
+        # Allow for recursive variable expansion as we do with global params and const_args.
+        deploy_params = DictTemplater(self.config['deploymentTemplateParameters'].copy()).expand_vars(
+            extra_source_dict=global_config or {})
+
+        self._deploy_params = merge_parameters(dest=deploy_params, source=global_config)
 
         # As a convenience, allow reading customData out of a file, rather than
         # embedding it in a json config file.

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
@@ -193,8 +193,7 @@ class AzureVMService(Service, SupportsHostProvisioning, SupportsHostOps, Support
         self._deploy_template = template
 
         # Allow for recursive variable expansion as we do with global params and const_args.
-        deploy_params = DictTemplater(self.config['deploymentTemplateParameters'].copy()).expand_vars(
-            extra_source_dict=global_config or {})
+        deploy_params = DictTemplater(self.config['deploymentTemplateParameters']).expand_vars(extra_source_dict=global_config)
 
         self._deploy_params = merge_parameters(dest=deploy_params, source=global_config)
 

--- a/mlos_bench/mlos_bench/tests/dict_templater_test.py
+++ b/mlos_bench/mlos_bench/tests/dict_templater_test.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests for DictTemplater class.
+"""
+
+from mlos_bench.dict_templater import DictTemplater
+
+
+def test_no_side_effects() -> None:
+    raise NotImplementedError("TODO")
+
+
+def test_secondary_expansion() -> None:
+    raise NotImplementedError("TODO")
+
+
+def test_from_os_env_expansion() -> None:
+    raise NotImplementedError("TODO")
+
+
+def test_from_extras_expansion() -> None:
+    raise NotImplementedError("TODO")

--- a/mlos_bench/mlos_bench/tests/dict_templater_test.py
+++ b/mlos_bench/mlos_bench/tests/dict_templater_test.py
@@ -6,20 +6,144 @@
 Unit tests for DictTemplater class.
 """
 
+from copy import deepcopy
+from typing import Any, Dict
+
+import os
+
+import pytest
+
 from mlos_bench.dict_templater import DictTemplater
 
 
-def test_no_side_effects() -> None:
-    raise NotImplementedError("TODO")
+@pytest.fixture
+def source_template_dict() -> Dict[str, Any]:
+    """A source dictionary with template variables."""
+    return {
+        "extra_str-ref": "$extra_str-ref",
+        "str": "string",
+        "str_ref": "$str-ref",
+        "secondary_expansion": "${str_ref}",
+        "tertiary_expansion": "$secondary_expansion",
+        "int": 1,
+        "int_ref": "$int-ref",
+        "float": 1.0,
+        "float_ref": "$float-ref",
+        "bool": True,
+        "bool_ref": "$bool-ref",
+        "list": [
+            "$str",
+            "$int",
+            "$float",
+        ],
+        "dict": {
+            "nested-str-ref": "nested-$str-ref",
+            "nested-extra-str-ref": "nested-$extra_str-ref",
+        },
+    }
 
 
-def test_secondary_expansion() -> None:
-    raise NotImplementedError("TODO")
+# pylint: disable=redefined-outer-name
 
 
-def test_from_os_env_expansion() -> None:
-    raise NotImplementedError("TODO")
+def test_no_side_effects(source_template_dict: Dict[str, Any]) -> None:
+    """
+    Test that the templater does not modify the source dictionary.
+    """
+    source_template_dict_copy = deepcopy(source_template_dict)
+    results = DictTemplater(source_template_dict_copy).expand_vars()
+    assert results
+    assert source_template_dict_copy == source_template_dict
 
 
-def test_from_extras_expansion() -> None:
-    raise NotImplementedError("TODO")
+def test_secondary_expansion(source_template_dict: Dict[str, Any]) -> None:
+    """
+    Test that internal expansions work as expected.
+    """
+    results = DictTemplater(source_template_dict).expand_vars()
+    assert results == {
+        "extra_str-ref": "$extra_str-ref",
+        "str": "string",
+        "str_ref": "string-ref",
+        "secondary_expansion": "string-ref",
+        "tertiary_expansion": "string-ref",
+        "int": 1,
+        "int_ref": "1-ref",
+        "float": 1.0,
+        "float_ref": "1.0-ref",
+        "bool": True,
+        "bool_ref": "True-ref",
+        "list": [
+            "string",
+            "1",
+            "1.0",
+        ],
+        "dict": {
+            "nested-str-ref": "nested-string-ref",
+            "nested-extra-str-ref": "nested-$extra_str-ref",
+        },
+    }
+
+
+def test_os_env_expansion(source_template_dict: Dict[str, Any]) -> None:
+    """
+    Test that expansions from OS env work as expected.
+    """
+    os.environ["extra_str"] = "os-env-extra_str"
+    os.environ["string"] = "shouldn't be used"
+    results = DictTemplater(source_template_dict).expand_vars(use_os_env=True)
+    assert results == {
+        "extra_str-ref": f"{os.environ['extra_str']}-ref",
+        "str": "string",
+        "str_ref": "string-ref",
+        "secondary_expansion": "string-ref",
+        "tertiary_expansion": "string-ref",
+        "int": 1,
+        "int_ref": "1-ref",
+        "float": 1.0,
+        "float_ref": "1.0-ref",
+        "bool": True,
+        "bool_ref": "True-ref",
+        "list": [
+            "string",
+            "1",
+            "1.0",
+        ],
+        "dict": {
+            "nested-str-ref": "nested-string-ref",
+            "nested-extra-str-ref": f"nested-{os.environ['extra_str']}-ref",
+        },
+    }
+
+
+def test_from_extras_expansion(source_template_dict: Dict[str, Any]) -> None:
+    """
+    Test that
+    """
+    extra_source_dict = {
+        "extra_str": "str-from-extras",
+        "string": "shouldn't be used",
+    }
+    results = DictTemplater(source_template_dict).expand_vars(extra_source_dict=extra_source_dict)
+    assert results == {
+        "extra_str-ref": f"{extra_source_dict['extra_str']}-ref",
+        "str": "string",
+        "str_ref": "string-ref",
+        "secondary_expansion": "string-ref",
+        "tertiary_expansion": "string-ref",
+        "int": 1,
+        "int_ref": "1-ref",
+        "float": 1.0,
+        "float_ref": "1.0-ref",
+        "bool": True,
+        "bool_ref": "True-ref",
+        "list": [
+            "string",
+            "1",
+            "1.0",
+        ],
+        "dict": {
+            "nested-str-ref": "nested-string-ref",
+            "nested-extra-str-ref": f"nested-{extra_source_dict['extra_str']}-ref",
+        },
+    }

--- a/mlos_bench/mlos_bench/tests/environments/base_env_test.py
+++ b/mlos_bench/mlos_bench/tests/environments/base_env_test.py
@@ -63,6 +63,7 @@ def test_expand_const_args() -> None:
         "a": "b",
         "foo": "$bar/baz",
         "1": 1,
+        "recursive": "$foo/expansion",
     }
     global_config: Dict[str, TunableValue] = {
         "bar": "blah",
@@ -72,4 +73,5 @@ def test_expand_const_args() -> None:
         "a": "b",
         "foo": "blah/baz",
         "1": 1,
+        "recursive": "blah/baz/expansion",
     }


### PR DESCRIPTION
Fixes extracted from #606 

This expands support for doing secondary `$var` string template expansion to two additional places beyond `global_config`:

- `const_args`
- `deploymentTemplateParameters` in `AzureVmService` (and soon `AzureNetworkService`)

Expands a few test cases to check for this and relies on one prior existing one to still pass (the `launch_parse_args` tests which already checked for this behavior in `global_config` expansion).