### PR TITLE
Cascading series of CI dependency problems

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,9 +42,9 @@ USER vscode:conda
 RUN umask 0002 \
     && /opt/conda/bin/conda config --set channel_priority strict \
     && /opt/conda/bin/conda info \
-    && /opt/conda/bin/conda update -v -y -n base -c defaults --all \
+    && /opt/conda/bin/conda update -v -y -n base -c conda-forge --all \
     && /opt/conda/bin/conda list -n base \
-    && /opt/conda/bin/conda install -v -y -n base conda-libmamba-solver \
+    && /opt/conda/bin/conda install -v -y -n base -c conda-forge conda-libmamba-solver \
     && /opt/conda/bin/conda config --set solver libmamba \
     && /opt/conda/bin/conda list -n base \
     && /opt/conda/bin/conda clean -v -y -a
@@ -52,8 +52,8 @@ RUN umask 0002 \
 # Update the base. This helps save space by making sure the same version
 # python is used for both the base env and mlos env.
 RUN umask 0002 \
-    && /opt/conda/bin/conda update -v -y -n base -c defaults --all \
-    && /opt/conda/bin/conda update -v -y -n base -c defaults conda python \
+    && /opt/conda/bin/conda update -v -y -n base -c conda-forge --all \
+    && /opt/conda/bin/conda update -v -y -n base -c conda-forge conda 'python<3.12' \
     && /opt/conda/bin/conda clean -v -y -a \
     && /opt/conda/bin/conda run -n base pip cache purge
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,20 +42,22 @@ USER vscode:conda
 RUN umask 0002 \
     && /opt/conda/bin/conda config --set channel_priority strict \
     && /opt/conda/bin/conda info \
-    && /opt/conda/bin/conda update -v -y -n base -c conda-forge --all \
+    && /opt/conda/bin/conda update -v -y -n base -c defaults --all \
     && /opt/conda/bin/conda list -n base \
-    && /opt/conda/bin/conda install -v -y -n base -c conda-forge conda-libmamba-solver \
+    && /opt/conda/bin/conda install -v -y -n base conda-libmamba-solver \
     && /opt/conda/bin/conda config --set solver libmamba \
     && /opt/conda/bin/conda list -n base \
-    && /opt/conda/bin/conda clean -v -y -a
-
-# Update the base. This helps save space by making sure the same version
-# python is used for both the base env and mlos env.
-RUN umask 0002 \
-    && /opt/conda/bin/conda update -v -y -n base -c conda-forge --all \
-    && /opt/conda/bin/conda update -v -y -n base -c conda-forge conda python \
     && /opt/conda/bin/conda clean -v -y -a \
     && /opt/conda/bin/conda run -n base pip cache purge
+
+# No longer relevant since we're using conda-forge in the environment files by default now.
+## Update the base. This helps save space by making sure the same version
+## python is used for both the base env and mlos env.
+#RUN umask 0002 \
+#    && /opt/conda/bin/conda update -v -y -n base -c defaults --all \
+#    && /opt/conda/bin/conda update -v -y -n base -c defaults conda python \
+#    && /opt/conda/bin/conda clean -v -y -a \
+#    && /opt/conda/bin/conda run -n base pip cache purge
 
 # Install some additional editor packages for the base environment.
 RUN umask 0002 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -53,7 +53,7 @@ RUN umask 0002 \
 # python is used for both the base env and mlos env.
 RUN umask 0002 \
     && /opt/conda/bin/conda update -v -y -n base -c conda-forge --all \
-    && /opt/conda/bin/conda update -v -y -n base -c conda-forge conda 'python<3.12' \
+    && /opt/conda/bin/conda update -v -y -n base -c conda-forge conda python \
     && /opt/conda/bin/conda clean -v -y -a \
     && /opt/conda/bin/conda run -n base pip cache purge
 

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -10,6 +10,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -25,7 +26,6 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
-    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -10,7 +10,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm>=8.1.0
+  - conda-forge::setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -11,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - conda-forge::setuptools-scm>=8.1.0
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -1,5 +1,6 @@
 name: mlos-3.10
 channels:
+  - conda-forge
   - defaults
 dependencies:
   # Basic dev environment packages.

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -10,7 +10,6 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -26,6 +25,7 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
+    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -10,6 +10,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -25,7 +26,6 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
-    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -1,7 +1,7 @@
 name: mlos-3.11
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -11,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - conda-forge::setuptools-scm>=8.1.0
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -1,6 +1,7 @@
 name: mlos-3.11
 channels:
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.
@@ -10,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm>=8.1.0
+  - conda-forge::setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -10,7 +10,6 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -26,6 +25,7 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
+    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -1,6 +1,7 @@
 name: mlos-3.8
 channels:
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.
@@ -10,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm>=8.1.0
+  - conda-forge::setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -10,6 +10,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -25,7 +26,6 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
-    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -11,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - conda-forge::setuptools-scm>=8.1.0
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -1,7 +1,7 @@
 name: mlos-3.8
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -10,7 +10,6 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -26,6 +25,7 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
+    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -1,6 +1,7 @@
 name: mlos-3.9
 channels:
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.
@@ -10,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm>=8.1.0
+  - conda-forge::setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -10,6 +10,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -25,7 +26,6 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
-    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -1,7 +1,7 @@
 name: mlos-3.9
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -11,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - conda-forge::setuptools-scm>=8.1.0
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -10,7 +10,6 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -26,6 +25,7 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
+    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -1,7 +1,6 @@
 name: mlos
 channels:
   # Note: we have to reverse the channel priority for Windows to accomodate strict channel_priority setups.
-  # Hence, additional dependencies may differ from the Linux setup.
   - conda-forge
   - defaults
 dependencies:

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -13,7 +13,6 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -30,6 +29,7 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
+    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -13,7 +13,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm>=8.1.0
+  - conda-forge::setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -13,6 +13,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -29,7 +30,6 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
-    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -12,7 +12,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - conda-forge::setuptools-scm>=8.1.0
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -25,7 +25,7 @@ dependencies:
   - python=3.11
   # Install an SMAC requirement pre-compiled from conda-forge.
   # This also requires a more recent vs2015_runtime from conda-forge.
-  - conda-forge::pyrfr>=0.9.0
+  - pyrfr>=0.9.0
   - pip:
     - autopep8>=1.7.0
     - bump2version

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -22,7 +22,8 @@ dependencies:
   - pyarrow
   - swig
   - libpq
-  - python=3.11
+  # FIXME: https://github.com/microsoft/MLOS/issues/727
+  - python<3.12
   # Install an SMAC requirement pre-compiled from conda-forge.
   # This also requires a more recent vs2015_runtime from conda-forge.
   - pyrfr>=0.9.0

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -1,6 +1,7 @@
 name: mlos
 channels:
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.
@@ -10,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm>=8.1.0
+  - conda-forge::setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -11,7 +11,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - conda-forge::setuptools-scm>=8.1.0
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -10,7 +10,6 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
-  - setuptools-scm
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -24,6 +23,7 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
+    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -21,7 +21,7 @@ dependencies:
   - pyarrow
   - swig
   - libpq
-  - python
+  - python<3.12
   - pip:
     - autopep8>=1.7.0
     - bump2version

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -1,7 +1,7 @@
 name: mlos
 channels:
-  - defaults
   - conda-forge
+  - defaults
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -21,6 +21,7 @@ dependencies:
   - pyarrow
   - swig
   - libpq
+  # FIXME: https://github.com/microsoft/MLOS/issues/727
   - python<3.12
   - pip:
     - autopep8>=1.7.0

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -10,6 +10,7 @@ dependencies:
   - pydocstyle
   - flake8
   - setuptools
+  - setuptools-scm>=8.1.0
   - jupyter
   - ipykernel
   - nb_conda_kernels
@@ -23,7 +24,6 @@ dependencies:
   - pip:
     - autopep8>=1.7.0
     - bump2version
-    - setuptools-scm>=8.1.0
     - check-jsonschema
     - licenseheaders
     - mypy

