### PR TITLE
Initial work to separate the scheduler and the optimizer (no async yet)

### DIFF
--- a/mlos_bench/mlos_bench/launcher.py
+++ b/mlos_bench/mlos_bench/launcher.py
@@ -76,7 +76,11 @@ class Launcher:
         else:
             config = {}
 
-        self.trial_config_repeat_count: int = args.trial_config_repeat_count or config.get("trial_config_repeat_count", 1)
+        self.trial_config_repeat_count: int = (
+            args.trial_config_repeat_count or config.get("trial_config_repeat_count", 1)
+        )
+        if self.trial_config_repeat_count <= 0:
+            raise ValueError(f"Invalid trial_config_repeat_count: {self.trial_config_repeat_count}")
 
         log_level = args.log_level or config.get("log_level", _LOG_LEVEL)
         try:

--- a/mlos_bench/mlos_bench/optimizers/base_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/base_optimizer.py
@@ -195,7 +195,7 @@ class Optimizer(metaclass=ABCMeta):     # pylint: disable=too-many-instance-attr
 
     @abstractmethod
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
-                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = True) -> bool:
+                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = False) -> bool:
         """
         Pre-load the optimizer with the bulk data from previous experiments.
 

--- a/mlos_bench/mlos_bench/optimizers/base_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/base_optimizer.py
@@ -195,7 +195,7 @@ class Optimizer(metaclass=ABCMeta):     # pylint: disable=too-many-instance-attr
 
     @abstractmethod
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
-                      status: Optional[Sequence[Status]] = None) -> bool:
+                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = True) -> bool:
         """
         Pre-load the optimizer with the bulk data from previous experiments.
 
@@ -207,13 +207,16 @@ class Optimizer(metaclass=ABCMeta):     # pylint: disable=too-many-instance-attr
             Benchmark results from experiments that correspond to `configs`.
         status : Optional[Sequence[float]]
             Status of the experiments that correspond to `configs`.
+        is_warm_up : bool
+            True for the initial load, False for subsequent calls.
 
         Returns
         -------
         is_not_empty : bool
             True if there is data to register, false otherwise.
         """
-        _LOG.info("Warm-up the optimizer with: %d configs, %d scores, %d status values",
+        _LOG.info("%s the optimizer with: %d configs, %d scores, %d status values",
+                  "Warm-up" if is_warm_up else "Load",
                   len(configs or []), len(scores or []), len(status or []))
         if len(configs or []) != len(scores or []):
             raise ValueError("Numbers of configs and scores do not match.")

--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -99,7 +99,7 @@ class MlosCoreOptimizer(Optimizer):
         return f"{self.__class__.__name__}:{self._opt.__class__.__name__}"
 
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
-                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = True) -> bool:
+                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = False) -> bool:
         if not super().bulk_register(configs, scores, status, is_warm_up):
             return False
         df_configs = self._to_df(configs)  # Impute missing values, if necessary

--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -111,6 +111,8 @@ class MlosCoreOptimizer(Optimizer):
             df_configs = df_configs[df_status_completed]
             df_scores = df_scores[df_status_completed]
         self._opt.register(df_configs, df_scores)
+        if not is_warm_up:
+            self._iter += len(df_scores)
         if _LOG.isEnabledFor(logging.DEBUG):
             (score, _) = self.get_best_observation()
             _LOG.debug("Warm-up end: %s = %s", self.target, score)

--- a/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mlos_core_optimizer.py
@@ -99,8 +99,8 @@ class MlosCoreOptimizer(Optimizer):
         return f"{self.__class__.__name__}:{self._opt.__class__.__name__}"
 
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
-                      status: Optional[Sequence[Status]] = None) -> bool:
-        if not super().bulk_register(configs, scores, status):
+                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = True) -> bool:
+        if not super().bulk_register(configs, scores, status, is_warm_up):
             return False
         df_configs = self._to_df(configs)  # Impute missing values, if necessary
         df_scores = pd.Series(scores, dtype=float) * self._opt_sign

--- a/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
@@ -42,7 +42,7 @@ class MockOptimizer(Optimizer):
         self._best_score: Optional[float] = None
 
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
-                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = True) -> bool:
+                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = False) -> bool:
         if not super().bulk_register(configs, scores, status, is_warm_up):
             return False
         if status is None:

--- a/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
+++ b/mlos_bench/mlos_bench/optimizers/mock_optimizer.py
@@ -42,15 +42,17 @@ class MockOptimizer(Optimizer):
         self._best_score: Optional[float] = None
 
     def bulk_register(self, configs: Sequence[dict], scores: Sequence[Optional[float]],
-                      status: Optional[Sequence[Status]] = None) -> bool:
-        if not super().bulk_register(configs, scores, status):
+                      status: Optional[Sequence[Status]] = None, is_warm_up: bool = True) -> bool:
+        if not super().bulk_register(configs, scores, status, is_warm_up):
             return False
         if status is None:
             status = [Status.SUCCEEDED] * len(configs)
         for (params, score, trial_status) in zip(configs, scores, status):
             tunables = self._tunables.copy().assign(params)
             self.register(tunables, trial_status, None if score is None else float(score))
-            self._iter -= 1  # Do not advance the iteration counter during warm-up.
+            if is_warm_up:
+                # Do not advance the iteration counter during warm-up.
+                self._iter -= 1
         if _LOG.isEnabledFor(logging.DEBUG):
             (score, _) = self.get_best_observation()
             _LOG.debug("Warm-up end: %s = %s", self.target, score)

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -99,7 +99,7 @@ def _optimization_loop(*,
             # Complete trials that are pending or in-progress.
             _scheduler(exp, env_context, global_config, running=True)
             # Load past trials data into the optimizer
-            _optimizer(exp, opt_context, is_warm_up=True)
+            last_trial_id = _optimizer(exp, opt_context, is_warm_up=True)
         else:
             _LOG.warning("Skip pending trials and warm-up: %s", opt)
 
@@ -113,7 +113,7 @@ def _optimization_loop(*,
             # TODO: In the future, _scheduler and _optimizer
             # can be run in parallel in two independent loops.
             _scheduler(exp, env_context, global_config)
-            _optimizer(exp, opt_context, last_trial_id, trial_config_repeat_count)
+            last_trial_id = _optimizer(exp, opt_context, last_trial_id, trial_config_repeat_count)
 
         if do_teardown:
             env_context.teardown()

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -161,7 +161,7 @@ def _optimizer(exp: Storage.Experiment, opt_context: Optimizer,
     Optimizer part of the loop. Load the results of the executed trials
     into the optimizer, suggest new configurations, and add them to the queue.
     """
