### PR TITLE
Cleanup a warning issued by the SmacOptimizer cleanup code

### DIFF
--- a/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
+++ b/mlos_core/mlos_core/optimizers/bayesian_optimizers/smac_optimizer.py
@@ -336,7 +336,7 @@ class SmacOptimizer(BaseBayesianOptimizer):
         return self.base_optimizer._config_selector._acquisition_function(configs).reshape(-1,)
 
     def cleanup(self) -> None:
-        if self._temp_output_directory is not None:
+        if hasattr(self, '_temp_output_directory') and self._temp_output_directory is not None:
             self._temp_output_directory.cleanup()
             self._temp_output_directory = None
 


### PR DESCRIPTION
Minor tweak to address this warning in pytest output:

```
mlos_core/mlos_core/tests/optimizers/optimizer_multiobj_test.py::test_multi_target_opt_wrong_weights[SmacOptimizer-kwargs2]
  C:\Users\bpkroth\.conda\envs\mlos\Lib\site-packages\_pytest\unraisableexception.py:80: PytestUnraisableExceptionWarning: Exception ignored in: <function SmacOptimizer.__del__ at 0x0000021F5FDC42C0>

  Traceback (most recent call last):
    File "C:\Users\bpkroth\src\MLOS\mlos_core\mlos_core\optimizers\bayesian_optimizers\smac_optimizer.py", line 208, in __del__
      self.cleanup()
    File "C:\Users\bpkroth\src\MLOS\mlos_core\mlos_core\optimizers\bayesian_optimizers\smac_optimizer.py", line 339, in cleanup
      if self._temp_output_directory is not None:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'SmacOptimizer' object has no attribute '_temp_output_directory'

    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))

mlos_core/mlos_core/tests/optimizers/optimizer_test.py: 135 warnings
```