### PR TITLE
Introduce pyproject.toml build changes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,8 +3,10 @@ current_version = 0.5.1
 commit = True
 tag = True
 
-[bumpversion:file:doc/source/conf.py]
+[bumpversion:file:doc/source/version.py]
 
-[bumpversion:file:mlos_core/_version.py]
+[bumpversion:file:mlos_core/mlos_core/version.py]
 
-[bumpversion:file:mlos_bench/_version.py]
+[bumpversion:file:mlos_bench/mlos_bench/version.py]
+
+[bumpversion:file:mlos_viz/mlos_viz/version.py]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -83,6 +83,7 @@
                 "redhat.vscode-yaml",
                 "stkb.rewrap",
                 "streetsidesoftware.code-spell-checker",
+                "tamasfe.even-better-toml",
                 "trond-snekvik.simple-rst",
                 "tyriar.sort-lines",
                 "waderyan.gitblame"

--- a/.devcontainer/scripts/common/prep-deps-files.sh
+++ b/.devcontainer/scripts/common/prep-deps-files.sh
@@ -27,7 +27,7 @@ tmpdir=$(mktemp -d)
 get_python_deps() {
     local pkg="$1"
     touch /tmp/conda-tmp/$pkg.requirements.txt
-    python3 /tmp/conda-tmp/$pkg/setup.py egg_info --egg-base "$tmpdir/"
+    (cd /tmp/conda-tmp/$pkg && python3 setup.py egg_info --egg-base "$tmpdir/")
     cat "$tmpdir/$pkg.egg-info/requires.txt" \
         | grep -v -e '^\[' -e '^\s*$' \
         | grep -v '^mlos-' \

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -31,9 +31,10 @@ fi
 mkdir -p .devcontainer/tmp/
 cp -v conda-envs/mlos.yml .devcontainer/tmp/mlos.yml
 for pkg in mlos_core mlos_bench mlos_viz; do
-    mkdir -p .devcontainer/tmp/$pkg
+    mkdir -p .devcontainer/tmp/$pkg/$pkg
+    cp -v $pkg/pyproject.toml .devcontainer/tmp/$pkg/pyproject.toml
     cp -v $pkg/setup.py .devcontainer/tmp/$pkg/setup.py
-    cp -v $pkg/_version.py .devcontainer/tmp/$pkg/_version.py
+    cp -v $pkg/$pkg/version.py .devcontainer/tmp/$pkg/$pkg/version.py
 done
 cp -v doc/requirements.txt .devcontainer/tmp/doc.requirements.txt
 

--- a/.devcontainer/scripts/prep-container-build.ps1
+++ b/.devcontainer/scripts/prep-container-build.ps1
@@ -27,9 +27,11 @@ New-Item -Type Directory .devcontainer/tmp
 
 Copy-Item conda-envs/mlos.yml .devcontainer/tmp/mlos.yml
 foreach ($pkg in @('mlos_core', 'mlos_bench', 'mlos_viz')) {
-    New-Item -Type Directory ".devcontainer/tmp/${pkg}"
-    Copy-Item "$pkg/setup.py" ".devcontainer/tmp/${pkg}/setup.py"
-    Copy-Item "$pkg/_version.py" ".devcontainer/tmp/${pkg}/_version.py"
+    New-Item -Type Directory ".devcontainer/tmp/$pkg"
+    New-Item -Type Directory ".devcontainer/tmp/$pkg/$pkg"
+    Copy-Item "$pkg/setup.py" ".devcontainer/tmp/$pkg/setup.py"
+    Copy-Item "$pkg/pyproject.toml" ".devcontainer/tmp/$pkg/pyproject.toml"
+    Copy-Item "$pkg/$pkg/version.py" ".devcontainer/tmp/$pkg/$pkg/version.py"
 }
 Copy-Item doc/requirements.txt .devcontainer/tmp/doc.requirements.txt
 

--- a/.github/workflows/build-dist-test.ps1
+++ b/.github/workflows/build-dist-test.ps1
@@ -18,7 +18,7 @@ Set-Location mlos_core
 if (Test-Path dist) {
     Remove-Item -Recurse -Force dist
 }
-conda run -n $env:CONDA_ENV_NAME python setup.py bdist_wheel
+conda run -n $env:CONDA_ENV_NAME python -m build
 Set-Location ..
 $mlos_core_whl = (Resolve-Path mlos_core/dist/mlos_core-*-py3-none-any.whl | Select-Object -ExpandProperty Path)
 Write-Host "mlos_core_whl: $mlos_core_whl"
@@ -32,7 +32,7 @@ Set-Location mlos_bench
 if (Test-Path dist) {
     Remove-Item -Recurse -Force dist
 }
-conda run -n $env:CONDA_ENV_NAME python setup.py bdist_wheel
+conda run -n $env:CONDA_ENV_NAME python -m build
 Set-Location ..
 $mlos_bench_whl = (Resolve-Path mlos_bench/dist/mlos_bench-*-py3-none-any.whl | Select-Object -ExpandProperty Path)
 Write-Host "mlos_bench_whl: $mlos_bench_whl"
@@ -46,7 +46,7 @@ Set-Location mlos_viz
 if (Test-Path dist) {
     Remove-Item -Recurse -Force dist
 }
-conda run -n $env:CONDA_ENV_NAME python setup.py bdist_wheel
+conda run -n $env:CONDA_ENV_NAME python -m build
 Set-Location ..
 $mlos_viz_whl = (Resolve-Path mlos_viz/dist/mlos_viz-*-py3-none-any.whl | Select-Object -ExpandProperty Path)
 Write-Host "mlos_viz_whl: $mlos_viz_whl"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,10 +80,10 @@ jobs:
       with:
         #path: ${{ env.CONDA_DIR }}/envs/${{ env.CONDA_ENV_NAME }}
         path: ${{ env.CONDA_DIR }}/pkgs
-        key: conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_cur_hour }}
+        key: conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_cur_hour }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_prev_hour }}
-          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}
+          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_prev_hour }}
+          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}
 
     - name: Restore cached pip packages
       id: restore-pip-cache
