### PR TITLE
Bump version: 0.4.2 → 0.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,7 @@ copyright = '2024, GSL'
 author = 'GSL'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.2'
+release = '0.5.0'
 
 try:
     from setuptools_scm import get_version

--- a/mlos_bench/_version.py
+++ b/mlos_bench/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_bench package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.4.2'
+_VERSION = '0.5.0'

--- a/mlos_core/_version.py
+++ b/mlos_core/_version.py
@@ -7,4 +7,4 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.4.2'
+_VERSION = '0.5.0'


### PR DESCRIPTION
Let's cut a new minor release with the new functionality we've merged in this week.