### PR TITLE
patch for managed identity storage authentication

### DIFF
--- a/mlos_bench/mlos_bench/config/cli/azure-redis-bench.jsonc
+++ b/mlos_bench/mlos_bench/config/cli/azure-redis-bench.jsonc
@@ -14,9 +14,9 @@
     "environment": "environments/root/root-azure-redis.jsonc",
     "storage": "storage/sqlite.jsonc",
 
-    "globals": [
-        "global_config_azure.jsonc"
-    ],
+    // "globals": [
+    //     "global_config_azure.jsonc"
+    // ],
 
     "teardown": false,
 

--- a/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/apps/redis/redis.jsonc
@@ -51,19 +51,22 @@
                         "trial_id"
                     ],
                     "setup": [
-                        "$mountPoint/$experiment_id/$trial_id/scripts/setup-workload.sh",
-                        "$mountPoint/$experiment_id/$trial_id/scripts/setup-app.sh"
+                        "sudo /usr/local/bin/azure_file_share_service --function 'download' --local_path $mountPoint/$experiment_id/$trial_id/scripts/ --remote_path $experiment_id/$trial_id/scripts",
+                        "sudo /usr/local/bin/azure_file_share_service --function 'download' --local_path $mountPoint/$experiment_id/$trial_id/input/redis.cfg --remote_path $experiment_id/$trial_id/input/redis.cfg",
+                        "sudo bash $mountPoint/$experiment_id/$trial_id/scripts/setup-workload.sh",
+                        "sudo bash $mountPoint/$experiment_id/$trial_id/scripts/setup-app.sh"
                     ],
                     "run": [
-                        "mkdir -p /tmp/mlos_bench/output/",
-                        "$mountPoint/$experiment_id/$trial_id/scripts/run-workload.sh",
-                        "mkdir -p $mountPoint/$experiment_id/$trial_id/output/",
-                        "cp -r /tmp/mlos_bench/output/* $mountPoint/$experiment_id/$trial_id/output/"
+                        "sudo mkdir -p /tmp/mlos_bench/output/",
+                        "sudo bash $mountPoint/$experiment_id/$trial_id/scripts/run-workload.sh",
+                        "sudo /usr/local/bin/azure_file_share_service --function 'upload' --local_path /tmp/mlos_bench/output/ --remote_path $experiment_id/$trial_id/output"
+                        // "mkdir -p $mountPoint/$experiment_id/$trial_id/output/",
+                        // "cp -r /tmp/mlos_bench/output/* $mountPoint/$experiment_id/$trial_id/output/"
                     ],
                     "teardown": [
-                        "$mountPoint/$experiment_id/$trial_id/scripts/cleanup-workload.sh",
-                        "$mountPoint/$experiment_id/$trial_id/scripts/cleanup-app.sh",
-                        "rm -r /tmp/mlos_bench/"
+                        "sudo bash $mountPoint/$experiment_id/$trial_id/scripts/cleanup-workload.sh",
+                        "sudo bash $mountPoint/$experiment_id/$trial_id/scripts/cleanup-app.sh"
+                        // "rm -r /tmp/mlos_bench/"
                     ]
                 }
             },

--- a/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
@@ -52,34 +52,51 @@
                 "config": {
                     "required_args": [
                         "vmName",
+                        "tenantId",
+                        "managedIdentityClientId",
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"
                     ],
                     "wait_boot": true,
                     "shell_env_params": [
+                        "tenantId",
+                        "managedIdentityClientId",
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"
                     ],
                     "setup": [
                         "sudo mkdir -p $mountPoint",
-                        "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
+                        "sudo chmod +x $mountPoint",
+                        "sudo apt install software-properties-common -y",
+                        "sudo add-apt-repository ppa:deadsnakes/ppa -y",
+                        "sudo apt-get update -y",
+                        "sudo apt-get install python3.8 -y",
+                        "sudo apt install python3-pip -y",
+                        "sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1",
+                        "sudo python -m pip install --upgrade pip setuptools wheel",
+                        "sudo python -m pip install azure-file-share-service",
+                        "echo storageAccountName=$storageAccountName | sudo tee -a /etc/environment",
+                        "echo storageFileShareName=$storageFileShareName | sudo tee -a /etc/environment",
+                        "echo managedIdentityClientId=$managedIdentityClientId | sudo tee -a /etc/environment",
+                        "echo tenantId=$tenantId | sudo tee -a /etc/environment",
+                        "source /etc/environment"
+
+                        // "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
                         // TODO: Apply GRUB parameters from config on shared storage at:
                         // "$mountPoint/$experiment_id/$trial_id/input/grub.cfg"
                         // "sudo update-grub",
                         // "sudo shutdown -r now"  // Reboot to apply the parameters
-                        "cat $mountPoint/$experiment_id/$trial_id/input/grub.cfg"
+                        // "cat $mountPoint/$experiment_id/$trial_id/input/grub.cfg"
                     ],
                     "teardown": [
                         // "sudo umount $mountPoint"
-                        "echo sudo umount $mountPoint"
+                        "echo sudo rm -rf $mountPoint"
                     ]
                 }
             }

