### PR TITLE
Remove the storageAccountKey parameter from all JSON configs and schemas

### DIFF
--- a/mlos_bench/README.md
+++ b/mlos_bench/README.md
@@ -104,8 +104,7 @@ This data produced in the `global_config_azure.jsonc` file is in the format that
 ```jsonc
 {
   "subscription": "some-guid",
-  "tenant": "some-other-guid",
-  "storageAccountKey": "some-base-64-encoded-key",
+  "tenant": "some-other-guid"
 }
 ```
 

--- a/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/boot/boot-ubuntu.jsonc
@@ -54,7 +54,6 @@
                         "vmName",
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"
@@ -63,7 +62,6 @@
                     "shell_env_params": [
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"

--- a/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
+++ b/mlos_bench/mlos_bench/config/environments/os/linux/runtime/setup-ubuntu.jsonc
@@ -56,7 +56,6 @@
                         "vmName",
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"
@@ -65,7 +64,6 @@
                     "shell_env_params": [
                         "storageAccountName",
                         "storageFileShareName",
-                        "storageAccountKey",
                         "mountPoint",
                         "experiment_id",
                         "trial_id"

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
@@ -27,10 +27,6 @@
                         "storageFileShareName": {
                             "description": "Azure storage file share name.",
                             "type": "string"
-                        },
-                        "storageAccountKey": {
-                            "description": "Azure storage account key (typically provided in the global config in order to omit from source control).",
-                            "type": "string"
                         }
                     },
                     "required": [

--- a/mlos_bench/mlos_bench/config/services/remote/azure/service-fileshare.jsonc
+++ b/mlos_bench/mlos_bench/config/services/remote/azure/service-fileshare.jsonc
@@ -2,7 +2,6 @@
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
         "storageAccountName": "PLACEHOLDER; e.g.: osatsharedstorage",
-        "storageFileShareName": "PLACEHOLDER; e.g.: os-autotune-file-share",
-        "storageAccountKey": "PLACEHOLDER; comes from global config"
+        "storageFileShareName": "PLACEHOLDER; e.g.: os-autotune-file-share"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/experiments/experiment_test_config.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/experiments/experiment_test_config.jsonc
@@ -8,7 +8,6 @@
     // FIXME: The setup ubuntu configs currently use these values in their mounting scripts.
     // We should abstract that out so those details are only needed when a service that uses those is used.
     "storageAccountName": "foo",
-    "storageAccountKey": "bar",
     "storageFileShareName": "baz",
 
     // Assign some values to variadic tunables and required parameters present in the config examples.

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_fileshare_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_fileshare_service-config-missing.jsonc
@@ -1,8 +1,7 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
-        "storageAccountName": "storage-account-name",
-        //"storageFileShareName": "required param missing",
-        "storageAccountKey": "required param missing"
+        // "storageAccountName": "storage-account-name",
+        "storageFileShareName": "required param missing"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_fileshare_service-config-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_fileshare_service-config-extras.jsonc
@@ -3,7 +3,6 @@
     "config": {
         "storageAccountName": "storage-account-name",
         "storageFileShareName": "file-share-name",
-        "storageAccountKey": "storage-account-key-blob",
 
         "extra": "invalid"
     }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_flex_service-extras.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/unhandled/azure_flex_service-extras.jsonc
@@ -16,7 +16,6 @@
         // 3 unhandled config parameters:
         "storageAccountName": "storage-account-name",
         "storageFileShareName": "file-share-name",
-        "storageAccountKey": "storage-account-key-blob",
 
         "requestTimeout": 20
     }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_fileshare_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_fileshare_service-full.jsonc
@@ -6,7 +6,6 @@
     "config": {
         "storageAccountName": "storage-account-name",
         "storageFileShareName": "file-share-name",
-        "storageAccountKey": "storage-account-key-blob",
 
         "pollInterval": 1,
         "pollTimeout": 10,

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_fileshare_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_fileshare_service-partial.jsonc
@@ -1,8 +1,7 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
-        //"storageAccountName": "storage-account-name",
-        //"storageAccountKey": "storage-account-key-blob",
+        // "storageAccountName": "storage-account-name",
         "storageFileShareName": "file-share-name"
     }
 }

--- a/scripts/generate-azure-credentials-config.ps1
+++ b/scripts/generate-azure-credentials-config.ps1
@@ -17,14 +17,4 @@ if (-not $AZURE_STORAGE_ACCOUNT_NAME) {
     Write-Error "Missing default az storage account name config."
 }
 
-az account get-access-token `
-    --query "{tenant:tenant,subscription:subscription}" |
-    ConvertFrom-Json |
-    Add-Member "storageAccountKey" (
-        az storage account keys list `
-            --resource-group $AZURE_DEFAULTS_GROUP `
-            --account-name $AZURE_STORAGE_ACCOUNT_NAME `
-            --query "[0].value" `
-            --output tsv `
-        ) -PassThru |
-    ConvertTo-Json
+az account get-access-token --query "{tenant:tenant,subscription:subscription}"

--- a/scripts/generate-azure-credentials-config.sh
+++ b/scripts/generate-azure-credentials-config.sh
@@ -11,10 +11,4 @@ AZURE_DEFAULTS_GROUP=${AZURE_DEFAULTS_GROUP:-$(az config get --local defaults.gr
 AZURE_STORAGE_ACCOUNT_RG=${AZURE_STORAGE_ACCOUNT_RG:-$AZURE_DEFAULTS_GROUP}
 AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME:-$(az config get --local storage.account --query value -o tsv)}
 
-az account get-access-token \
-    --query "{tenant:tenant,subscription:subscription}" |
-    jq ".storageAccountKey = `
-        az storage account keys list \
-            --resource-group $AZURE_STORAGE_ACCOUNT_RG \
-            --account-name $AZURE_STORAGE_ACCOUNT_NAME \
-            --query '[0].value'`"
+az account get-access-token --query "{tenant:tenant,subscription:subscription}"


### PR DESCRIPTION
This is part of PR #777. Merge after #779 and ... (azcopy PR coming soon)