### PR TITLE
Move deploymentName from the Service config to the Environment config

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-service-subschema.json
@@ -20,11 +20,6 @@
                             "description": "The name of the resource group to place the deployment in (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
-                        "deploymentName": {
-                            "$comment": "TODO: provide templating strings to augment names via experiment_id/trial_id, for instance.",
-                            "description": "Name of the deployment to create for the experiment resources.",
-                            "type": "string"
-                        },
                         "deploymentTemplatePath": {
                             "description": "Path to an ARM template file.",
                             "type": "string",
@@ -56,7 +51,6 @@
                         }
                     },
                     "required": [
-                        "deploymentName",
                         "deploymentTemplatePath"
                     ]
                 }

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
@@ -10,7 +10,6 @@
                 // can be overridden by the parameters pushed from the caller Environment.
                 "subscription": "PLACEHOLDER; AZURE SUBSCRIPTION ID",
                 "resourceGroup": "PLACEHOLDER; e.g., os-autotune",
-                "deploymentName": "PLACEHOLDER; e.g., mlos-2vms",
 
                 "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
 

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_network_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_network_services.py
@@ -68,6 +68,15 @@ class AzureNetworkService(AzureService, SupportsNetworkProvisioning):
             ])
         )
 
+    def _set_default_params(self, params: dict) -> dict:    # pylint: disable=no-self-use
+        # Try and provide a semi sane default for the deploymentName if not provided
+        # since this is a common way to set the deploymentName and can same some
+        # config work for the caller.
+        if 'vnetName' not in params:
+            raise ValueError("Required param 'vnetName' is missing.")
+        params.setdefault(f"{params['vnetName']}-deployment")
+        return params
+
     def wait_network_deployment(self, params: dict, *, is_setup: bool) -> Tuple[Status, dict]:
         """
         Waits for a pending operation on an Azure VM to resolve to SUCCEEDED or FAILED.
@@ -127,6 +136,7 @@ class AzureNetworkService(AzureService, SupportsNetworkProvisioning):
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        params = self._set_default_params(params)
         config = merge_parameters(
             dest=self.config.copy(),
             source=params,

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_vm_services.py
@@ -162,6 +162,15 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             with open(self._custom_data_file, 'r', encoding='utf-8') as custom_data_fh:
                 self._deploy_params["customData"] = custom_data_fh.read()
 
+    def _set_default_params(self, params: dict) -> dict:    # pylint: disable=no-self-use
+        # Try and provide a semi sane default for the deploymentName if not provided
+        # since this is a common way to set the deploymentName and can same some
+        # config work for the caller.
+        if 'vmName' not in params:
+            raise ValueError("Required param 'vmName' is missing.")
+        params.setdefault(f"{params['vmName']}-deployment")
+        return params
+
     def wait_host_deployment(self, params: dict, *, is_setup: bool) -> Tuple[Status, dict]:
         """
         Waits for a pending operation on an Azure VM to resolve to SUCCEEDED or FAILED.
