### PR TITLE
Remove mistakenly added columns

### DIFF
--- a/mlos_bench/mlos_bench/storage/sql/schema.py
+++ b/mlos_bench/mlos_bench/storage/sql/schema.py
@@ -62,8 +62,6 @@ class DbSchema:
             Column("root_env_config", String(1024), nullable=False),
             Column("git_repo", String(1024), nullable=False),
             Column("git_commit", String(40), nullable=False),
-            Column("optimization_target", String(1024), nullable=True),
-            Column("optimization_direction", String(10), nullable=True),
 
             PrimaryKeyConstraint("exp_id"),
         )


### PR DESCRIPTION
#628 mistakenly included an early attempt at adding `optimization_target` and `optimization_direction` to the `experiment` table in the `mlos_bench.storage.sql` backend.

In that PR we later moved it to its own `objectives` table to eventually support multi-objectives.

Nothing accesses those columns now, however including them in the metadata makes it impossible to load storage backends previously created with the old schema since adjusting columns with sqlalchemy's `create_all()` API only considers table existence.

On the contrary, the latter means that we will automatically support old storage backends with the new code for the `objectives` table.

Removing these two columns in the `metadata` schema description simply allows that to proceed without error.

See Also: #649 