### PR TITLE
bugfix: MySQL can round microseconds into the future causing scheduler to skip trials

### DIFF
--- a/mlos_bench/mlos_bench/os_environ.py
+++ b/mlos_bench/mlos_bench/os_environ.py
@@ -16,10 +16,6 @@ environ.get('PWD')
 import os
 import sys
 
-
-if sys.platform == 'win32':
-    import nt   # type: ignore[import-not-found]    # pylint: disable=import-error  # (3.8)
-
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
 else:
@@ -32,6 +28,10 @@ else:
 
 # Handle case sensitivity differences between platforms.
 # https://stackoverflow.com/a/19023293
-environ: EnvironType = nt.environ if sys.platform == 'win32' else os.environ    # type: ignore[name-defined]
+if sys.platform == 'win32':
+    import nt   # type: ignore[import-not-found]    # pylint: disable=import-error  # (3.8)
+    environ: EnvironType = nt.environ
+else:
+    environ: EnvironType = os.environ
 
 __all__ = ['environ']

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -253,7 +253,8 @@ class Experiment(Storage.Experiment):
 
     def new_trial(self, tunables: TunableGroups, ts_start: Optional[datetime] = None,
                   config: Optional[Dict[str, Any]] = None) -> Storage.Trial:
-        # bugfix: MySQL can round microseconds into the future causing scheduler to skip trials.
+        # MySQL can round microseconds into the future causing scheduler to skip trials.
+        # Truncate microseconds to avoid this issue.
         ts_start = utcify_timestamp(ts_start or datetime.now(UTC), origin="local").replace(microsecond=0)
         _LOG.debug("Create trial: %s:%d @ %s", self._experiment_id, self._trial_id, ts_start)
         with self._engine.begin() as conn:

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -253,7 +253,8 @@ class Experiment(Storage.Experiment):
 
     def new_trial(self, tunables: TunableGroups, ts_start: Optional[datetime] = None,
                   config: Optional[Dict[str, Any]] = None) -> Storage.Trial:
-        ts_start = utcify_timestamp(ts_start or datetime.now(UTC), origin="local")
+        # bugfix: MySQL can round microseconds into the future causing scheduler to skip trials.
+        ts_start = utcify_timestamp(ts_start or datetime.now(UTC), origin="local").replace(microsecond=0)
         _LOG.debug("Create trial: %s:%d @ %s", self._experiment_id, self._trial_id, ts_start)
         with self._engine.begin() as conn:
             try:


### PR DESCRIPTION
Solution: truncate microseconds of the current timestamp when scheduling new trials to be executed ASAP

Closes #756