@@ -203,6 +212,8 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             Result is info on the operation runtime if SUCCEEDED, otherwise {}.
         """
         _LOG.info("Wait for operation on VM %s", params["vmName"])
+        # Try and provide a semi sane default for the deploymentName
+        params.setdefault(f"{params['vmName']}-deployment")
         return self._wait_while(self._check_operation_status, Status.RUNNING, params)
 
     def wait_os_operation(self, params: dict) -> Tuple["Status", dict]:
@@ -243,6 +254,7 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        params = self._set_default_params(params)
         config = merge_parameters(
             dest=self.config.copy(),
             source=params,
@@ -280,6 +292,7 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        params = self._set_default_params(params)
         config = merge_parameters(
             dest=self.config.copy(),
             source=params,
@@ -311,6 +324,7 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        params = self._set_default_params(params)
         config = merge_parameters(
             dest=self.config.copy(),
             source=params,
@@ -344,6 +358,7 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        params = self._set_default_params(params)
         config = merge_parameters(
             dest=self.config.copy(),
             source=params,
@@ -380,6 +395,7 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        params = self._set_default_params(params)
         config = merge_parameters(
             dest=self.config.copy(),
             source=params,
@@ -422,6 +438,7 @@ class AzureVMService(AzureService, SupportsHostProvisioning, SupportsHostOps, Su
             A pair of Status and result.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+        config = self._set_default_params(config)
         config = merge_parameters(
             dest=self.config.copy(),
             source=config,

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_network_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_network_service-config-missing.jsonc
@@ -1,9 +1,8 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureNetworkService",
     "config": {
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+        //"deploymentTemplatePath": "some/path/to/deployment/template.jsonc", // <-- missing
         "subscription": "subscription-id",
         "resourceGroup": "rg"
-        //"deploymentName": "deployment"    // <-- missing
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array-object.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array-object.jsonc
@@ -5,7 +5,6 @@
         "subscription": "subscription-id",
 
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "deploymentTemplateParameters": {
             "array": [ { "invalid": "type"} ]
         }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array.jsonc
@@ -5,7 +5,6 @@
         "subscription": "subscription-id",
 
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "deploymentTemplateParameters": {
             "array": [ ["nested", "array", "invalid"] ]
         }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-object.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-object.jsonc
@@ -5,7 +5,6 @@
         "subscription": "subscription-id",
 
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "deploymentTemplateParameters": {
             "object": { "invalid": "type" }
         }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-empty-arm-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-empty-arm-params.jsonc
@@ -3,7 +3,6 @@
     "config": {
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
             // "param": "value" // <-- need at least one parameter

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
@@ -1,9 +1,8 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureVMService",
     "config": {
-        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+        // "deploymentTemplatePath": "some/path/to/deployment/template.jsonc", // <-- missing
         "subscription": "subscription-id",
         "resourceGroup": "rg"
-        //"deploymentName": "deployment"    // <-- missing
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_network_service-config-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_network_service-config-extras.jsonc
@@ -4,7 +4,6 @@
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "vmName": "test-vm",
         "extra": "invalid"
     }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_vm_service-config-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_vm_service-config-extras.jsonc
@@ -4,7 +4,6 @@
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "vmName": "test-vm",
         "extra": "invalid"
     }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_network_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_network_service-full.jsonc
@@ -7,7 +7,6 @@
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "${experiment_id}-vnet-deployment",
 
         "deploymentTemplateParameters": {
             "location": "westus2",

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -7,7 +7,6 @@
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
 
         "customDataFile": "some/path/to/custom/data.yml",
         "deploymentTemplateParameters": {

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_network_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_network_service-partial.jsonc
@@ -3,7 +3,6 @@
     "config": {
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
             "param": "value"

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial-no-arm-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial-no-arm-params.jsonc
@@ -1,7 +1,6 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureVMService",
     "config": {
-        "deploymentName": "deployment",
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial.jsonc
@@ -3,7 +3,6 @@
     "config": {
         "subscription": "subscription-id",
         "resourceGroup": "rg",
-        "deploymentName": "deployment",
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
             "param": "value"

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_vm_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_vm_services_test.py
@@ -62,7 +62,6 @@ def test_azure_vm_service_recursive_template_params(azure_auth_service: AzureAut
     """
     config = {
         "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-        "deploymentName": "TEST_DEPLOYMENT1",
         "subscription": "TEST_SUB1",
         "resourceGroup": "TEST_RG1",
         "deploymentTemplateParameters": {
@@ -72,6 +71,7 @@ def test_azure_vm_service_recursive_template_params(azure_auth_service: AzureAut
         },
     }
     global_config = {
+        "deploymentName": "TEST_DEPLOYMENT1",
         "vmName": "test-vm",
         "location": "eastus",
     }
@@ -88,7 +88,6 @@ def test_azure_vm_service_custom_data(azure_auth_service: AzureAuthService) -> N
     config = {
         "customDataFile": "services/remote/azure/cloud-init/alt-ssh.yml",
         "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-        "deploymentName": "TEST_DEPLOYMENT1",
         "subscription": "TEST_SUB1",
         "resourceGroup": "TEST_RG1",
         "deploymentTemplateParameters": {
@@ -96,6 +95,7 @@ def test_azure_vm_service_custom_data(azure_auth_service: AzureAuthService) -> N
         },
     }
     global_config = {
+        "deploymentName": "TEST_DEPLOYMENT1",
         "vmName": "test-vm",
     }
     with pytest.raises(ValueError):

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/conftest.py
@@ -47,7 +47,6 @@ def azure_network_service(azure_auth_service: AzureAuthService) -> AzureNetworkS
     """
     return AzureNetworkService(config={
         "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-        "deploymentName": "TEST_DEPLOYMENT-VNET",
         "subscription": "TEST_SUB",
         "resourceGroup": "TEST_RG",
         "deploymentTemplateParameters": {
@@ -56,6 +55,7 @@ def azure_network_service(azure_auth_service: AzureAuthService) -> AzureNetworkS
         "pollInterval": 1,
         "pollTimeout": 2
     }, global_config={
+        "deploymentName": "TEST_DEPLOYMENT-VNET",
         "vnetName": "test-vnet",  # Should come from the upper-level config
     }, parent=azure_auth_service)
 
@@ -67,7 +67,6 @@ def azure_vm_service(azure_auth_service: AzureAuthService) -> AzureVMService:
     """
     return AzureVMService(config={
         "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
-        "deploymentName": "TEST_DEPLOYMENT-VM",
         "subscription": "TEST_SUB",
         "resourceGroup": "TEST_RG",
         "deploymentTemplateParameters": {
@@ -76,6 +75,7 @@ def azure_vm_service(azure_auth_service: AzureAuthService) -> AzureVMService:
         "pollInterval": 1,
         "pollTimeout": 2
     }, global_config={
+        "deploymentName": "TEST_DEPLOYMENT-VM",
         "vmName": "test-vm",  # Should come from the upper-level config
     }, parent=azure_auth_service)
 


### PR DESCRIPTION
Needed so that we can support multiple Environment deployments under the same Service.

Closes #610