### PR TITLE
Ignore reformatting revision

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Reformat with black, isort, docformatter, etc.
+e40ac28317c61ea90345d3499986957b0e1c9134


### PR DESCRIPTION
Follow-on work to #774, this PR uses a [`.git-blame-ignore-revs` file](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) to ignore revs that cause major reformatting changes in git blame view.