### PR TITLE
CI fixups

### DIFF
--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -38,6 +38,9 @@ dependencies:
     - types-pygments
     - types-requests
     - types-setuptools
-    - "--editable ../mlos_core[full-tests]"
-    - "--editable ../mlos_bench[full-tests]"
-    - "--editable ../mlos_viz[full-tests]"
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -38,6 +38,9 @@ dependencies:
     - types-pygments
     - types-requests
     - types-setuptools
-    - "--editable ../mlos_core[full-tests]"
-    - "--editable ../mlos_bench[full-tests]"
-    - "--editable ../mlos_viz[full-tests]"
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -38,6 +38,9 @@ dependencies:
     - types-pygments
     - types-requests
     - types-setuptools
-    - "--editable ../mlos_core[full-tests]"
-    - "--editable ../mlos_bench[full-tests]"
-    - "--editable ../mlos_viz[full-tests]"
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -38,6 +38,9 @@ dependencies:
     - types-pygments
     - types-requests
     - types-setuptools
-    - "--editable ../mlos_core[full-tests]"
-    - "--editable ../mlos_bench[full-tests]"
-    - "--editable ../mlos_viz[full-tests]"
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -42,6 +42,9 @@ dependencies:
     - types-requests
     - types-setuptools
     - pyarrow
-    - "--editable ../mlos_core[full-tests]"
-    - "--editable ../mlos_bench[full-tests]"
-    - "--editable ../mlos_viz[full-tests]"
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -37,6 +37,9 @@ dependencies:
     - types-pygments
     - types-requests
     - types-setuptools
-    - "--editable ../mlos_core[full-tests]"
-    - "--editable ../mlos_bench[full-tests]"
-    - "--editable ../mlos_viz[full-tests]"
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"

--- a/mlos_bench/pyproject.toml
+++ b/mlos_bench/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm>=8.1.0", "wheel"]
+requires = ["setuptools>64", "setuptools-scm>=8.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mlos_bench/setup.py
+++ b/mlos_bench/setup.py
@@ -70,7 +70,7 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
 extra_requires: Dict[str, List[str]] = {    # pylint: disable=consider-using-namedtuple-or-dataclass
     # Additional tools for extra functionality.
     'azure': ['azure-storage-file-share', 'azure-identity', 'azure-keyvault'],
-    'ssh': ['asyncssh'],
+    'ssh': ['asyncssh<2.15.0'],  # FIXME: asyncssh 2.15.0 has a bug that breaks the tests
     'storage-sql-duckdb': ['sqlalchemy', 'duckdb_engine'],
     'storage-sql-mysql': ['sqlalchemy', 'mysql-connector-python'],
     'storage-sql-postgres': ['sqlalchemy', 'psycopg2'],

--- a/mlos_core/pyproject.toml
+++ b/mlos_core/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm>=8.1.0", "wheel"]
+requires = ["setuptools>64", "setuptools-scm>=8.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/mlos_viz/pyproject.toml
+++ b/mlos_viz/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm>=8.1.0", "wheel"]
+requires = ["setuptools>64", "setuptools-scm>=8.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION

1. Temporarily avoid recent asyncssh version that breaks the tests
2. Workaround pylance issue with pyproject.toml related changes and pip editable modules install format (#768)
   See Also: 
   - https://github.com/microsoft/pylance-release/issues/3473
   May also affect `mypy`:
   - https://github.com/python/mypy/issues/16988
   - https://github.com/python/mypy/issues/12313