### PR TITLE
Limit CI concurrency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,10 @@
 #
 name: "CodeQL"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -21,6 +21,10 @@ on:
   schedule:
     - cron: "1 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   DevContainer:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: "1 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   Linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,6 +12,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   # Check in-repo markdown links
   markdown-link-check:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: "1 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   Windows:
     runs-on: windows-latest


### PR DESCRIPTION
Saves some resources and should speed up PRs that push frequently.

https://docs.github.com/en/actions/using-jobs/using-concurrency