### PR TITLE
Enforce correct code coverage threshold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ PYTEST_OPTIONS :=
 SKIP_COVERAGE := $(shell echo $${SKIP_COVERAGE:-} | grep -i -x -e 1 -e true)
 
 ifeq ($(SKIP_COVERAGE),)
-    PYTEST_OPTIONS += --cov=. --cov-append --cov-fail-under=0.92 --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml --local-badge-output-dir=doc/source/badges/
+    PYTEST_OPTIONS += --cov=. --cov-append --cov-fail-under=92 --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml --local-badge-output-dir=doc/source/badges/
 endif
 
 # Run the pytest target on only the modules that have changed recently, but

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ PYTEST_OPTIONS :=
 SKIP_COVERAGE := $(shell echo $${SKIP_COVERAGE:-} | grep -i -x -e 1 -e true)
 
 ifeq ($(SKIP_COVERAGE),)
-    PYTEST_OPTIONS += --cov=. --cov-append --cov-fail-under=92 --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml --local-badge-output-dir=doc/source/badges/
+    PYTEST_OPTIONS += --cov=. --cov-append --cov-fail-under=91.5 --cov-report=xml --cov-report=html --junitxml=junit/test-results.xml --local-badge-output-dir=doc/source/badges/
 endif
 
 # Run the pytest target on only the modules that have changed recently, but


### PR DESCRIPTION
Corrects this error:

```
---------- coverage: platform linux, python 3.11.5-final-0 -----------
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

Required test coverage of 0.92% reached. Total coverage: 93.12%
=========================== short test summary info ============================
```