@@ -91,10 +91,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.PIP_CACHE_DIR }}
-        key: conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_cur_hour }}
+        key: conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_cur_hour }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_prev_hour }}
-          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}
+          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_prev_hour }}
+          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_NAME }}.yml') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}
 
     - name: Log some environment variables for debugging
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,10 +68,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.CONDA }}/envs/mlos
-        key: conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_YML }}') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_cur_hour }}
+        key: conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_YML }}') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_cur_hour }}
         restore-keys: |
-          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_YML }}') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_prev_hour }}
-          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_YML }}') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}
+          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_YML }}') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}-${{ env.cache_prev_hour }}
+          conda-${{ runner.os }}-${{ env.CONDA_ENV_NAME }}-${{ hashFiles('conda-envs/${{ env.CONDA_ENV_YML }}') }}-${{ hashFiles('mlos_*/pyproject.toml') }}-${{ hashFiles('mlos_*/setup.py') }}-${{ env.cache_cur_date }}
 
     - name: Log some environment variables for debugging
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,9 @@ build/*.build-stamp
 .vscode/
 !.vscode/settings.json
 !.vscode/extensions.json
+!.vscode/launch.json
 !.devcontainer/build/
+!.devcontainer/scripts/
 
 # Test configs. May contain sensitive information
 # like Azure credentials, DB password, etc.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -26,6 +26,7 @@
         "redhat.vscode-yaml",
         "stkb.rewrap",
         "streetsidesoftware.code-spell-checker",
+        "tamasfe.even-better-toml",
         "trond-snekvik.simple-rst",
         "tyriar.sort-lines",
         "waderyan.gitblame"

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp: doc/requirements.txt
 	touch $@
 
 .PHONY: doc-prereqs
-doc-prereqs: build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp
+doc-prereqs: build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp build/unshallow.build-stamp
 
 .PHONY: clean-doc-env
 clean-doc-env:

--- a/Makefile
+++ b/Makefile
@@ -334,8 +334,8 @@ mlos_viz/dist/tmp/mlos_viz-latest.tar: PACKAGE_NAME := mlos_viz
 	# Check to make sure the README contents made it into the package metadata.
 	unzip -p $(MODULE_NAME)/dist/tmp/$(MODULE_NAME)-latest-py3-none-any.whl */METADATA | egrep -v '^[A-Z][a-zA-Z-]+:' | grep -q -i '^# mlos'
 
-.PHONY: dist-test-env-clean
-dist-test-env-clean:
+.PHONY: clean-dist-test-env
+clean-dist-test-env:
 	# Remove any existing mlos-dist-test environment so we can start clean.
 	conda env remove -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) 2>/dev/null || true
 	rm -f build/dist-test-env.$(PYTHON_VERSION).build-stamp
@@ -350,7 +350,7 @@ build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_core/dist/tmp/mlos_core-
 build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl
 build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl
 	# Create a clean test environment for checking the wheel files.
-	$(MAKE) dist-test-env-clean
+	$(MAKE) clean-dist-test-env
 	conda create -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) python=$(PYTHON_VERS_REQ)
 	# Install some additional dependencies necessary for clean building some of the wheels.
 	conda install -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) swig libpq
@@ -365,7 +365,7 @@ build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_viz/dist/tmp/mlos_viz-la
 	touch $@
 
 .PHONY: dist-test
-#dist-test: dist-clean
+#dist-test: clean-dist
 dist-test: dist-test-env build/dist-test.$(PYTHON_VERSION).build-stamp
 
 # Unnecessary if we invoke it as "python3 -m pytest ..."
@@ -384,7 +384,7 @@ build/dist-test.$(PYTHON_VERSION).build-stamp: $(PYTHON_FILES) build/dist-test-e
 	PYTHONPATH=mlos_bench conda run -n mlos-dist-test-$(PYTHON_VERSION) python3 -m pytest mlos_viz/mlos_viz/tests/test_dabl_plot.py
 	touch $@
 
-dist-test-clean: dist-test-env-clean
+clean-dist-test: clean-dist-test-env
 	rm -f build/dist-test-env.$(PYTHON_VERSION).build-stamp
 
 
@@ -414,6 +414,7 @@ build/publish.${CONDA_ENV_NAME}.%.py.build-stamp: $(PUBLISH_DEPS)
 
 publish-pypi: build/publish.${CONDA_ENV_NAME}.pypi.py.build-stamp
 publish-test-pypi: build/publish.${CONDA_ENV_NAME}.testpypi.py.build-stamp
+
 
 build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp: build/conda-env.${CONDA_ENV_NAME}.build-stamp
 build/doc-prereqs.${CONDA_ENV_NAME}.build-stamp: doc/requirements.txt
@@ -597,15 +598,15 @@ clean-test:
 	rm -rf junit/
 	rm -rf test-output.xml
 
-.PHONY: dist-clean
-dist-clean:
-	rm -rf build dist
+.PHONY: clean-dist
+clean-dist:
+	rm -rf dist
 	rm -rf mlos_core/build mlos_core/dist
 	rm -rf mlos_bench/build mlos_bench/dist
 	rm -rf mlos_viz/build mlos_viz/dist
 
 .PHONY: clean
-clean: clean-check clean-test dist-clean clean-doc clean-doc-env dist-test-clean
+clean: clean-format clean-check clean-test clean-dist clean-doc clean-doc-env clean-dist-test
 	rm -f .*.build-stamp
 	rm -f build/conda-env.build-stamp build/conda-env.*.build-stamp
 	rm -rf mlos_core.egg-info

--- a/Makefile
+++ b/Makefile
@@ -566,10 +566,17 @@ build/linklint-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov
 	@echo "OK"
 	touch $@
 
