### PR TITLE
Add `default_tunable_config_id` property to `ExperimentData`

### DIFF
--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -131,12 +131,18 @@ def _optimize(*,
                 trial = exp.new_trial(tunables, config={
                     # Add some additional metadata to track for the trial such as the
                     # optimizer config used.
+                    # Note: these values are unfortunately mutable at the moment.
+                    # Consider them as hints of what the config was the trial *started*.
+                    # It is possible that the experiment configs were changed
+                    # between resuming the experiment (since that is not currently
+                    # prevented).
                     # TODO: Improve for supporting multi-objective
                     # (e.g., opt_target_1, opt_target_2, ... and opt_direction_1, opt_direction_2, ...)
                     "optimizer": opt.name,
                     "opt_target": opt.target,
                     "opt_direction": opt.direction,
                     "repeat_i": repeat_i,
+                    "is_defaults": tunables.is_defaults,
                 })
                 _run(env_context, opt_context, trial, global_config)
 

--- a/mlos_bench/mlos_bench/storage/base_experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/base_experiment_data.py
@@ -8,7 +8,7 @@ Base interface for accessing the stored benchmark experiment data.
 
 from abc import ABCMeta, abstractmethod
 from distutils.util import strtobool    # pylint: disable=deprecated-module
-from typing import Dict, Literal, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
 import pandas
 

--- a/mlos_bench/mlos_bench/storage/base_experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/base_experiment_data.py
@@ -7,7 +7,8 @@ Base interface for accessing the stored benchmark experiment data.
 """
 
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Tuple, TYPE_CHECKING
+from distutils.util import strtobool    # pylint: disable=deprecated-module
+from typing import Dict, Literal, Optional, Tuple, TYPE_CHECKING
 
 import pandas
 
@@ -118,6 +119,33 @@ class ExperimentData(metaclass=ABCMeta):
         trials : Dict[int, TunableConfigTrialGroupData]
             A dictionary of the trials' data, keyed by (tunable) by config id.
         """
+
+    @property
+    def default_tunable_config_id(self) -> Optional[int]:
+        """
+        Retrieves the (tunable) config id for the default tunable values for this experiment.
+
+        Note: this is by *default* the first trial executed for this experiment.
+        However, it is currently possible that the user changed the tunables config
+        in between resumptions of an experiment.
+
+        Returns
+        -------
+        int
+        """
+        # Note: this implementation is quite inefficient and may be better
+        # reimplemented by subclasses.
+
+        # Check to see if we included it in trial metadata.
+        trials_items = sorted(self.trials.items())
+        if not trials_items:
+            return None
+        for (_trial_id, trial) in trials_items:
+            # Take the first config id marked as "defaults" when it was instantiated.
+            if strtobool(str(trial.metadata_dict.get('is_defaults', False))):
+                return trial.tunable_config_id
+        # Fallback (min trial_id)
+        return trials_items[0][1].tunable_config_id
 
     @property
     @abstractmethod

--- a/mlos_bench/mlos_bench/storage/sql/experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment_data.py
@@ -10,7 +10,7 @@ from typing import Dict
 import logging
 
 import pandas
-from sqlalchemy import Engine, Integer, func
+from sqlalchemy import Engine, Integer, String, func
 
 from mlos_bench.storage.base_experiment_data import ExperimentData
 from mlos_bench.storage.base_trial_data import TrialData
@@ -113,7 +113,8 @@ class ExperimentSqlData(ExperimentData):
             tunable_config_trial_groups = conn.execute(
                 self._schema.trial.select().with_only_columns(
                     self._schema.trial.c.config_id,
-                    func.min(self._schema.trial.c.trial_id).cast(Integer).label('tunable_config_trial_group_id'),
+                    func.min(self._schema.trial.c.trial_id).cast(Integer).label(    # pylint: disable=not-callable
+                        'tunable_config_trial_group_id'),
                 ).where(
                     self._schema.trial.c.exp_id == self._experiment_id,
                 ).group_by(
@@ -153,6 +154,62 @@ class ExperimentSqlData(ExperimentData):
                 )
                 for tunable_config in tunable_configs.fetchall()
             }
+
+    @property
+    def default_tunable_config_id(self) -> Optional[int]:
+        """
+        Retrieves the (tunable) config id for the default tunable values for this experiment.
+
+        Note: this is by *default* the first trial executed for this experiment.
+        However, it is currently possible that the user changed the tunables config
+        in between resumptions of an experiment.
+
+        Returns
+        -------
+        int
+        """
+        with self._engine.connect() as conn:
+            query_results = conn.execute(
+                self._schema.trial.select().with_only_columns(
+                    self._schema.trial.c.config_id.cast(Integer).label('config_id'),
+                ).where(
+                    self._schema.trial.c.exp_id == self._experiment_id,
+                    self._schema.trial.c.trial_id.in_(
+                        self._schema.trial_param.select().with_only_columns(
+                            func.min(self._schema.trial_param.c.trial_id).cast(Integer).label(  # pylint: disable=not-callable
+                                "first_trial_id_with_defaults"),
+                        ).where(
+                            self._schema.trial_param.c.exp_id == self._experiment_id,
+                            self._schema.trial_param.c.param_id == "is_defaults",
+                            func.lower(self._schema.trial_param.c.param_value, type_=String).in_(["1", "true"]),
+                        ).scalar_subquery()
+                    )
+                )
+            )
+            min_default_trial_row = query_results.fetchone()
+            if min_default_trial_row is not None:
+                # pylint: disable=protected-access  # following DeprecationWarning in sqlalchemy
+                return min_default_trial_row._tuple()[0]
+            # fallback logic - assume minimum trial_id for experiment
+            query_results = conn.execute(
+                self._schema.trial.select().with_only_columns(
+                    self._schema.trial.c.config_id.cast(Integer).label('config_id'),
+                ).where(
+                    self._schema.trial.c.exp_id == self._experiment_id,
+                    self._schema.trial.c.trial_id.in_(
+                        self._schema.trial.select().with_only_columns(
+                            func.min(self._schema.trial.c.trial_id).cast(Integer).label("first_trial_id"),
+                        ).where(
+                            self._schema.trial.c.exp_id == self._experiment_id,
+                        ).scalar_subquery()
+                    )
+                )
+            )
+            min_trial_row = query_results.fetchone()
+            if min_trial_row is not None:
+                # pylint: disable=protected-access  # following DeprecationWarning in sqlalchemy
+                return min_trial_row._tuple()[0]
+            return None
 
     @property
     def results_df(self) -> pandas.DataFrame:

--- a/mlos_bench/mlos_bench/storage/sql/experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment_data.py
@@ -5,7 +5,7 @@
 """
 An interface to access the experiment benchmark data stored in SQL DB.
 """
-from typing import Dict
+from typing import Dict, Optional
 
 import logging
 

--- a/mlos_bench/mlos_bench/tests/storage/exp_data_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/exp_data_test.py
@@ -140,3 +140,8 @@ def test_exp_data_tunable_configs(exp_data: ExperimentData) -> None:
     assert [config.tunable_config_id
             for config in exp_data.tunable_configs.values()
             ] == list(range(1, CONFIG_COUNT + 1))
+
+
+def test_exp_data_default_config_id(exp_data: ExperimentData) -> None:
+    """Tests the default_tunable_config_id property of ExperimentData"""
+    assert exp_data.default_tunable_config_id == 1


### PR DESCRIPTION
Splitting work out from #633.

Having an easy way to identify what is the "default" config group for an Experiment makes analysis of improvements easier.

One challenge with this is that we don't currently strictly enforce non-changes between resumptions of an Experiment, so it's currently possible for the user to change the tunables config and adjust what the "default".

Moreover, in the past we didn't store what the default config was in the DB.

By convention we take the first one for now as a fallback.