### PR TITLE
Handle some mypy errors and increase test coverage

### DIFF
--- a/mlos_core/mlos_core/optimizers/optimizer.py
+++ b/mlos_core/mlos_core/optimizers/optimizer.py
@@ -8,7 +8,7 @@ Contains the BaseOptimizer abstract class.
 
 import collections
 from abc import ABCMeta, abstractmethod
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import ConfigSpace
 import numpy as np
@@ -237,7 +237,7 @@ class BaseOptimizer(metaclass=ABCMeta):
                     j += 1
         return pd.DataFrame(df_dict)
 
-    def _to_1hot(self, config: pd.DataFrame) -> npt.NDArray:
+    def _to_1hot(self, config: Union[pd.DataFrame, pd.Series]) -> npt.NDArray:
         """
         Convert pandas DataFrame to one-hot-encoded numpy array.
         """
@@ -253,10 +253,14 @@ class BaseOptimizer(metaclass=ABCMeta):
             j = 0
             for param in self.optimizer_parameter_space.values():
                 if config.ndim > 1:
+                    assert isinstance(config, pd.DataFrame)
                     col = config.columns.get_loc(param.name)
+                    assert isinstance(col, int)
                     val = config.iloc[i, col]
                 else:
+                    assert isinstance(config, pd.Series)
                     col = config.index.get_loc(param.name)
+                    assert isinstance(col, int)
                     val = config.iloc[col]
                 if isinstance(param, ConfigSpace.CategoricalHyperparameter):
                     offset = param.choices.index(val)

--- a/mlos_core/mlos_core/tests/optimizers/one_hot_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/one_hot_test.py
@@ -101,9 +101,9 @@ def test_from_1hot_series(configuration_space: CS.ConfigurationSpace,
     Toy problem to test one-hot decoding of series.
     """
     optimizer = SmacOptimizer(parameter_space=configuration_space)
-    df = optimizer._from_1hot(one_hot_series)
-    assert df.shape[0] == 1, f"Unexpected number of rows ({df.shape[0]} != 1)"
-    assert df.iloc[0].to_dict() == series.to_dict()
+    one_hot_df = optimizer._from_1hot(one_hot_series)
+    assert one_hot_df.shape[0] == 1, f"Unexpected number of rows ({one_hot_df.shape[0]} != 1)"
+    assert one_hot_df.iloc[0].to_dict() == series.to_dict()
 
 
 def test_round_trip_data_frame(configuration_space: CS.ConfigurationSpace, data_frame: pd.DataFrame) -> None:

--- a/mlos_core/mlos_core/tests/optimizers/one_hot_test.py
+++ b/mlos_core/mlos_core/tests/optimizers/one_hot_test.py
@@ -32,7 +32,7 @@ def data_frame() -> pd.DataFrame:
 
 
 @pytest.fixture
-def one_hot() -> npt.NDArray:
+def one_hot_data_frame() -> npt.NDArray:
     """
     One-hot encoding of the `data_frame` above.
     The columns follow the order of the hyperparameters in `configuration_space`.
@@ -44,25 +44,69 @@ def one_hot() -> npt.NDArray:
     ])
 
 
-def test_to_1hot(configuration_space: CS.ConfigurationSpace,
-                 data_frame: pd.DataFrame, one_hot: npt.NDArray) -> None:
+@pytest.fixture
+def series() -> pd.Series:
     """
-    Toy problem to test one-hot encoding.
+    Toy series corresponding to the `configuration_space` hyperparameters.
+    The columns are deliberately *not* in alphabetic order.
+    """
+    return pd.Series({
+        'y': 'b',
+        'x': 0.4,
+        'z': 3,
+    })
+
+
+@pytest.fixture
+def one_hot_series() -> npt.NDArray:
+    """
+    One-hot encoding of the `series` above.
+    The columns follow the order of the hyperparameters in `configuration_space`.
+    """
+    return np.array([
+        [0.4, 0.0, 1.0, 0.0, 3],
+    ])
+
+
+def test_to_1hot_data_frame(configuration_space: CS.ConfigurationSpace,
+                            data_frame: pd.DataFrame, one_hot_data_frame: npt.NDArray) -> None:
+    """
+    Toy problem to test one-hot encoding of dataframe.
     """
     optimizer = SmacOptimizer(parameter_space=configuration_space)