+
 .PHONY: clean-doc
 clean-doc:
 	rm -rf doc/build/ doc/global/ doc/source/api/ doc/source/generated
 	rm -rf doc/source/source_tree_docs/*
+
+.PHONY: clean-format
+clean-format:
+	# TODO: add black and isort rules
+	rm -f build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
+	rm -f build/licenseheaders-prereqs.${CONDA_ENV_NAME}.build-stamp
 
 .PHONY: clean-check
 clean-check:
@@ -583,8 +590,6 @@ clean-check:
 	rm -f build/pydocstyle.build-stamp
 	rm -f build/pydocstyle.${CONDA_ENV_NAME}.build-stamp
 	rm -f build/pydocstyle.mlos_*.${CONDA_ENV_NAME}.build-stamp
-	rm -f build/licenseheaders.${CONDA_ENV_NAME}.build-stamp
-	rm -f build/licenseheaders-prereqs.${CONDA_ENV_NAME}.build-stamp
 
 .PHONY: clean-test
 clean-test:

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ PYCODESTYLE_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/pycodestyle.%.${CONDA_ENV_NAME}.build-stamp: $(PYCODESTYLE_COMMON_PREREQS)
 	# Check for decent pep8 code style with pycodestyle.
-	# Note: if this fails, try using 'make format' to fix it.
-	conda run -n ${CONDA_ENV_NAME} pycodestyle $(filter %.py,$+)
+	# Note: if this fails, try using 'make format' or 'make clean-format format' to fix it.
+	conda run -n ${CONDA_ENV_NAME} pycodestyle $(filter %.py,$?)
 	touch $@
 
 .PHONY: pydocstyle
@@ -132,7 +132,7 @@ PYDOCSTYLE_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/pydocstyle.%.${CONDA_ENV_NAME}.build-stamp: $(PYDOCSTYLE_COMMON_PREREQS)
 	# Check for decent pep8 doc style with pydocstyle.
-	conda run -n ${CONDA_ENV_NAME} pydocstyle $(filter %.py,$+)
+	conda run -n ${CONDA_ENV_NAME} pydocstyle $(filter %.py,$?)
 	touch $@
 
 .PHONY: cspell
@@ -178,7 +178,7 @@ PYLINT_COMMON_PREREQS += $(FORMAT_PREREQS)
 PYLINT_COMMON_PREREQS += .pylintrc
 
 build/pylint.%.${CONDA_ENV_NAME}.build-stamp: $(PYLINT_COMMON_PREREQS)
-	conda run -n ${CONDA_ENV_NAME} pylint -j0 $(filter %.py,$+)
+	conda run -n ${CONDA_ENV_NAME} pylint -j0 $(filter %.py,$?)
 	touch $@
 
 .PHONY: flake8
@@ -195,7 +195,7 @@ FLAKE8_COMMON_PREREQS += $(FORMAT_PREREQS)
 FLAKE8_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/flake8.%.${CONDA_ENV_NAME}.build-stamp: $(FLAKE8_COMMON_PREREQS)
-	conda run -n ${CONDA_ENV_NAME} flake8 -j0 $(filter %.py,$+)
+	conda run -n ${CONDA_ENV_NAME} flake8 -j0 $(filter %.py,$?)
 	touch $@
 
 .PHONY: mypy
@@ -216,7 +216,7 @@ MYPY_COMMON_PREREQS += scripts/dmypy-wrapper.sh
 
 build/mypy.%.${CONDA_ENV_NAME}.build-stamp: $(MYPY_COMMON_PREREQS)
 	conda run -n ${CONDA_ENV_NAME} scripts/dmypy-wrapper.sh \
-		$(filter %.py,$+)
+		$(filter %.py,$?)
 	touch $@
 
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ conda-env: build/conda-env.${CONDA_ENV_NAME}.build-stamp
 MLOS_CORE_CONF_FILES := mlos_core/pyproject.toml mlos_core/setup.py mlos_core/MANIFEST.in
 MLOS_BENCH_CONF_FILES := mlos_bench/pyproject.toml mlos_bench/setup.py mlos_bench/MANIFEST.in
 MLOS_VIZ_CONF_FILES := mlos_viz/pyproject.toml mlos_viz/setup.py mlos_viz/MANIFEST.in
-MLOS_GLOBAL_CONF_FILES := setup.cfg pyproject.toml
+MLOS_GLOBAL_CONF_FILES := setup.cfg # pyproject.toml
 
 MLOS_PKGS := mlos_core mlos_bench mlos_viz
 MLOS_PKG_CONF_FILES := $(MLOS_CORE_CONF_FILES) $(MLOS_BENCH_CONF_FILES) $(MLOS_VIZ_CONF_FILES) $(MLOS_GLOBAL_CONF_FILES)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build/conda-env.${CONDA_ENV_NAME}.build-stamp: ${ENV_YML} $(MLOS_PKG_CONF_FILES)
 	@echo "CONDA_INFO_LEVEL: ${CONDA_INFO_LEVEL}"
 	conda env list -q | grep -q "^${CONDA_ENV_NAME} " || conda env create ${CONDA_INFO_LEVEL} -n ${CONDA_ENV_NAME} -f ${ENV_YML}
 	conda env update ${CONDA_INFO_LEVEL} -n ${CONDA_ENV_NAME} --prune -f ${ENV_YML}
-	$(MAKE) clean-check clean-test clean-doc
+	$(MAKE) clean-format clean-check clean-test clean-doc clean-dist
 	touch $@
 
 .PHONY: clean-conda-env

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ PYCODESTYLE_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 build/pycodestyle.%.${CONDA_ENV_NAME}.build-stamp: $(PYCODESTYLE_COMMON_PREREQS)
 	# Check for decent pep8 code style with pycodestyle.
 	# Note: if this fails, try using 'make format' or 'make clean-format format' to fix it.
-	conda run -n ${CONDA_ENV_NAME} pycodestyle $(filter %.py,$?)
+	conda run -n ${CONDA_ENV_NAME} pycodestyle $(filter %.py,$+)
 	touch $@
 
 .PHONY: pydocstyle
@@ -132,7 +132,7 @@ PYDOCSTYLE_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/pydocstyle.%.${CONDA_ENV_NAME}.build-stamp: $(PYDOCSTYLE_COMMON_PREREQS)
 	# Check for decent pep8 doc style with pydocstyle.
-	conda run -n ${CONDA_ENV_NAME} pydocstyle $(filter %.py,$?)
+	conda run -n ${CONDA_ENV_NAME} pydocstyle $(filter %.py,$+)
 	touch $@
 
 .PHONY: cspell
@@ -178,7 +178,7 @@ PYLINT_COMMON_PREREQS += $(FORMAT_PREREQS)
 PYLINT_COMMON_PREREQS += .pylintrc
 
 build/pylint.%.${CONDA_ENV_NAME}.build-stamp: $(PYLINT_COMMON_PREREQS)
-	conda run -n ${CONDA_ENV_NAME} pylint -j0 $(filter %.py,$?)
+	conda run -n ${CONDA_ENV_NAME} pylint -j0 $(filter %.py,$+)
 	touch $@
 
 .PHONY: flake8
@@ -195,7 +195,7 @@ FLAKE8_COMMON_PREREQS += $(FORMAT_PREREQS)
 FLAKE8_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/flake8.%.${CONDA_ENV_NAME}.build-stamp: $(FLAKE8_COMMON_PREREQS)
-	conda run -n ${CONDA_ENV_NAME} flake8 -j0 $(filter %.py,$?)
+	conda run -n ${CONDA_ENV_NAME} flake8 -j0 $(filter %.py,$+)
 	touch $@
 
 .PHONY: mypy
@@ -216,7 +216,7 @@ MYPY_COMMON_PREREQS += scripts/dmypy-wrapper.sh
 
 build/mypy.%.${CONDA_ENV_NAME}.build-stamp: $(MYPY_COMMON_PREREQS)
 	conda run -n ${CONDA_ENV_NAME} scripts/dmypy-wrapper.sh \
-		$(filter %.py,$?)
+		$(filter %.py,$+)
 	touch $@
 
 

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ PYCODESTYLE_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/pycodestyle.%.${CONDA_ENV_NAME}.build-stamp: $(PYCODESTYLE_COMMON_PREREQS)
 	# Check for decent pep8 code style with pycodestyle.
-	# Note: if this fails, try using "'make format' or 'make clean-format format'" to fix it.
+	# Note: if this fails, try using 'make format' to fix it.
 	conda run -n ${CONDA_ENV_NAME} pycodestyle $(filter %.py,$+)
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,9 @@ bdist_wheel: mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl
 bdist_wheel: mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl
 bdist_wheel: mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl
 
+# Make the whl files depend on the .tar.gz files, mostly to prevent conflicts
+# with shared use of the their build/ trees.
+
 mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl: MODULE_NAME := mlos_core
 mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl: PACKAGE_NAME := mlos_core
 mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl: mlos_core/dist/tmp/mlos_core-latest.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -443,10 +443,10 @@ PUBLISH_DEPS += build/check-doc.build-stamp
 PUBLISH_DEPS += build/linklint-doc.build-stamp
 
 build/publish.${CONDA_ENV_NAME}.%.py.build-stamp: $(PUBLISH_DEPS)
-	test $(ls -1 mlos_core/dist/*.tar.gz | wc -l) -eq 1
-	test $(ls -1 mlos_bench/dist/*.tar.gz | wc -l) -eq 1
-	test $(ls -1 mlos_viz/dist/*.tar.gz | wc -l) -eq 1
-	test $(ls -1 mlos_*/dist/*.tar.gz | wc -l) -eq 3
+	test `ls -1 mlos_core/dist/*.tar.gz | wc -l` -eq 1
+	test `ls -1 mlos_bench/dist/*.tar.gz | wc -l` -eq 1
+	test `ls -1 mlos_viz/dist/*.tar.gz | wc -l` -eq 1
+	test `ls -1 mlos_*/dist/*.tar.gz | wc -l` -eq 3
 	repo_name=`echo "$@" | sed -r -e 's|build/publish\.[^.]+\.||' -e 's|\.py\.build-stamp||'` \
 		&& conda run -n ${CONDA_ENV_NAME} python3 -m twine upload --repository $$repo_name \
 			mlos_*/dist/mlos*-*.tar.gz mlos_*/dist/mlos*-*.whl

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,15 @@ all: format check test dist dist-test doc | conda-env
 .PHONY: conda-env
 conda-env: build/conda-env.${CONDA_ENV_NAME}.build-stamp
 
