### PR TITLE
Temporarily restrict ConfigSpace version

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/tunables/tunable-params-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/tunables/tunable-params-schema.json
@@ -124,7 +124,7 @@
             "uniqueItems": true
         },
         "quantization": {
-            "description": "The number of buckets to quantize the range into.\nSee Also:\nhttps://automl.github.io/ConfigSpace/main/api/hyperparameters.html#module-ConfigSpace.api.types.float,\nhttps://automl.github.io/ConfigSpace/main/api/hyperparameters.html#module-ConfigSpace.api.types.integer",
+            "description": "The number of buckets to quantize the range into.",
             "$comment": "type left unspecified here"
         },
         "log_scale": {

--- a/mlos_bench/mlos_bench/tunables/README.md
+++ b/mlos_bench/mlos_bench/tunables/README.md
@@ -8,4 +8,4 @@ A good example are "boot time" kernel parameters vs. "runtime" kernel parameters
 
 ## TODOs
 
-- Evaluate replacing these entirely with [`ConfigSpace`](https://automl.github.io/ConfigSpace/main/), since that is currently what we use to configure the ([`mlos_core`](../../../mlos_core/)) [`Optimizer`](../optimizers/).
+- Evaluate replacing these entirely with [`ConfigSpace`](https://automl.github.io/ConfigSpace/), since that is currently what we use to configure the ([`mlos_core`](../../../mlos_core/)) [`Optimizer`](../optimizers/).

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -95,7 +95,7 @@ setup(
         'numpy>=1.24', 'numpy<2.0.0',   # FIXME: https://github.com/numpy/numpy/issues/26710
         'pandas >= 2.2.0;python_version>="3.9"', 'Bottleneck > 1.3.5;python_version>="3.9"',
         'pandas >= 1.0.3;python_version<"3.9"',
-        'ConfigSpace==0.7.2',   # Temporarily restrict ConfigSpace version.
+        'ConfigSpace==0.7.1',   # Temporarily restrict ConfigSpace version.
     ],
     extras_require=extra_requires,
     **_get_long_desc_from_readme("https://github.com/microsoft/MLOS/tree/main/mlos_core"),

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -95,7 +95,7 @@ setup(
         'numpy>=1.24', 'numpy<2.0.0',   # FIXME: https://github.com/numpy/numpy/issues/26710
         'pandas >= 2.2.0;python_version>="3.9"', 'Bottleneck > 1.3.5;python_version>="3.9"',
         'pandas >= 1.0.3;python_version<"3.9"',
-        'ConfigSpace>=0.7.1',
+        'ConfigSpace==0.7.2',   # Temporarily restrict ConfigSpace version.
     ],
     extras_require=extra_requires,
     **_get_long_desc_from_readme("https://github.com/microsoft/MLOS/tree/main/mlos_core"),


### PR DESCRIPTION
ConfigSpace 1.0.0 was just released and includes some important changes that we'll eventually want to support, but in the interest of making progress on other things for the time being, this PR pins us at the previous stable version we were using.

https://github.com/automl/ConfigSpace/compare/v0.7.2...v1.0.0