### PR TITLE
Don't shell interpret commit messages

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -84,7 +84,7 @@ jobs:
         echo "EVENT_NAME: ${{ github.event_name }}"
         echo "BEFORE: ${{ github.event.before }}"
         echo "AFTER: ${{ github.event.after }}"
-        echo "COMMIT_MESSAGES: ${{ steps.get-commit-messages.outputs.COMMIT_MESSAGES }}"
+        echo 'COMMIT_MESSAGES: ${{ steps.get-commit-messages.outputs.COMMIT_MESSAGES }}'
         echo "COMMIT_SHA: ${{ github.sha }}"
         echo "git log -1 ${{ github.sha }}: $(git log -1 ${{ github.sha }})"
         echo "Manual Trigger Input Tags: ${{ github.event.inputs.tags }}"


### PR DESCRIPTION
Fixup following the commit message from #699 which includes a backtick command.