-    assert optimizer._to_1hot(data_frame) == pytest.approx(one_hot)
+    assert optimizer._to_1hot(data_frame) == pytest.approx(one_hot_data_frame)
 
 
-def test_from_1hot(configuration_space: CS.ConfigurationSpace,
-                   data_frame: pd.DataFrame, one_hot: npt.NDArray) -> None:
+def test_to_1hot_series(configuration_space: CS.ConfigurationSpace,
+                        series: pd.Series, one_hot_series: npt.NDArray) -> None:
     """
-    Toy problem to test one-hot decoding.
+    Toy problem to test one-hot encoding of series.
     """
     optimizer = SmacOptimizer(parameter_space=configuration_space)
-    assert optimizer._from_1hot(one_hot).to_dict() == data_frame.to_dict()
+    assert optimizer._to_1hot(series) == pytest.approx(one_hot_series)
 
 
-def test_round_trip(configuration_space: CS.ConfigurationSpace, data_frame: pd.DataFrame) -> None:
+def test_from_1hot_data_frame(configuration_space: CS.ConfigurationSpace,
+                              data_frame: pd.DataFrame, one_hot_data_frame: npt.NDArray) -> None:
+    """
+    Toy problem to test one-hot decoding of dataframe.
+    """
+    optimizer = SmacOptimizer(parameter_space=configuration_space)
+    assert optimizer._from_1hot(one_hot_data_frame).to_dict() == data_frame.to_dict()
+
+
+def test_from_1hot_series(configuration_space: CS.ConfigurationSpace,
+                          series: pd.Series, one_hot_series: npt.NDArray) -> None:
+    """
+    Toy problem to test one-hot decoding of series.
+    """
+    optimizer = SmacOptimizer(parameter_space=configuration_space)
+    df = optimizer._from_1hot(one_hot_series)
+    assert df.shape[0] == 1, f"Unexpected number of rows ({df.shape[0]} != 1)"
+    assert df.iloc[0].to_dict() == series.to_dict()
+
+
+def test_round_trip_data_frame(configuration_space: CS.ConfigurationSpace, data_frame: pd.DataFrame) -> None:
     """
     Round-trip test for one-hot-encoding and then decoding a data frame.
     """
@@ -73,10 +117,30 @@ def test_round_trip(configuration_space: CS.ConfigurationSpace, data_frame: pd.D
     assert (df_round_trip.z == data_frame.z).all()
 
 
-def test_round_trip_reverse(configuration_space: CS.ConfigurationSpace, one_hot: npt.NDArray) -> None:
+def test_round_trip_series(configuration_space: CS.ConfigurationSpace, series: pd.DataFrame) -> None:
+    """
+    Round-trip test for one-hot-encoding and then decoding a series.
+    """
+    optimizer = SmacOptimizer(parameter_space=configuration_space)
+    series_round_trip = optimizer._from_1hot(optimizer._to_1hot(series))
+    assert series_round_trip.x.to_numpy() == pytest.approx(series.x)
+    assert (series_round_trip.y == series.y).all()
+    assert (series_round_trip.z == series.z).all()
+
+
+def test_round_trip_reverse_data_frame(configuration_space: CS.ConfigurationSpace, one_hot_data_frame: npt.NDArray) -> None:
     """
     Round-trip test for one-hot-decoding and then encoding of a numpy array.
     """
     optimizer = SmacOptimizer(parameter_space=configuration_space)
-    round_trip = optimizer._to_1hot(optimizer._from_1hot(one_hot))
-    assert round_trip == pytest.approx(one_hot)
+    round_trip = optimizer._to_1hot(optimizer._from_1hot(one_hot_data_frame))
+    assert round_trip == pytest.approx(one_hot_data_frame)
+
+
+def test_round_trip_reverse_series(configuration_space: CS.ConfigurationSpace, one_hot_series: npt.NDArray) -> None:
+    """
+    Round-trip test for one-hot-decoding and then encoding of a numpy array.
+    """
+    optimizer = SmacOptimizer(parameter_space=configuration_space)
+    round_trip = optimizer._to_1hot(optimizer._from_1hot(one_hot_series))
+    assert round_trip == pytest.approx(one_hot_series)


### PR DESCRIPTION
Our one hot encoding previously had some conditional handling of 1 dimensional DataFrames.
That doesn't exist - those are Series.  As such, the typing returns recently started alerting (due to an upstream dependency bump).
Moreover, we lacked test coverage for that path.
This change makes it more clear what those type expectations are and adds tests.