### PR TITLE
CI tweak: use "release" event instead of "tag push" for pypi publishing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.5
+current_version = 0.2.6
 commit = True
 tag = True
 

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -58,6 +58,10 @@ jobs:
           echo "ERROR: tag ${{ github.ref_name }} doesn't appear to be included in the main branch." >&2
           exit 1
         fi
+        if ! echo "${{ github.ref_name }}" | egrep -q '^v([0-9]+\.){2,3}[0-9]+$'; then
+          echo "ERROR: tag ${{ github.ref_name }} doesn't appear to be a valid version tag." >&2
+          exit 1
+        fi
 
     - name: Set NO_CACHE variable based on commit messages and for nightly builds
       if: github.event_name == 'schedule' || contains(steps.get-commit-messages.outputs.COMMIT_MESSAGES, 'NO_CACHE=true') || github.event.inputs.NO_CACHE == 'true'

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -221,6 +221,7 @@ jobs:
         # other resources used.
         password: ${{ secrets.ACR_PASSWORD }}
     - name: Publish the container images
+      # TODO: add cleanup step to remove old images
       if: (github.repository == 'microsoft/mlos') && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
       timeout-minutes: 15
       run: |

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -11,10 +11,11 @@ on:
         default: false
         required: false
   push:
-    tags: ["v*"]
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [ published ]
   merge_group:
     types: [checks_requested]
   schedule:
@@ -172,7 +173,7 @@ jobs:
         rm -f doc/build/html/htmlcov/.gitignore
 
     - name: Publish package to Test PyPi
-      if: github.ref_type == 'tag'
+      if: github.event == 'release' && github.ref_type == 'tag'
       run: |
         if [ -n "${{ secrets.PYPI_TEST_USERNAME }}" ]; then
           docker exec --user vscode --env USER=vscode --env MAKEFLAGS=-Oline \
@@ -181,7 +182,7 @@ jobs:
         fi
 
     - name: Publish package to PyPi
-      if: github.repository == 'microsoft/mlos' && github.ref_type == 'tag'
+      if: github.repository == 'microsoft/mlos' && github.event == 'release' && github.ref_type == 'tag'
       run: |
         if [ -n "${{ secrets.PYPI_USERNAME }}" ]; then
           docker exec --user vscode --env USER=vscode --env MAKEFLAGS=-Oline \

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -35,7 +35,7 @@ copyright = '2022, GSL'
 author = 'GSL'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.5'
+release = '0.2.6'
 
 try:
     from setuptools_scm import get_version

--- a/mlos_bench/_version.py
+++ b/mlos_bench/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.2.5'
+_VERSION = '0.2.6'

--- a/mlos_core/_version.py
+++ b/mlos_core/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.2.5'
+_VERSION = '0.2.6'


### PR DESCRIPTION
Minor tweak on #626: instead of acting on tag push events, we only act on "release" events.  This gives us a chance to fix bad tag pushes (which otherwise don't have much gated checking on them) prior to attempting to publish a version on pypi, which cannot be overwritten (only superseded).