### PR TITLE
Abstract OS environment variable case sensitivity name handling across platforms

### DIFF
--- a/mlos_bench/mlos_bench/dict_templater.py
+++ b/mlos_bench/mlos_bench/dict_templater.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from string import Template
 from typing import Any, Dict, Optional
 
-import os
+from mlos_bench.os_env import environ
 
 
 class DictTemplater:    # pylint: disable=too-few-public-methods
@@ -67,7 +67,7 @@ class DictTemplater:    # pylint: disable=too-few-public-methods
                 value = Template(value).safe_substitute(extra_source_dict)
             # Finally, fallback to the os environment.
             if use_os_env:
-                value = Template(value).safe_substitute(dict(os.environ))
+                value = Template(value).safe_substitute(dict(environ))
         elif isinstance(value, dict):
             # Note: we use a loop instead of dict comprehension in order to
             # allow secondary expansion of subsequent values immediately.

--- a/mlos_bench/mlos_bench/dict_templater.py
+++ b/mlos_bench/mlos_bench/dict_templater.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from string import Template
 from typing import Any, Dict, Optional
 
-from mlos_bench.os_env import environ
+from mlos_bench.os_environ import environ
 
 
 class DictTemplater:    # pylint: disable=too-few-public-methods

--- a/mlos_bench/mlos_bench/os_env.py
+++ b/mlos_bench/mlos_bench/os_env.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Simple abstraction for the OS environment variables.
+"""
+
+import os
+import sys
+
+
+if sys.platform == 'win32':
+    import nt
+
+
+# Handle case sensitivity differences between platforms.
+# https://stackoverflow.com/a/19023293
+environ: os._Environ[str] = nt.environ if sys.platform == 'win32' else os.environ
+# alias
+os_environ = environ
+
+__all__ = ['environ', 'os_environ']

--- a/mlos_bench/mlos_bench/os_env.py
+++ b/mlos_bench/mlos_bench/os_env.py
@@ -3,7 +3,14 @@
 # Licensed under the MIT License.
 #
 """
