### PR TITLE
Roll back forceful assignment of PATH when invoking a local process

### DIFF
--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -195,10 +195,8 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
         cmd = [token for subcmd in subcmds for token in subcmd]
 
         env: Dict[str, str] = {}
-        # Need to include at least some basic environment variables to run the script.
-        env["PATH"] = environ["PATH"]
         if env_params:
-            env.update({key: str(val) for (key, val) in env_params.items()})
+            env = {key: str(val) for (key, val) in env_params.items()}
 
         if sys.platform == 'win32':
             # A hack to run Python on Windows with env variables set:


### PR DESCRIPTION
Roll back one of the updates from #705 
It breaks tests on both Windows and WSL DevContainer on my PC.
* On Windows, `environ` may not have `PATH` at all
* On my WSL DevContainer, passing non-null `env` to `subprocess.run` prevents it from finding the right python interpreter