--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -27,7 +27,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
     Wrapper class for SMAC based Bayesian optimization.
     """
 
-    def __init__(self, *,  # pylint: disable=too-many-locals
+    def __init__(self, *,  # pylint: disable=too-many-locals,too-many-arguments
                  parameter_space: ConfigSpace.ConfigurationSpace,
                  optimization_targets: List[str],
                  space_adapter: Optional[BaseSpaceAdapter] = None,
@@ -283,7 +283,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
             Pandas dataframe with a single row. Column names are the parameter names.
         """
         if TYPE_CHECKING:
-            from smac.runhistory import TrialInfo  # pylint: disable=import-outside-toplevel
+            from smac.runhistory import TrialInfo  # pylint: disable=import-outside-toplevel,unused-import
 
         if context is not None:
             warn(f"Not Implemented: Ignoring context {list(context.columns)}", UserWarning)

--- a/mlos_core/mlos_core/optimizers/flaml_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/flaml_optimizer.py
@@ -30,7 +30,7 @@ class FlamlOptimizer(BaseOptimizer):
     Wrapper class for FLAML Optimizer: A fast library for AutoML and tuning.
     """
 
-    def __init__(self, *,
+    def __init__(self, *,   # pylint: disable=too-many-arguments
                  parameter_space: ConfigSpace.ConfigurationSpace,
                  optimization_targets: List[str],
                  space_adapter: Optional[BaseSpaceAdapter] = None,

--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -222,7 +222,7 @@ class LlamaTuneAdapter(BaseSpaceAdapter):   # pylint: disable=too-many-instance-
                 index = max(0, min(len(param.choices) - 1, index))
                 # NOTE: potential rounding here would be unfair to first & last values
                 orig_value = param.choices[index]
-            elif isinstance(param, ConfigSpace.hyperparameters.NumericalHyperparameter):
+            elif isinstance(param, NumericalHyperparameter):
                 if param.name in self._special_param_values_dict:
                     value = self._special_param_value_scaler(param, value)
 

--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 from warnings import warn
 
 import ConfigSpace
+from ConfigSpace.hyperparameters import NumericalHyperparameter
 import numpy as np
 import numpy.typing as npt
 import pandas as pd

--- a/mlos_core/mlos_core/spaces/converters/flaml.py
+++ b/mlos_core/mlos_core/spaces/converters/flaml.py
@@ -6,7 +6,7 @@
 Contains space converters for FLAML.
 """
 
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 
 import sys
 
@@ -16,17 +16,20 @@ import numpy as np
 import flaml.tune
 import flaml.tune.sample
 
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
+    from ConfigSpace.hyperparameters import Hyperparameter
+
+    FlamlDomain: TypeAlias = flaml.tune.sample.Domain
+    FlamlSpace: TypeAlias = Dict[str, flaml.tune.sample.Domain]
 
 
-FlamlDomain: TypeAlias = flaml.tune.sample.Domain
-FlamlSpace: TypeAlias = Dict[str, flaml.tune.sample.Domain]
-
-
-def configspace_to_flaml_space(config_space: ConfigSpace.ConfigurationSpace) -> Dict[str, FlamlDomain]:
+def configspace_to_flaml_space(config_space: ConfigSpace.ConfigurationSpace) -> Dict[str, "FlamlDomain"]:
     """Converts a ConfigSpace.ConfigurationSpace to dict.
 
     Parameters
@@ -46,7 +49,7 @@ def configspace_to_flaml_space(config_space: ConfigSpace.ConfigurationSpace) -> 
         (ConfigSpace.UniformFloatHyperparameter, True): flaml.tune.loguniform,
     }
 
-    def _one_parameter_convert(parameter: ConfigSpace.hyperparameters.Hyperparameter) -> FlamlDomain:
+    def _one_parameter_convert(parameter: "Hyperparameter") -> "FlamlDomain":
         if isinstance(parameter, ConfigSpace.UniformFloatHyperparameter):
             # FIXME: upper isn't included in the range
             return flaml_numeric_type[(type(parameter), parameter.log)](parameter.lower, parameter.upper)

--- a/mlos_core/mlos_core/spaces/converters/flaml.py
+++ b/mlos_core/mlos_core/spaces/converters/flaml.py
@@ -16,20 +16,20 @@ import numpy as np
 import flaml.tune
 import flaml.tune.sample
 
-
 if TYPE_CHECKING:
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
-
     from ConfigSpace.hyperparameters import Hyperparameter
 
-    FlamlDomain: TypeAlias = flaml.tune.sample.Domain
-    FlamlSpace: TypeAlias = Dict[str, flaml.tune.sample.Domain]
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 
-def configspace_to_flaml_space(config_space: ConfigSpace.ConfigurationSpace) -> Dict[str, "FlamlDomain"]:
+FlamlDomain: TypeAlias = flaml.tune.sample.Domain
+FlamlSpace: TypeAlias = Dict[str, flaml.tune.sample.Domain]
+
+
+def configspace_to_flaml_space(config_space: ConfigSpace.ConfigurationSpace) -> Dict[str, FlamlDomain]:
     """Converts a ConfigSpace.ConfigurationSpace to dict.
 
     Parameters