-build/conda-env.${CONDA_ENV_NAME}.build-stamp: ${ENV_YML} mlos_core/setup.py mlos_bench/setup.py mlos_viz/setup.py
+MLOS_CORE_CONF_FILES := mlos_core/setup.py mlos_core/MANIFEST.in
+MLOS_BENCH_CONF_FILES := mlos_bench/setup.py mlos_bench/MANIFEST.in
+MLOS_VIZ_CONF_FILES := mlos_viz/setup.py mlos_viz/MANIFEST.in
+MLOS_GLOBAL_CONF_FILES := setup.cfg
+
+MLOS_PKGS := mlos_core mlos_bench mlos_viz
+MLOS_PKG_CONF_FILES := $(MLOS_CORE_CONF_FILES) $(MLOS_BENCH_CONF_FILES) $(MLOS_VIZ_CONF_FILES) $(MLOS_GLOBAL_CONF_FILES)
+
+build/conda-env.${CONDA_ENV_NAME}.build-stamp: ${ENV_YML} $(MLOS_PKG_CONF_FILES)
 	@echo "CONDA_SOLVER: ${CONDA_SOLVER}"
 	@echo "CONDA_EXPERIMENTAL_SOLVER: ${CONDA_EXPERIMENTAL_SOLVER}"
 	@echo "CONDA_INFO_LEVEL: ${CONDA_INFO_LEVEL}"

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ PYCODESTYLE_COMMON_PREREQS += $(MLOS_GLOBAL_CONF_FILES)
 
 build/pycodestyle.%.${CONDA_ENV_NAME}.build-stamp: $(PYCODESTYLE_COMMON_PREREQS)
 	# Check for decent pep8 code style with pycodestyle.