--- a/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
@@ -56,7 +56,6 @@
                         "vmName",
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"
@@ -65,15 +64,15 @@
                     "shell_env_params": [
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"
                     ],
                     "setup": [
                         "sudo mkdir -p $mountPoint",
-                        "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
-                        "sudo $mountPoint/$experiment_id/$trial_id/input/config-kernel.sh"
+                        "sudo /usr/local/bin/azure_file_share_service --function 'download' --local_path $mountPoint/$experiment_id/$trial_id/input/ --remote_path $experiment_id/$trial_id/input",
+                        "sudo bash $mountPoint/$experiment_id/$trial_id/input/config-kernel.sh"
+                        // "sudo mount -t cifs //$storageAccountName.file.core.windows.net/$storageFileShareName $mountPoint -o username=$storageAccountName,password=\"$storageAccountKey\",serverino,nosharesock,actimeo=30",
                     ]
                 }
             }

--- a/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
+++ b/mlos_bench/mlos_bench/config/experiments/experiment_RedisBench.jsonc
@@ -10,6 +10,11 @@
     "deploymentName": "$experiment_id",
     "vmName": "os-autotune-linux-vm",
 
+    "subscription": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "managedIdentityClientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "managedIdentityName": "mlos-managed-identity",
+    "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+
     "resourceGroup": "os-autotune",
     "location": "westus2",
 

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-deployment-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-deployment-service-subschema.json
@@ -20,6 +20,10 @@
                             "description": "The name of the resource group to place the deployment in (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
+                        "managedIdentityName": {
+                            "description": "The name of the managed identity used for storage authentication (typically provided in the global config in order to omit from source control).",
+                            "type": "string"
+                        },
                         "deploymentTemplatePath": {
                             "description": "Path to an ARM template file, or null if it should be skipped.",
                             "type": ["string", "null"],

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
@@ -28,8 +28,12 @@
                             "description": "Azure storage file share name.",
                             "type": "string"
                         },
-                        "storageAccountKey": {
-                            "description": "Azure storage account key (typically provided in the global config in order to omit from source control).",
+                        "managedIdentityClientId": {
+                            "description": "Azure Managed Identity Client Id (typically provided in the global config in order to omit from source control).",
+                            "type": "string"
+                        },
+                        "tenantId": {
+                            "description": "Azure Tenant Id (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         }
                     },

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-fileshare.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-fileshare.jsonc
@@ -3,6 +3,7 @@
     "config": {
         "storageAccountName": "PLACEHOLDER; e.g.: osatsharedstorage",
         "storageFileShareName": "PLACEHOLDER; e.g.: os-autotune-file-share",
-        "storageAccountKey": "PLACEHOLDER; comes from global config"
+        "managedIdentityClientId": "PLACEHOLDER; comes from global config",
+        "tenantId": "PLACEHOLDER; comes from global config"
     }
 }

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-linux-vm-ops.jsonc
@@ -10,6 +10,7 @@
                 // can be overridden by the parameters pushed from the caller Environment.
                 "subscription": "PLACEHOLDER; AZURE SUBSCRIPTION ID",
                 "resourceGroup": "PLACEHOLDER; e.g., os-autotune",
+                "managedIdentityName": "PLACEHOLDER; e.g., mlos-managed-identity",
 
                 "deploymentTemplatePath": "services/remote/azure/arm-templates/azuredeploy-ubuntu-vm.jsonc",
 

