### PR TITLE
Added missing 'shell_env_params' in redis.jsonc

### DIFF
--- a/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
@@ -45,6 +45,11 @@
                         "trial_id",
                         "mountPoint"
                     ],
+                    "shell_env_params": [
+                        "mountPoint",
+                        "experiment_id",
+                        "trial_id"
+                    ],
                     "setup": [
                         "$mountPoint/$experiment_id/$trial_id/scripts/setup-workload.sh",
                         "$mountPoint/$experiment_id/$trial_id/scripts/setup-app.sh"


### PR DESCRIPTION
These missing environment variables were causing the Redis benchmark to fail.