### PR TITLE
Pin a devcontainer version to workaround library search path issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/devcontainers/miniconda:3 AS base
+# Workaround a broken upstream devcontainer image that somehow adjusts the LD_LIBRARY_PATH incorrectly for conda envs.
+#FROM mcr.microsoft.com/devcontainers/miniconda:3 AS base
+FROM mcr.microsoft.com/devcontainers/miniconda:0.203.6-3 AS base
 
 # Add some additional packages for the devcontainer terminal environment.
 USER root


### PR DESCRIPTION
A new base devcontainer image was [released](https://github.com/devcontainers/images/blob/main/src/miniconda/history/0.203.7.md) recently that introduces the following error in our environment when running `make test`:

```
 import pandas._libs.window.aggregations as window_aggregations\n'
 'ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version '
 "`GLIBCXX_3.4.29' not found (required by "
 '/opt/conda/envs/mlos/lib/python3.11/site-packages/pandas/_libs/window/aggregations.cpython-311-x86_64-linux-gnu.so)\n')
```

A simplified reproduction involves running `conda run -n mlos pytest mlos_bench/mlos_bench/launcher_run_test.ph`.

Unfortunately, it appears that under the latest version somewhere between `conda` and `pytest` the `libc.so.6` library found is the one under `/usr/lib` instead of `/opt/conda/envs/mlos/lib`.

I haven't quite seen where that's happening, but I've confirmed that rolling back to the previous release for the base devcontainer image fixes it.

Note that even then, we update `conda` to the latest and no-cache update our own dependencies nightly, so we are getting the latest conda at least, if not the latest Debian base packages.

This will be somewhat of a security issue eventually, but for now it frees up our CI pipeline to get moving again.