--- a/mlos_bench/mlos_bench/environments/remote/host_env.py
+++ b/mlos_bench/mlos_bench/environments/remote/host_env.py
@@ -84,7 +84,11 @@ class HostEnv(Environment):
         if status.is_pending():
             (status, _) = self._host_service.wait_host_deployment(params, is_setup=True)
 
-        self._is_ready = status.is_succeeded()
+        (status_id_assign, params) = self._host_service.assign_managed_identity(self._params)
+        if status_id_assign.is_pending():
+            (status_id_assign, _) = self._host_service.wait_host_managed_identity_assignment(params)
+
+        self._is_ready = status.is_succeeded() and status_id_assign.is_succeeded()
         return self._is_ready
 
     def teardown(self) -> None:

--- a/mlos_bench/mlos_bench/services/types/host_provisioner_type.py
+++ b/mlos_bench/mlos_bench/services/types/host_provisioner_type.py
@@ -90,3 +90,35 @@ class SupportsHostProvisioning(Protocol):
             A pair of Status and result. The result is always {}.
             Status is one of {PENDING, SUCCEEDED, FAILED}
         """
+
+    def assign_managed_identity(self, params: dict) -> Tuple["Status", dict]:
+        """
+        Assigns a managed identity to the Host/VM.
+
+        Parameters
+        ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of tunable parameters.
+
+        Returns
+        -------
+        result : (Status, dict={})
+            A pair of Status and result. The result is always {}.
+            Status is one of {PENDING, SUCCEEDED, FAILED}
+        """
+
+    def wait_host_managed_identity_assignment(self, params: dict) -> Tuple["Status", dict]:
+        """
+        Waits for a pending managed identity assignment operation to resolve to SUCCEEDED or FAILED.
+
+        Parameters
+        ----------
+        params : dict
+            Flat dictionary of (key, value) pairs of tunable parameters.
+
+        Returns
+        -------
+        result : (Status, dict={})
+            A pair of Status and result. The result is always {}.
+            Status is one of {PENDING, SUCCEEDED, FAILED}
+        """


### PR DESCRIPTION
MLOS can no longer work with `storage account keys` for storage authentication because account key access must be disabled for security reasons. Users must enable storage authentication with managed identities instead.

That's a temporary patch that switches to managed identity authentication.
Users must create a managed identity and assign to it proper "contributor" roles that allow it to manage the file share.
Then they must pass the managed identity's info `managedIdentityClientId` and `managedIdentityName` to MLOS as global parameters. 

The managed identity must be assigned to the MLOS host in order for the `local file share service` to work.
```bash 
az vm identity assign -g <resource-group> -n <vm-name> --identities <managed-identity-name>
```

Implementation Details:
- The managed identity must be assigned to all provisioned VMs.
Currently, I assign the identity using the REST API right after the VM has been provisioned. A better approach would be to assign the identity directly using the ARM template. The reason I did not use the better/easier approach is that I was somehow tricked after reading [this](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-configure-managed-identities?pivots=qs-configure-portal-windows-vm#assign-a-user-assigned-identity-during-the-creation-of-a-vm) into thinking that it was not supported! I intend to switch soon.

- [Mounting file shares doesn't work with managed identities](https://learn.microsoft.com/en-us/answers/questions/1620270/how-do-i-mount-an-azure-file-share-in-azure-contai). The VMs provisioned by MLOS access scripts uploaded by the host by mounting the file share. My temporary workaround is to download/upload files using the functionality from `azure-file-share-service` instead which I updated to use the Managed Identity Credential. To make that script available to the provisioned VMs I packaged it and [uploaded it to PyPI ](https://pypi.org/project/azure-file-share-service/). Then, scripts booting/setting up the VM must install the package (e.g. in boot-ubuntu.jsonc) in order to be able to interact with the file share. The proper, long-term solution would be to enable mounting again after adding to it support for managed identities.

I updated the config files for the `RedisBench` experiment and verified that the flow works.

Opening this PR to raise concern about the deprecation of storage account keys and how this currently breaks MLOS (no longer working because retrieving the keys is prohibited). Will be using this patch for my personal work until there is a more formal solution.