-Simple abstraction for the OS environment variables.
+Simple platform agnostic abstraction for the OS environment variables.
+Meant as a replacement for os.environ vs nt.environ.
+
+Example
+-------
+from mlos_bench.os_env import environ
+environ['FOO'] = 'bar'
+environ.get('PWD')
 """
 
 import os
@@ -11,13 +18,11 @@ import sys
 
 
 if sys.platform == 'win32':
-    import nt
+    import nt   # type: ignore[import-not-found]
 
 
 # Handle case sensitivity differences between platforms.
 # https://stackoverflow.com/a/19023293
 environ: os._Environ[str] = nt.environ if sys.platform == 'win32' else os.environ
-# alias
-os_environ = environ
 
-__all__ = ['environ', 'os_environ']
+__all__ = ['environ']

--- a/mlos_bench/mlos_bench/os_environ.py
+++ b/mlos_bench/mlos_bench/os_environ.py
@@ -18,7 +18,7 @@ import sys
 
 
 if sys.platform == 'win32':
-    import nt   # type: ignore[import-not-found]
+    import nt   # type: ignore[import-not-found]    # pylint: disable=import-error  # (3.8)
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -26,12 +26,12 @@ else:
     from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 9):
-    EnvironType: TypeAlias = os._Environ[str]
+    EnvironType: TypeAlias = os._Environ[str]   # pylint: disable=protected-access
 else:
-    EnvironType: TypeAlias = os._Environ
+    EnvironType: TypeAlias = os._Environ        # pylint: disable=protected-access
 
 # Handle case sensitivity differences between platforms.
 # https://stackoverflow.com/a/19023293
-environ: EnvironType = nt.environ if sys.platform == 'win32' else os.environ
+environ: EnvironType = nt.environ if sys.platform == 'win32' else os.environ    # type: ignore[name-defined]
 
 __all__ = ['environ']

--- a/mlos_bench/mlos_bench/os_environ.py
+++ b/mlos_bench/mlos_bench/os_environ.py
@@ -26,12 +26,12 @@ else:
     from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 9):
-    ENVIRON_TYPE: TypeAlias = os._Environ[str]
+    EnvironType: TypeAlias = os._Environ[str]
 else:
-    ENVIRON_TYPE: TypeAlias = os._Environ
+    EnvironType: TypeAlias = os._Environ
 
 # Handle case sensitivity differences between platforms.
 # https://stackoverflow.com/a/19023293
-environ: ENVIRON_TYPE = nt.environ if sys.platform == 'win32' else os.environ
+environ: EnvironType = nt.environ if sys.platform == 'win32' else os.environ
 
 __all__ = ['environ']

--- a/mlos_bench/mlos_bench/os_environ.py
+++ b/mlos_bench/mlos_bench/os_environ.py
@@ -26,7 +26,7 @@ else:
     from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 9):
-    EnvironType: TypeAlias = os._Environ[str]   # pylint: disable=protected-access
+    EnvironType: TypeAlias = os._Environ[str]   # pylint: disable=protected-access,disable=unsubscriptable-object
 else:
     EnvironType: TypeAlias = os._Environ        # pylint: disable=protected-access
 

--- a/mlos_bench/mlos_bench/os_environ.py
+++ b/mlos_bench/mlos_bench/os_environ.py
@@ -20,9 +20,18 @@ import sys
 if sys.platform == 'win32':
     import nt   # type: ignore[import-not-found]
 
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+if sys.version_info >= (3, 9):
+    ENVIRON_TYPE: TypeAlias = os._Environ[str]
+else:
+    ENVIRON_TYPE: TypeAlias = os._Environ
 
 # Handle case sensitivity differences between platforms.
 # https://stackoverflow.com/a/19023293
-environ: os._Environ[str] = nt.environ if sys.platform == 'win32' else os.environ
+environ: ENVIRON_TYPE = nt.environ if sys.platform == 'win32' else os.environ
 
 __all__ = ['environ']

--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -18,6 +18,7 @@ from typing import (
     Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING, Union
 )
 
+from mlos_bench.os_env import environ
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.local.temp_dir_context import TempDirContextService
 from mlos_bench.services.types.local_exec_type import SupportsLocalExec
@@ -199,7 +200,7 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
 
         if sys.platform == 'win32':
             # A hack to run Python on Windows with env variables set:
-            env_copy = os.environ.copy()
+            env_copy = environ.copy()
             env_copy["PYTHONPATH"] = ""
             env_copy.update(env)
             env = env_copy

--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -18,7 +18,7 @@ from typing import (
     Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, TYPE_CHECKING, Union
 )
 
-from mlos_bench.os_env import environ
+from mlos_bench.os_environ import environ
 from mlos_bench.services.base_service import Service
 from mlos_bench.services.local.temp_dir_context import TempDirContextService
 from mlos_bench.services.types.local_exec_type import SupportsLocalExec

--- a/mlos_bench/mlos_bench/tests/dict_templater_test.py
+++ b/mlos_bench/mlos_bench/tests/dict_templater_test.py
@@ -9,11 +9,10 @@ Unit tests for DictTemplater class.
 from copy import deepcopy
 from typing import Any, Dict
 
-import os
-
 import pytest
 
 from mlos_bench.dict_templater import DictTemplater
+from mlos_bench.os_env import environ
 
 
 @pytest.fixture
@@ -89,11 +88,12 @@ def test_os_env_expansion(source_template_dict: Dict[str, Any]) -> None:
     """
     Test that expansions from OS env work as expected.
     """
-    os.environ["extra_str"] = "os-env-extra_str"
-    os.environ["string"] = "shouldn't be used"
+    environ["extra_str"] = "os-env-extra_str"
+    environ["string"] = "shouldn't be used"
+
     results = DictTemplater(source_template_dict).expand_vars(use_os_env=True)
     assert results == {
-        "extra_str-ref": f"{os.environ['extra_str']}-ref",
+        "extra_str-ref": f"{environ['extra_str']}-ref",
         "str": "string",
         "str_ref": "string-ref",
         "secondary_expansion": "string-ref",
@@ -111,7 +111,7 @@ def test_os_env_expansion(source_template_dict: Dict[str, Any]) -> None:
         ],
         "dict": {
             "nested-str-ref": "nested-string-ref",
-            "nested-extra-str-ref": f"nested-{os.environ['extra_str']}-ref",
+            "nested-extra-str-ref": f"nested-{environ['extra_str']}-ref",
         },
     }
 

--- a/mlos_bench/mlos_bench/tests/dict_templater_test.py
+++ b/mlos_bench/mlos_bench/tests/dict_templater_test.py
@@ -12,7 +12,7 @@ from typing import Any, Dict
 import pytest
 
 from mlos_bench.dict_templater import DictTemplater
-from mlos_bench.os_env import environ
+from mlos_bench.os_environ import environ
 
 
 @pytest.fixture

--- a/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
@@ -16,6 +16,7 @@ import pytest
 
 from mlos_bench.launcher import Launcher
 from mlos_bench.optimizers import MockOptimizer
+from mlos_bench.os_env import environ
 from mlos_bench.config.schemas import ConfigSchema
 from mlos_bench.util import path_join
 from mlos_bench.services.types import (
@@ -61,10 +62,10 @@ def test_launcher_args_parse_1(config_paths: List[str]) -> None:
     # changing into the code directory, but doesn't update the PWD environment
     # variable so we use a separate variable.
     # See global_test_config.jsonc for more details.
-    os.environ["CUSTOM_PATH_FROM_ENV"] = os.getcwd()
+    environ["CUSTOM_PATH_FROM_ENV"] = os.getcwd()
     if sys.platform == 'win32':
         # Some env tweaks for platform compatibility.
-        os.environ['USER'] = os.environ['USERNAME']
+        environ['USER'] = environ['USERNAME']
 
     # This is part of the minimal required args by the Launcher.
     env_conf_path = 'environments/mock/mock_env.jsonc'
@@ -113,10 +114,10 @@ def test_launcher_args_parse_2(config_paths: List[str]) -> None:
     # changing into the code directory, but doesn't update the PWD environment
     # variable so we use a separate variable.
     # See global_test_config.jsonc for more details.
-    os.environ["CUSTOM_PATH_FROM_ENV"] = os.getcwd()
+    environ["CUSTOM_PATH_FROM_ENV"] = os.getcwd()
     if sys.platform == 'win32':
         # Some env tweaks for platform compatibility.
-        os.environ['USER'] = os.environ['USERNAME']
+        environ['USER'] = environ['USERNAME']
 
     config_file = 'cli/test-cli-config.jsonc'
     cli_args = ' '.join([f"--config-path {config_path}" for config_path in config_paths]) + \

--- a/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_parse_args_test.py
@@ -16,7 +16,7 @@ import pytest
 
 from mlos_bench.launcher import Launcher
 from mlos_bench.optimizers import MockOptimizer
-from mlos_bench.os_env import environ
+from mlos_bench.os_environ import environ
 from mlos_bench.config.schemas import ConfigSchema
 from mlos_bench.util import path_join
 from mlos_bench.services.types import (


### PR DESCRIPTION
Fixes a bug introduced in #614 for Windows tests.

On Windows, 

```python
os.environ["string"] = "str"
```

internally gets replaced as

```python
os.environ["STRING"]
```

The workaround is to use `nt.environ` on Windows instead.

This change introduces an abstraction to use a new simple drop in replacement library everywhere we need to handle environment variables.