### PR TITLE
Disallow `!` characters in tunable parameter names.

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/tunables/tunable-params-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/tunables/tunable-params-schema.json
@@ -136,7 +136,8 @@
         "tunable_params_set": {
             "type": "object",
             "patternProperties": {
-                "^.+$": {
+                "^[^!]+$": {
+                    "$comment": "`!` characters are not currently allowed in tunable parameter names.",
                     "$ref": "#/$defs/tunable_param"
                 }
             },

--- a/mlos_bench/mlos_bench/tests/config/schemas/tunable-params/test-cases/bad/invalid/tunable-params-bad-name.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/tunable-params/test-cases/bad/invalid/tunable-params-bad-name.jsonc
@@ -1,0 +1,12 @@
+{
+    "covariant_group_name-1": {
+        "cost": 1,
+        "params": {
+            "bad-!-char-in-name": {
+                "type": "categorical",
+                "default": "foo",
+                "values": ["foo", "bar"]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow on to #617 