-    (configs, scores, status) = exp.load(last_trial_id)
+    (configs, scores, status) = exp.load(last_trial_id - 1)
     opt_context.bulk_register(configs, scores, status, is_warm_up)
 
     tunables = opt_context.suggest()

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -73,9 +73,6 @@ def _optimization_loop(*,
     trial_config_repeat_count : int
         How many trials to repeat for the same configuration.
     """
-    if trial_config_repeat_count <= 0:
-        raise ValueError(f"Invalid trial_config_repeat_count: {trial_config_repeat_count}")
-
     if _LOG.isEnabledFor(logging.INFO):
         _LOG.info("Root Environment:\n%s", env.pprint())
 

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -169,7 +169,7 @@ def _schedule_trial(exp: Storage.Experiment, opt: Optimizer,
     Add a configuration to the queue of trials.
     """
     for repeat_i in range(1, trial_config_repeat_count + 1):
-        trial = exp.new_trial(tunables, config={
+        exp.new_trial(tunables, config={
             # Add some additional metadata to track for the trial such as the
             # optimizer config used.
             # Note: these values are unfortunately mutable at the moment.

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -109,8 +109,8 @@ def _optimize(*,
             opt_context.bulk_register(configs, scores, status)
             # Complete any pending trials.
             for trial in exp.pending_trials(datetime.utcnow(), running=True):
-                (status, score) = _run(env_context, trial, global_config)
-                opt_context.register(trial.tunables, status, score)
+                (trial_status, trial_score) = _run(env_context, trial, global_config)
+                opt_context.register(trial.tunables, trial_status, trial_score)
         else:
             _LOG.warning("Skip pending trials and warm-up: %s", opt)
 
@@ -145,8 +145,8 @@ def _optimize(*,
                     "repeat_i": repeat_i,
                     "is_defaults": tunables.is_defaults,
                 })
-                (status, score) = _run(env_context, trial, global_config)
-                opt_context.register(trial.tunables, status, score)
+                (trial_status, trial_score) = _run(env_context, trial, global_config)
+                opt_context.register(trial.tunables, trial_status, trial_score)
 
         if do_teardown:
             env_context.teardown()
@@ -169,6 +169,11 @@ def _run(env: Environment, trial: Storage.Trial,
         A storage system to persist the experiment data.
     global_config : dict
         Global configuration parameters.
+
+    Returns
+    -------
+    (trial_status, trial_score) : (Status, Optional[Dict[str, float]])
+        Status and results of the trial.
     """
     _LOG.info("Trial: %s", trial)
 

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -106,7 +106,7 @@ def _optimization_loop(*,
             # Complete trials that are pending or in-progress.
             _scheduler(exp, env_context, global_config, running=True)
             # Load past trials data into the optimizer
-            last_trial_id = _optimizer(exp, opt_context)
+            last_trial_id = _optimizer(exp, opt_context, is_warm_up=True)
         else:
             _LOG.warning("Skip pending trials and warm-up: %s", opt)
 
@@ -155,13 +155,14 @@ def _scheduler(exp: Storage.Experiment, env_context: Environment,
 
 
 def _optimizer(exp: Storage.Experiment, opt_context: Optimizer,
-               last_trial_id: int = -1, trial_config_repeat_count: int = 1) -> int:
+               last_trial_id: int = -1, trial_config_repeat_count: int = 1,
+               is_warm_up: bool = False) -> int:
     """
     Optimizer part of the loop. Load the results of the executed trials
     into the optimizer, suggest new configurations, and add them to the queue.
     """
     (configs, scores, status) = exp.load(last_trial_id)
-    opt_context.bulk_register(configs, scores, status)
+    opt_context.bulk_register(configs, scores, status, is_warm_up)
 
     tunables = opt_context.suggest()
     return _schedule_trial(exp, opt_context, tunables, trial_config_repeat_count)

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -26,7 +26,7 @@ from mlos_bench.tunables.tunable_groups import TunableGroups
 _LOG = logging.getLogger(__name__)
 
 
-def _main() -> None:
+def _main() -> Tuple[Optional[float], Optional[TunableGroups]]:
 
     launcher = Launcher("mlos_bench", "Systems autotuning and benchmarking tool")
 
@@ -41,6 +41,7 @@ def _main() -> None:
     )
 
     _LOG.info("Final result: %s", result)
+    return result
 
 
 def _optimization_loop(*,

--- a/mlos_bench/mlos_bench/run.py
+++ b/mlos_bench/mlos_bench/run.py
@@ -79,10 +79,6 @@ def _optimization_loop(*,
     if _LOG.isEnabledFor(logging.INFO):
         _LOG.info("Root Environment:\n%s", env.pprint())
 
-    experiment_id = global_config["experiment_id"].strip()
-    trial_id = int(global_config["trial_id"])
-    config_id = int(global_config.get("config_id", -1))
-
     # Start new or resume the existing experiment. Verify that the
     # experiment configuration is compatible with the previous runs.
     # If the `merge` config parameter is present, merge in the data
@@ -90,8 +86,8 @@ def _optimization_loop(*,
     with env as env_context, \
          opt as opt_context, \
          storage.experiment(
-            experiment_id=experiment_id,
-            trial_id=trial_id,
+            experiment_id=global_config["experiment_id"].strip(),
+            trial_id=int(global_config["trial_id"]),
             root_env_config=root_env_config,
             description=env.name,
             tunables=env.tunable_params,
@@ -110,6 +106,7 @@ def _optimization_loop(*,
         else:
             _LOG.warning("Skip pending trials and warm-up: %s", opt)
 
+        config_id = int(global_config.get("config_id", -1))
         if config_id > 0:
             tunables = _load_config(exp, env_context, config_id)
             last_trial_id = _schedule_trial(exp, opt_context, tunables,

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -258,7 +258,8 @@ class Storage(metaclass=ABCMeta):
         @abstractmethod
         def load(self,
                  last_trial_id: int = -1,
-                 opt_target: Optional[str] = None) -> Tuple[List[dict], List[Optional[float]], List[Status]]:
+                 opt_target: Optional[str] = None
+                 ) -> Tuple[List[int], List[dict], List[Optional[float]], List[Status]]:
             """
             Load (tunable values, benchmark scores, status) to warm-up the optimizer.
 
@@ -275,8 +276,8 @@ class Storage(metaclass=ABCMeta):
 
             Returns
             -------
-            (configs, scores, status) : Tuple[List[dict], List[Optional[float]], List[Status]]
-                Tunable values, benchmark scores, and status of the trials.
+            (trial_ids, configs, scores, status) : ([dict], [Optional[float]], [Status])
+                Trial ids, Tunable values, benchmark scores, and status of the trials.
             """
 
         @abstractmethod

--- a/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
@@ -23,7 +23,7 @@ from mlos_bench.run import _optimization_loop
             "--config", "mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc",
             "--trial_config_repeat_count", "3",
             "--max_iterations", "3",
-        ], 64.8847),
+        ], 64.2758),
     ]
 )
 def test_main_bench(argv: List[str], expected_score: float) -> None:

--- a/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
@@ -29,4 +29,4 @@ def test_main_bench() -> None:
         do_teardown=launcher.teardown,
         trial_config_repeat_count=launcher.trial_config_repeat_count,
     )
-    assert pytest.approx(score, 1e-6) == 65.67
+    assert pytest.approx(score, 1e-6) == 65.6742

--- a/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Unit tests to check the launcher and the main optimization loop in-process.
+"""
+
+import pytest
+
+from mlos_bench.launcher import Launcher
+from mlos_bench.run import _optimization_loop
+
+
+def test_main_bench() -> None:
+    """
+    Run mlos_bench optimization loop with given config and check the results.
+    """
+    launcher = Launcher("mlos_bench", "TEST RUN", argv=[
+        "--config",
+        "mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc",
+    ])
+    (score, _config) = _optimization_loop(
+        env=launcher.environment,
+        opt=launcher.optimizer,
+        storage=launcher.storage,
+        root_env_config=launcher.root_env_config,
+        global_config=launcher.global_config,
+        do_teardown=launcher.teardown,
+        trial_config_repeat_count=launcher.trial_config_repeat_count,
+    )
+    assert pytest.approx(score, 1e-6) == 65.67

--- a/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
@@ -6,20 +6,31 @@
 Unit tests to check the launcher and the main optimization loop in-process.
 """
 
+from typing import List
+
 import pytest
 
 from mlos_bench.launcher import Launcher
 from mlos_bench.run import _optimization_loop
 
 
-def test_main_bench() -> None:
+@pytest.mark.parametrize(
+    ("argv", "expected_score"), [
+        ([
+            "--config", "mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc",
+        ], 65.6742),
+        ([
+            "--config", "mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc",
+            "--trial_config_repeat_count", "3",
+            "--max_iterations", "3",
+        ], 64.53),
+    ]
+)
+def test_main_bench(argv: List[str], expected_score: float) -> None:
     """
     Run mlos_bench optimization loop with given config and check the results.
     """
-    launcher = Launcher("mlos_bench", "TEST RUN", argv=[
-        "--config",
-        "mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc",
-    ])
+    launcher = Launcher("mlos_bench", "TEST RUN", argv=argv)
     (score, _config) = _optimization_loop(
         env=launcher.environment,
         opt=launcher.optimizer,
@@ -29,4 +40,4 @@ def test_main_bench() -> None:
         do_teardown=launcher.teardown,
         trial_config_repeat_count=launcher.trial_config_repeat_count,
     )
-    assert pytest.approx(score, 1e-6) == 65.6742
+    assert pytest.approx(score, 1e-6) == expected_score

--- a/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_in_process_test.py
@@ -23,7 +23,7 @@ from mlos_bench.run import _optimization_loop
             "--config", "mlos_bench/mlos_bench/tests/config/cli/mock-opt.jsonc",
             "--trial_config_repeat_count", "3",
             "--max_iterations", "3",
-        ], 64.53),
+        ], 64.8847),
     ]
 )
 def test_main_bench(argv: List[str], expected_score: float) -> None:

--- a/mlos_bench/mlos_bench/tests/launcher_run_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_run_test.py
@@ -10,9 +10,7 @@ import re
 from typing import List
 
 import pytest
-from unittest.mock import MagicMock, patch
 
-from mlos_bench.run import _main
 from mlos_bench.services.local.local_exec import LocalExecService
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.util import path_join
@@ -111,19 +109,3 @@ def test_launch_main_app_opt(root_path: str, local_exec_service: LocalExecServic
             r"_optimize INFO Env: Mock environment best score: 64\.53\d+\s*$",
         ]
     )
-
-
-@patch("sys.argv")
-def test_main_bench(mock_argv: MagicMock, root_path: str) -> None:
-    """
-    Run mlos_bench command-line application with given config
-    and check the results in the log.
-    """
-    mock_argv.sys.argv = [
-        "run.py",
-        "--config",
-        "mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc",
-    ]
-
-    (score, _config) = _main()
-    assert pytest.approx(score, 1e-6) == 65.67

--- a/mlos_bench/mlos_bench/tests/launcher_run_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_run_test.py
@@ -10,7 +10,9 @@ import re
 from typing import List
 
 import pytest
+from unittest.mock import MagicMock, patch
 
+from mlos_bench.run import _main
 from mlos_bench.services.local.local_exec import LocalExecService
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.util import path_join
@@ -109,3 +111,19 @@ def test_launch_main_app_opt(root_path: str, local_exec_service: LocalExecServic
             r"_optimize INFO Env: Mock environment best score: 64\.53\d+\s*$",
         ]
     )
+
+
+@patch("sys.argv")
+def test_main_bench(mock_argv: MagicMock, root_path: str) -> None:
+    """
+    Run mlos_bench command-line application with given config
+    and check the results in the log.
+    """
+    mock_argv.sys.argv = [
+        "run.py",
+        "--config",
+        "mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc",
+    ]
+
+    (score, _config) = _main()
+    assert pytest.approx(score, 1e-6) == 65.67

--- a/mlos_bench/mlos_bench/tests/launcher_run_test.py
+++ b/mlos_bench/mlos_bench/tests/launcher_run_test.py
@@ -81,7 +81,7 @@ def test_launch_main_app_bench(root_path: str, local_exec_service: LocalExecServ
         "--config mlos_bench/mlos_bench/tests/config/cli/mock-bench.jsonc",
         [
             f"^{_RE_DATE} run\\.py:\\d+ " +
-            r"_optimize INFO Env: Mock environment best score: 65\.67\d+\s*$",
+            r"_optimization_loop INFO Env: Mock environment best score: 65\.67\d+\s*$",
         ]
     )
 
@@ -97,15 +97,15 @@ def test_launch_main_app_opt(root_path: str, local_exec_service: LocalExecServic
         [
             # Iteration 1: Expect first value to be the baseline
             f"^{_RE_DATE} mlos_core_optimizer\\.py:\\d+ " +
-            r"register DEBUG Score: 64\.88\d+ Dataframe:\s*$",
+            r"bulk_register DEBUG Warm-up end: score = 64\.88\d+$",
             # Iteration 2: The result may not always be deterministic
             f"^{_RE_DATE} mlos_core_optimizer\\.py:\\d+ " +
-            r"register DEBUG Score: \d+\.\d+ Dataframe:\s*$",
+            r"bulk_register DEBUG Warm-up end: score = \d+\.\d+$",
             # Iteration 3: non-deterministic (depends on the optimizer)
             f"^{_RE_DATE} mlos_core_optimizer\\.py:\\d+ " +
-            r"register DEBUG Score: \d+\.\d+ Dataframe:\s*$",
+            r"bulk_register DEBUG Warm-up end: score = \d+\.\d+$",
             # Final result: baseline is the optimum for the mock environment
             f"^{_RE_DATE} run\\.py:\\d+ " +
-            r"_optimize INFO Env: Mock environment best score: 64\.53\d+\s*$",
+            r"_optimization_loop INFO Env: Mock environment best score: 64\.27\d+\s*$",
         ]
     )

--- a/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/exp_load_test.py
@@ -18,7 +18,8 @@ def test_exp_load_empty(exp_storage: Storage.Experiment) -> None:
     """
     Try to retrieve old experimental data from the empty storage.
     """
-    (configs, scores, status) = exp_storage.load()
+    (trial_ids, configs, scores, status) = exp_storage.load()
+    assert not trial_ids
     assert not configs
     assert not scores
     assert not status
@@ -93,6 +94,7 @@ def test_exp_trial_update_categ(exp_storage: Storage.Experiment,
     trial = exp_storage.new_trial(tunable_groups)
     trial.update(Status.SUCCEEDED, datetime.utcnow(), {"score": 99.9, "benchmark": "test"})
     assert exp_storage.load() == (
+        [trial.trial_id],
         [{
             'idle': 'halt',
             'kernel_sched_latency_ns': '2000000',
@@ -133,7 +135,8 @@ def test_exp_trial_pending_3(exp_storage: Storage.Experiment,
     (pending,) = list(exp_storage.pending_trials(datetime.utcnow(), running=True))
     assert pending.trial_id == trial_pend.trial_id
 
-    (configs, scores, status) = exp_storage.load()
+    (trial_ids, configs, scores, status) = exp_storage.load()
+    assert trial_ids == [trial_fail.trial_id, trial_succ.trial_id]
     assert len(configs) == 2
     assert scores == [None, score]
     assert status == [Status.FAILED, Status.SUCCEEDED]


### PR DESCRIPTION
Initial work to support pluggable Schedulers (#679).
This starts by adding the necessary support to auxiliary classes and splits the current simple run/optimize loop into two stages.
Future PRs will expand on this to separate abstract and configurable classes for more flexible scheduling policies.