### PR TITLE
Workaround pytest version bump incompatibility with pytest-lazy-fixtures plugin

### DIFF
--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -75,7 +75,7 @@ extra_requires: Dict[str, List[str]] = {    # pylint: disable=consider-using-nam
 extra_requires['full'] = list(set(chain(*extra_requires.values())))
 
 extra_requires['full-tests'] = extra_requires['full'] + [
-    'pytest',
+    'pytest<8.0.0',     # FIXME: https://github.com/TvoroG/pytest-lazy-fixture/issues/65
     'pytest-forked',
     'pytest-xdist',
     'pytest-cov',


### PR DESCRIPTION
See Also:
- https://github.com/TvoroG/pytest-lazy-fixture/issues/65
- https://github.com/pytest-dev/pytest/issues/11890