-	# Note: if this fails, try using 'make format' or 'make clean-format format' to fix it.
+	# Note: if this fails, try using 'make format' to fix it.
 	conda run -n ${CONDA_ENV_NAME} pycodestyle $(filter %.py,$+)
 	touch $@
 

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -1,7 +1,7 @@
 name: mlos-3.10
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -10,8 +10,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - setuptools
-  - setuptools-scm>=8.1.0
+  - build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -1,7 +1,7 @@
 name: mlos-3.11
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -10,8 +10,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - setuptools
-  - setuptools-scm>=8.1.0
+  - build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -1,7 +1,7 @@
 name: mlos-3.8
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -10,8 +10,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - setuptools
-  - setuptools-scm>=8.1.0
+  - build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -1,7 +1,7 @@
 name: mlos-3.9
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -10,8 +10,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - setuptools
-  - setuptools-scm>=8.1.0
+  - build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -11,8 +11,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - setuptools
-  - setuptools-scm>=8.1.0
+  - build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -1,7 +1,7 @@
 name: mlos
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   # Basic dev environment packages.
   # All other dependencies for the mlos modules come from pip.

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -10,8 +10,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - setuptools
-  - setuptools-scm>=8.1.0
+  - build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
+setuptools-scm
 sphinx
 nbsphinx
 jupyter_core>=4.11.2    # nbsphix dependency - addresses CVE-2022-39286

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-setuptools-scm
+setuptools-scm>=8.1.0
 sphinx
 nbsphinx
 jupyter_core>=4.11.2    # nbsphix dependency - addresses CVE-2022-39286

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,22 +31,27 @@ sys.path.insert(1, os.path.abspath('../../mlos_viz/mlos_viz'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'MlosCore'
-copyright = '2024, GSL'
-author = 'GSL'
+project = 'MLOS'
+copyright = '2024, Microsoft GSL'
+author = 'Microsoft GSL'
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.1'
+try:
+    from version import VERSION
+except ImportError:
+    VERSION = '0.0.1-dev'
+    warning(f"version.py not found, using dummy VERSION={VERSION}")
 
 try:
     from setuptools_scm import get_version
-    version = get_version(root='../..', relative_to=__file__)
+    version = get_version(root='../..', relative_to=__file__, fallback_version=VERSION)
     if version is not None:
-        release = version
+        VERSION = version
 except ImportError:
-    warning("setuptools_scm not found, using version from _version.py")
+    warning("setuptools_scm not found, using VERSION {VERSION}")
 except LookupError as e:
-    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
+    warning(f"setuptools_scm failed to find git version, using VERSION {VERSION}: {e}")
+release = VERSION
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/version.py
+++ b/doc/source/version.py
@@ -3,8 +3,11 @@
 # Licensed under the MIT License.
 #
 """
-Version number for the mlos_viz package.
+Version number for the MLOS documentation.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.1.0'
+VERSION = '0.5.1'
+
+if __name__ == "__main__":
+    print(VERSION)

--- a/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
@@ -45,6 +45,11 @@
                         "trial_id",
                         "mountPoint"
                     ],
+                    "shell_env_params": [
+                        "mountPoint",
+                        "experiment_id",
+                        "trial_id"
+                    ],
                     "setup": [
                         "$mountPoint/$experiment_id/$trial_id/scripts/setup-workload.sh",
                         "$mountPoint/$experiment_id/$trial_id/scripts/setup-app.sh"

--- a/mlos_bench/mlos_bench/version.py
+++ b/mlos_bench/mlos_bench/version.py
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+"""
+Version number for the mlos_bench package.
+"""
+
+# NOTE: This should be managed by bumpversion.
+VERSION = '0.5.1'
+
+if __name__ == "__main__":
+    print(VERSION)

--- a/mlos_bench/pyproject.toml
+++ b/mlos_bench/pyproject.toml
@@ -1,0 +1,72 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm>=8.1.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mlos-bench"
+description = "MLOS Bench Python interface for benchmark automation and optimization."
+keywords = [
+    "autotuning",
+    "benchmarking",
+    "optimization",
+    "systems",
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+]
+license = { "text" = "MIT" }
+requires-python = ">=3.8"
+authors = [
+    { name = "Microsoft", email = "mlos-maintainers@service.microsoft.com" },
+]
+maintainers = [
+    { name = "Microsoft", email = "mlos-maintainers@service.microsoft.com" },
+]
+dynamic = [
+    "readme",   # urls get dynamically mutated by the build process
+    "version",  # managed by setuptools_scm
+    # managed in combination with version from setuptools_scm
+    "dependencies",
+    "optional-dependencies",
+]
+
+[project.scripts]
+mlos_bench = "mlos_bench.run:_main"
+
+[project.urls]
+Documentation = "https://microsoft.github.io/MLOS/"
+Repository = "https://github.com/microsoft/MLOS/"
+Issues = "https://github.com/microsoft/MLOS/issues"
+"Package Source" = "https://github.com/microsoft/MLOS/tree/main/mlos_bench/"
+
+# Tell setuptools_scm to use the root directory for git info.
+# Note: when setuptools_scm is involved we also need to use MANIFEST.in to include/exclude files.
+[tool.setuptools_scm]
+root = ".."
+
+# Tell setuptools where to find the package.
+[tool.setuptools.packages.find]
+exclude = ["*.tests", "*.tests.*"]
+
+[tool.setuptools.package-data]
+mlos_bench = [
+    "py.typed", "**/*.pyi",
+    "config/**/*.md",
+    "config/**/*.jsonc",
+    "config/**/*.json",
+    "config/**/*.py",
+    "config/**/*.sh",
+    "config/**/*.cmd",
+    "config/**/*.ps1",
+]
+
+[tool.distutils.bdist_wheel]
+# Command option bdist_wheel.universal is not defined
+#universal = 1
+# https://github.com/pypa/wheel/issues/582
+py-limited-api = "cp38"

--- a/mlos_bench/pyproject.toml
+++ b/mlos_bench/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = [
 mlos_bench = "mlos_bench.run:_main"
 
 [project.urls]
-Documentation = "https://microsoft.github.io/MLOS/"
+Documentation = "https://microsoft.github.io/MLOS/source_tree_docs/mlos_bench/"
 Repository = "https://github.com/microsoft/MLOS/"
 Issues = "https://github.com/microsoft/MLOS/issues"
 "Package Source" = "https://github.com/microsoft/MLOS/tree/main/mlos_bench/"

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -15,9 +15,28 @@ from typing import Dict, List
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
-from _version import _VERSION    # pylint: disable=import-private-name
+PKG_NAME = "mlos_bench"
+
+try:
+    ns: Dict[str, str] = {}
+    with open(f"{PKG_NAME}/version.py", encoding="utf-8") as version_file:
+        exec(version_file.read(), ns)   # pylint: disable=exec-used
+    VERSION = ns['VERSION']
+except OSError:
+    VERSION = "0.0.1-dev"
+    warning(f"version.py not found, using dummy VERSION={VERSION}")
+
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__, fallback_version=VERSION)
+    if version is not None:
+        VERSION = version
+except ImportError:
+    warning("setuptools_scm not found, using version from version.py")
+except LookupError as e:
+    warning(f"setuptools_scm failed to find git version, using version from version.py: {e}")
 
 
 # A simple routine to read and adjust the README.md for this module into a format
@@ -31,7 +50,9 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
     pkg_dir = os.path.dirname(__file__)
     readme_path = os.path.join(pkg_dir, 'README.md')
     if not os.path.isfile(readme_path):
-        return {}
+        return {
+            'long_description': 'missing',
+        }
     jsonc_re = re.compile(r'```jsonc')
     link_re = re.compile(r'\]\(([^:#)]+)(#[a-zA-Z0-9_-]+)?\)')
     with open(readme_path, mode='r', encoding='utf-8') as readme_fh:
@@ -44,17 +65,6 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
             'long_description': ''.join(lines),
             'long_description_content_type': 'text/markdown',
         }
-
-
-try:
-    from setuptools_scm import get_version
-    version = get_version(root='..', relative_to=__file__)
-    if version is not None:
-        _VERSION = version  # noqa: F811
-except ImportError:
-    warning("setuptools_scm not found, using version from _version.py")
-except LookupError as e:
-    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
 
 
 extra_requires: Dict[str, List[str]] = {    # pylint: disable=consider-using-namedtuple-or-dataclass
@@ -85,60 +95,15 @@ extra_requires['full-tests'] = extra_requires['full'] + [
     'fasteners',
 ]
 
-# pylint: disable=duplicate-code
-MODULE_BASE_NAME = 'mlos_bench'
 setup(
-    name='mlos-bench',
-    version=_VERSION,
-    packages=find_packages(exclude=[f"{MODULE_BASE_NAME}.tests", f"{MODULE_BASE_NAME}.tests.*"]),
-    package_data={
-        '': ['py.typed', '**/*.pyi'],
-        'mlos_bench': [
-            'config/**/*.md',
-            'config/**/*.jsonc',
-            'config/**/*.json',
-            'config/**/*.py',
-            'config/**/*.sh',
-            'config/**/*.cmd',
-            'config/**/*.ps1',
-        ],
-    },
-    entry_points={
-        'console_scripts': [
-            'mlos_bench = mlos_bench.run:_main',
-        ],
-    },
+    version=VERSION,
     install_requires=[
-        'mlos-core==' + _VERSION,
+        'mlos-core==' + VERSION,
         'requests',
         'json5',
         'jsonschema>=4.18.0', 'referencing>=0.29.1',
         'importlib_resources;python_version<"3.10"',
     ] + extra_requires['storage-sql-sqlite'],   # NOTE: For now sqlite is a fallback storage backend, so we always install it.
     extras_require=extra_requires,
-    author='Microsoft',
-    license='MIT',
     **_get_long_desc_from_readme('https://github.com/microsoft/MLOS/tree/main/mlos_bench'),
-    author_email='mlos-maintainers@service.microsoft.com',
-    description=('MLOS Bench Python interface for benchmark automation and optimization.'),
-    url='https://github.com/microsoft/MLOS',
-    project_urls={
-        'Documentation': 'https://microsoft.github.io/MLOS',
-        'Package Source': 'https://github.com/microsoft/MLOS/tree/main/mlos_bench/',
-    },
-    python_requires='>=3.8',
-    keywords=[
-        'autotuning',
-        'benchmarking',
-        'optimization',
-        'systems',
-    ],
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-    ],
 )

--- a/mlos_core/MANIFEST.in
+++ b/mlos_core/MANIFEST.in
@@ -1,3 +1,5 @@
 # setuptools-scm has an issue that causes it to include all files in git in the sdist produced.
 # Here we exclude test files.
 prune **/tests
+# Also exclude the example notebooks.
+prune notebooks/

--- a/mlos_core/mlos_core/version.py
+++ b/mlos_core/mlos_core/version.py
@@ -7,4 +7,7 @@ Version number for the mlos_core package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.5.1'
+VERSION = '0.5.1'
+
+if __name__ == "__main__":
+    print(VERSION)

--- a/mlos_core/pyproject.toml
+++ b/mlos_core/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm>=8.1.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mlos-core"
+description = "MLOS Core Python interface for parameter optimization."
+keywords = [
+    "autotuning",
+    "optimization",
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+]
+license = { "text" = "MIT" }
+requires-python = ">=3.8"
+authors = [
+    { name = "Microsoft", email = "mlos-maintainers@service.microsoft.com" },
+]
+maintainers = [
+    { name = "Microsoft", email = "mlos-maintainers@service.microsoft.com" },
+]
+dynamic = [
+    "readme",   # urls get dynamically mutated by the build process
+    "version",  # managed by setuptools_scm
+    # managed in combination with version from setuptools_scm
+    "dependencies",
+    "optional-dependencies",
+]
+
+[project.urls]
+Documentation = "https://microsoft.github.io/MLOS/"
+Repository = "https://github.com/microsoft/MLOS/"
+Issues = "https://github.com/microsoft/MLOS/issues"
+"Package Source" = "https://github.com/microsoft/MLOS/tree/main/mlos_core/"
+
+# Tell setuptools_scm to use the root directory for git info.
+# Note: when setuptools_scm is involved we also need to use MANIFEST.in to include/exclude files.
+[tool.setuptools_scm]
+root = ".."
+
+# Tell setuptools where to find the package.
+[tool.setuptools.packages.find]
+exclude = ["*.tests", "*.tests.*"]
+
+[tool.setuptools.package-data]
+mlos_core = ["py.typed", "**/*.pyi"]
+
+[tool.distutils.bdist_wheel]
+# Command option bdist_wheel.universal is not defined
+#universal = 1
+# https://github.com/pypa/wheel/issues/582
+py-limited-api = "cp38"

--- a/mlos_core/pyproject.toml
+++ b/mlos_core/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 
 [project.urls]
-Documentation = "https://microsoft.github.io/MLOS/"
+Documentation = "https://microsoft.github.io/MLOS/source_tree_docs/mlos_core/"
 Repository = "https://github.com/microsoft/MLOS/"
 Issues = "https://github.com/microsoft/MLOS/issues"
 "Package Source" = "https://github.com/microsoft/MLOS/tree/main/mlos_core/"

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -88,7 +88,7 @@ setup(
         'scikit-learn>=1.2',
         'joblib>=1.1.1',        # CVE-2022-21797: scikit-learn dependency, addressed in 1.2.0dev0, which isn't currently released
         'scipy>=1.3.2',
-        'numpy>=1.24',
+        'numpy>=1.24', 'numpy<2.0.0',   # FIXME: https://github.com/numpy/numpy/issues/26710
         'pandas >= 2.2.0;python_version>="3.9"', 'Bottleneck > 1.3.5;python_version>="3.9"',
         'pandas >= 1.0.3;python_version<"3.9"',
         'ConfigSpace>=0.7.1',

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -15,19 +15,28 @@ from typing import Dict, List
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
-from _version import _VERSION   # pylint: disable=import-private-name
+PKG_NAME = "mlos_core"
+
+try:
+    ns: Dict[str, str] = {}
+    with open(f"{PKG_NAME}/version.py", encoding="utf-8") as version_file:
+        exec(version_file.read(), ns)   # pylint: disable=exec-used
+    VERSION = ns['VERSION']
+except OSError:
+    VERSION = "0.0.1-dev"
+    warning(f"version.py not found, using dummy VERSION={VERSION}")
 
 try:
     from setuptools_scm import get_version
-    version = get_version(root='..', relative_to=__file__)
+    version = get_version(root='..', relative_to=__file__, fallback_version=VERSION)
     if version is not None:
-        _VERSION = version  # noqa: F811
+        VERSION = version
 except ImportError:
-    warning("setuptools_scm not found, using version from _version.py")
+    warning("setuptools_scm not found, using version from version.py")
 except LookupError as e:
-    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
+    warning(f"setuptools_scm failed to find git version, using version from version.py: {e}")
 
 
 # A simple routine to read and adjust the README.md for this module into a format
@@ -43,7 +52,9 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
     pkg_dir = os.path.dirname(__file__)
     readme_path = os.path.join(pkg_dir, 'README.md')
     if not os.path.isfile(readme_path):
-        return {}
+        return {
+            'long_description': 'missing',
+        }
     jsonc_re = re.compile(r'```jsonc')
     link_re = re.compile(r'\]\(([^:#)]+)(#[a-zA-Z0-9_-]+)?\)')
     with open(readme_path, mode='r', encoding='utf-8') as readme_fh:
@@ -75,15 +86,8 @@ extra_requires['full-tests'] = extra_requires['full'] + [
     'pytest-local-badge',
 ]
 
-# pylint: disable=duplicate-code
-MODULE_BASE_NAME = 'mlos_core'
 setup(
-    name='mlos-core',
-    version=_VERSION,
-    packages=find_packages(exclude=[f"{MODULE_BASE_NAME}.tests", f"{MODULE_BASE_NAME}.tests.*"]),
-    package_data={
-        '': ['py.typed', '**/*.pyi'],
-    },
+    version=VERSION,
     install_requires=[
         'scikit-learn>=1.2',
         'joblib>=1.1.1',        # CVE-2022-21797: scikit-learn dependency, addressed in 1.2.0dev0, which isn't currently released
@@ -94,27 +98,5 @@ setup(
         'ConfigSpace>=0.7.1',
     ],
     extras_require=extra_requires,
-    author='Microsoft',
-    author_email='mlos-maintainers@service.microsoft.com',
-    license='MIT',
-    **_get_long_desc_from_readme('https://github.com/microsoft/MLOS/tree/main/mlos_core'),
-    description=('MLOS Core Python interface for parameter optimization.'),
-    url='https://github.com/microsoft/MLOS',
-    project_urls={
-        'Documentation': 'https://microsoft.github.io/MLOS',
-        'Package Source': 'https://github.com/microsoft/MLOS/tree/main/mlos_core/',
-    },
-    python_requires='>=3.8',
-    keywords=[
-        'autotuning',
-        'optimization',
-    ],
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-    ],
+    **_get_long_desc_from_readme("https://github.com/microsoft/MLOS/tree/main/mlos_core"),
 )

--- a/mlos_viz/mlos_viz/version.py
+++ b/mlos_viz/mlos_viz/version.py
@@ -3,8 +3,11 @@
 # Licensed under the MIT License.
 #
 """
-Version number for the mlos_bench package.
+Version number for the mlos_viz package.
 """
 
 # NOTE: This should be managed by bumpversion.
-_VERSION = '0.5.1'
+VERSION = '0.5.1'
+
+if __name__ == "__main__":
+    print(VERSION)

--- a/mlos_viz/pyproject.toml
+++ b/mlos_viz/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm>=8.1.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mlos-viz"
+description = "Visualization Python interface for benchmark automation and optimization results."
+keywords = [
+    "autotuning",
+    "benchmarking",
+    "optimization",
+    "systems",
+    "visualization",
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+]
+license = { "text" = "MIT" }
+requires-python = ">=3.8"
+authors = [
+    { name = "Microsoft", email = "mlos-maintainers@service.microsoft.com" },
+]
+maintainers = [
+    { name = "Microsoft", email = "mlos-maintainers@service.microsoft.com" },
+]
+dynamic = [
+    "readme",   # urls get dynamically mutated by the build process
+    "version",  # managed by setuptools_scm
+    # managed in combination with version from setuptools_scm
+    "dependencies",
+    "optional-dependencies",
+]
+
+[project.urls]
+Documentation = "https://microsoft.github.io/MLOS/"
+Repository = "https://github.com/microsoft/MLOS/"
+Issues = "https://github.com/microsoft/MLOS/issues"
+"Package Source" = "https://github.com/microsoft/MLOS/tree/main/mlos_viz/"
+
+# Tell setuptools_scm to use the root directory for git info.
+# Note: when setuptools_scm is involved we also need to use MANIFEST.in to include/exclude files.
+[tool.setuptools_scm]
+root = ".."
+
+# Tell setuptools where to find the package.
+[tool.setuptools.packages.find]
+exclude = ["*.tests", "*.tests.*"]
+
+[tool.setuptools.package-data]
+mlos_viz = ["py.typed", "**/*.pyi"]
+
+[tool.distutils.bdist_wheel]
+# Command option bdist_wheel.universal is not defined
+#universal = 1
+# https://github.com/pypa/wheel/issues/582
+py-limited-api = "cp38"

--- a/mlos_viz/pyproject.toml
+++ b/mlos_viz/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 ]
 
 [project.urls]
-Documentation = "https://microsoft.github.io/MLOS/"
+Documentation = "https://microsoft.github.io/MLOS/source_tree_docs/mlos_viz/"
 Repository = "https://github.com/microsoft/MLOS/"
 Issues = "https://github.com/microsoft/MLOS/issues"
 "Package Source" = "https://github.com/microsoft/MLOS/tree/main/mlos_viz/"

--- a/mlos_viz/setup.py
+++ b/mlos_viz/setup.py
@@ -15,9 +15,29 @@ from typing import Dict, List
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
-from _version import _VERSION    # pylint: disable=import-private-name
+
+PKG_NAME = "mlos_viz"
+
+try:
+    ns: Dict[str, str] = {}
+    with open(f"{PKG_NAME}/version.py", encoding="utf-8") as version_file:
+        exec(version_file.read(), ns)   # pylint: disable=exec-used
+    VERSION = ns['VERSION']
+except OSError:
+    VERSION = "0.0.1-dev"
+    warning(f"version.py not found, using dummy VERSION={VERSION}")
+
+try:
+    from setuptools_scm import get_version
+    version = get_version(root='..', relative_to=__file__, fallback_version=VERSION)
+    if version is not None:
+        VERSION = version
+except ImportError:
+    warning("setuptools_scm not found, using version from version.py")
+except LookupError as e:
+    warning(f"setuptools_scm failed to find git version, using version from version.py: {e}")
 
 
 # A simple routine to read and adjust the README.md for this module into a format
@@ -31,7 +51,9 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
     pkg_dir = os.path.dirname(__file__)
     readme_path = os.path.join(pkg_dir, 'README.md')
     if not os.path.isfile(readme_path):
-        return {}
+        return {
+            'long_description': 'missing',
+        }
     jsonc_re = re.compile(r'```jsonc')
     link_re = re.compile(r'\]\(([^:#)]+)(#[a-zA-Z0-9_-]+)?\)')
     with open(readme_path, mode='r', encoding='utf-8') as readme_fh:
@@ -44,17 +66,6 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
             'long_description': ''.join(lines),
             'long_description_content_type': 'text/markdown',
         }
-
-
-try:
-    from setuptools_scm import get_version
-    version = get_version(root='..', relative_to=__file__)
-    if version is not None:
-        _VERSION = version  # noqa: F811
-except ImportError:
-    warning("setuptools_scm not found, using version from _version.py")
-except LookupError as e:
-    warning(f"setuptools_scm failed to find git version, using version from _version.py: {e}")
 
 
 extra_requires: Dict[str, List[str]] = {}
@@ -71,44 +82,13 @@ extra_requires['full-tests'] = extra_requires['full'] + [
     'pytest-local-badge',
 ]
 
-# pylint: disable=duplicate-code
-MODULE_BASE_NAME = 'mlos_viz'
 setup(
-    name='mlos-viz',
-    version=_VERSION,
-    packages=find_packages(exclude=[f"{MODULE_BASE_NAME}.tests", f"{MODULE_BASE_NAME}.tests.*"]),
-    package_data={
-        '': ['py.typed', '**/*.pyi'],
-    },
+    version=VERSION,
     install_requires=[
-        'mlos-bench==' + _VERSION,
+        'mlos-bench==' + VERSION,
         'dabl>=0.2.6',
         'matplotlib<3.9',   # FIXME: https://github.com/dabl/dabl/pull/341
     ],
     extras_require=extra_requires,
-    author='Microsoft',
-    license='MIT',
     **_get_long_desc_from_readme('https://github.com/microsoft/MLOS/tree/main/mlos_viz'),
-    author_email='mlos-maintainers@service.microsoft.com',
-    description=('MLOS Visualization Python interface for benchmark automation and optimization results.'),
-    url='https://github.com/microsoft/MLOS',
-    project_urls={
-        'Documentation': 'https://microsoft.github.io/MLOS',
-        'Package Source': 'https://github.com/microsoft/MLOS/tree/main/mlos_viz/',
-    },
-    python_requires='>=3.8',
-    keywords=[
-        'autotuning',
-        'benchmarking',
-        'optimization',
-        'systems',
-    ],
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-    ],
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,4 @@
 # vim: set ft=dosini:
-[bdist_wheel]
-universal = 1
 
 [pycodestyle]
 count = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,10 +79,10 @@ strict = True
 allow_any_generics = True
 hide_error_codes = False
 # regex of files to skip type checking
-# _version.py and setup.py look like duplicates when run from the root of the repo even though they're part of different packages.
+# setup.py looks like duplicates when run from the root of the repo even though they're part of different packages.
 # There's not much in them so we just skip them.
 # We also skip several vendor files that currently throw errors.
-exclude = (mlos_(core|bench)/(_version|setup).py)|(doc/)|(/build/)|(-packages/_pytest/)
+exclude = (mlos_(core|bench|viz)/setup.py)|(doc/)|(/build/)|(-packages/_pytest/)
 
 # https://github.com/automl/ConfigSpace/issues/293
 [mypy-ConfigSpace.*]


### PR DESCRIPTION
This PR builds off of #762 and #763 

These are in part 
1. followup fixups for #746 (e.g., to allow setuptools-scm to be pulled in at build time as a build dependency only when conda an pip have mismatched version issues), and
2. Modernization improvements to allow us to make better use of other tools (e.g., `black` that only accept `pyproject.toml` files as their configuration files).

To do so, we move some configs from `setup.py` to `pyproject.toml` for each module.
However, to retain the ability to rewrite URLs in published README.md files on PyPi as well as consistent version dependencies across modules without the need to manually specify version numbers (e.g., using `setuptools-scm`) we mark a few dependencies as dynamic and leave our existing logic inside the `setup.py` file.

Finally, we reorganize the `version.py` file to be inside the module and fix a few previous omissions for `mlos_viz`.