### PR TITLE
PyPi publish makefile rules fixup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = True
 tag = True
 

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ PUBLISH_DEPS += build/linklint-doc.build-stamp
 build/publish.${CONDA_ENV_NAME}.%.py.build-stamp: $(PUBLISH_DEPS)
 	rm -f mlos_*/dist/*.tar.gz
 	ls mlos_*/dist/*.tar | xargs -I% gzip -k %
-	repo_name=`echo "$@" | sed -e 's|build/publish\.||' -e 's|\.py\.build-stamp||'` \
+	repo_name=`echo "$@" | sed -r -e 's|build/publish\.[^.]+\.||' -e 's|\.py\.build-stamp||'` \
 		&& conda run -n ${CONDA_ENV_NAME} python3 -m twine upload --repository $$repo_name \
 			mlos_*/dist/mlos*-*.tar.gz mlos_*/dist/mlos*-*.whl
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -309,14 +309,13 @@ build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_viz/dist/tmp/mlos_viz-la
 	conda create -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) python=$(PYTHON_VERS_REQ)
 	# Install some additional dependencies necessary for clean building some of the wheels.
 	conda install -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) swig libpq
-	# Test a clean install of the mlos_core wheel.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl[full-tests]"
-	# Test a clean install of the mlos_bench wheel.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl[full-tests]"
+	# Test a clean install of the mlos wheels.
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install \
+		"mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl[full-tests]" \
+		"mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl[full-tests]" \
+		"mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl[full-tests]"
 	# Test that the config dir for mlos_bench got distributed.
 	test -e `conda env list | grep "mlos-dist-test-$(PYTHON_VERSION) " | awk '{ print $$2 }'`/lib/python$(PYTHON_VERS_REQ)/site-packages/mlos_bench/config/README.md
-	# Test a clean install of the mlos_viz wheel.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl[full-tests]"
 	touch $@
 
 .PHONY: dist-test

--- a/Makefile
+++ b/Makefile
@@ -309,13 +309,14 @@ build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_viz/dist/tmp/mlos_viz-la
 	conda create -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) python=$(PYTHON_VERS_REQ)
 	# Install some additional dependencies necessary for clean building some of the wheels.
 	conda install -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) swig libpq
-	# Test a clean install of the mlos wheels.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install \
-		"mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl[full-tests]" \
-		"mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl[full-tests]" \
-		"mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl[full-tests]"
+	# Test a clean install of the mlos_core wheel.
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl[full-tests]"
+	# Test a clean install of the mlos_bench wheel.
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl[full-tests]"
 	# Test that the config dir for mlos_bench got distributed.
 	test -e `conda env list | grep "mlos-dist-test-$(PYTHON_VERSION) " | awk '{ print $$2 }'`/lib/python$(PYTHON_VERS_REQ)/site-packages/mlos_bench/config/README.md
+	# Test a clean install of the mlos_viz wheel.
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl[full-tests]"
 	touch $@
 
 .PHONY: dist-test

--- a/Makefile
+++ b/Makefile
@@ -346,18 +346,19 @@ dist-test-clean: dist-test-env-clean
 publish: publish-pypi
 
 .PHONY:
-publish-pypi-deps: build/publish-pypi-deps.build-stamp
+publish-pypi-deps: build/publish-pypi-deps.${CONDA_ENV_NAME}.build-stamp
 
 build/publish-pypi-deps.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NAME}.build-stamp
 	conda run -n ${CONDA_ENV_NAME} pip install -U twine
 	touch $@
 
-build/publish.%.py.build-stamp: build/publish-pypi-deps.${CONDA_ENV_NAME}.build-stamp
-build/publish.%.py.build-stamp: build/pytest.${CONDA_ENV_NAME}.build-stamp
-build/publish.%.py.build-stamp: build/dist-test.$(PYTHON_VERSION).build-stamp
-build/publish.%.py.build-stamp: build/check-doc.build-stamp
-build/publish.%.py.build-stamp: build/linklint-doc.build-stamp
-build/publish.%.py.build-stamp:
+PUBLISH_DEPS := build/publish-pypi-deps.${CONDA_ENV_NAME}.build-stamp
+PUBLISH_DEPS += build/pytest.${CONDA_ENV_NAME}.build-stamp
+PUBLISH_DEPS += build/dist-test.$(PYTHON_VERSION).build-stamp
+PUBLISH_DEPS += build/check-doc.build-stamp
+PUBLISH_DEPS += build/linklint-doc.build-stamp
+
+build/publish.${CONDA_ENV_NAME}.%.py.build-stamp: $(PUBLISH_DEPS)
 	rm -f mlos_*/dist/*.tar.gz
 	ls mlos_*/dist/*.tar | xargs -I% gzip -k %
 	repo_name=`echo "$@" | sed -e 's|build/publish\.||' -e 's|\.py\.build-stamp||'` \
@@ -365,8 +366,8 @@ build/publish.%.py.build-stamp:
 			mlos_*/dist/mlos*-*.tar.gz mlos_*/dist/mlos*-*.whl
 	touch $@
 
-publish-pypi: build/publish.pypi.py.build-stamp
-publish-test-pypi: build/publish.testpypi.py.build-stamp
+publish-pypi: build/publish.${CONDA_ENV_NAME}.pypi.py.build-stamp
+publish-test-pypi: build/publish.${CONDA_ENV_NAME}.testpypi.py.build-stamp
 
 build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NAME}.build-stamp
 build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp: doc/requirements.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,7 @@ copyright = '2024, GSL'
 author = 'GSL'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.1'
+release = '0.3.2'
 
 try:
     from setuptools_scm import get_version

--- a/mlos_bench/_version.py
+++ b/mlos_bench/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_bench package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.3.1'
+_VERSION = '0.3.2'

--- a/mlos_core/_version.py
+++ b/mlos_core/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.3.1'
+_VERSION = '0.3.2'


### PR DESCRIPTION
Prior Makefile rule consolidation tried to group dependencies for the pattern rule into separate lines for readability, but apparently this isn't allowed.

This minor changes separates those out into a variable we can reference instead.  Tested on a clean build tree locally.