@@ -49,7 +49,7 @@ def configspace_to_flaml_space(config_space: ConfigSpace.ConfigurationSpace) -> 
         (ConfigSpace.UniformFloatHyperparameter, True): flaml.tune.loguniform,
     }
 
-    def _one_parameter_convert(parameter: "Hyperparameter") -> "FlamlDomain":
+    def _one_parameter_convert(parameter: "Hyperparameter") -> FlamlDomain:
         if isinstance(parameter, ConfigSpace.UniformFloatHyperparameter):
             # FIXME: upper isn't included in the range
             return flaml_numeric_type[(type(parameter), parameter.log)](parameter.lower, parameter.upper)

--- a/mlos_core/mlos_core/tests/spaces/spaces_test.py
+++ b/mlos_core/mlos_core/tests/spaces/spaces_test.py
@@ -18,7 +18,7 @@ import pytest
 import scipy
 
 import ConfigSpace as CS
-from ConfigSpace.hyperparameters import NormalIntegerHyperparameter
+from ConfigSpace.hyperparameters import Hyperparameter, NormalIntegerHyperparameter
 
 import flaml.tune.sample
 
@@ -26,7 +26,7 @@ from mlos_core.spaces.converters.flaml import configspace_to_flaml_space, FlamlD
 
 
 OptimizerSpace = Union[FlamlSpace, CS.ConfigurationSpace]
-OptimizerParam = Union[FlamlDomain, CS.hyperparameters.Hyperparameter]
+OptimizerParam = Union[FlamlDomain, Hyperparameter]
 
 
 def assert_is_uniform(arr: npt.NDArray) -> None:

--- a/mlos_viz/mlos_viz/base.py
+++ b/mlos_viz/mlos_viz/base.py
@@ -180,7 +180,7 @@ def augment_results_df_with_config_trial_group_stats(exp_data: Optional[Experime
         compute_zscore_for_group_agg(results_groups_perf, stats_df, result_col, "var")
         quantiles = [0.50, 0.75, 0.90, 0.95, 0.99]
         for quantile in quantiles:     # TODO: can we do this in one pass?
-            quantile_col = result_col + f".p{int(quantile*100)}"
+            quantile_col = f"{result_col}.p{int(quantile * 100)}"
             stats_df[quantile_col] = results_groups_perf.transform("quantile", quantile)
         augmented_results_df = pandas.concat([augmented_results_df, stats_df], axis=1)
     return augmented_results_df


### PR DESCRIPTION
A new git version outputs a different date format that older versions of python's datetime module don't recognize.
https://github.com/pypa/setuptools_scm/issues/1038

setuptools-scm cut a new version to address that, but it's not available in conda main channel yet, which is required, since without that the conda pip phase can't execute in a single transaction

For now, we install things via conda-forge and adjust the channel priority order so that the full set of dependencies could be resolved.

That of course brought in additional changes (e.g., `python=3.12` by default, new `pylint`, `pycodestyle`, etc.), so this now also includes some additional linting changes.

However, longer term, we need to switch to a pyproject.toml file to fix this properly. 
 There we can specify prereqs for even loading the setup.py as well as fix some other config complexities, though that is a broader change.