### PR TITLE
Upgrade required dabl version and simplify related dependency rules

### DIFF
--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -88,10 +88,11 @@ extra_requires["full-tests"] = extra_requires["full"] + [
 setup(
     version=VERSION,
     install_requires=[
-        "scikit-learn>=1.2",
+        "scikit-learn>=1.3",
         "scipy>=1.3.2",
         "numpy>=1.24",
-        "pandas>=2.2.0",
+        'pandas >= 2.2.0;python_version>="3.9"',
+        'pandas >= 1.0.3;python_version<"3.9"',
         "ConfigSpace>=1.0",
     ],
     extras_require=extra_requires,

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -89,15 +89,9 @@ setup(
     version=VERSION,
     install_requires=[
         "scikit-learn>=1.2",
-        # CVE-2022-21797: scikit-learn dependency, addressed in 1.2.0dev0, which
-        # isn't currently released
-        "joblib>=1.1.1",
         "scipy>=1.3.2",
         "numpy>=1.24",
-        "numpy<2.0.0",  # FIXME: https://github.com/numpy/numpy/issues/26710
-        'pandas >= 2.2.0;python_version>="3.9"',
-        'Bottleneck > 1.3.5;python_version>="3.9"',
-        'pandas >= 1.0.3;python_version<"3.9"',
+        "pandas>=2.2.0",
         "ConfigSpace>=1.0",
     ],
     extras_require=extra_requires,

--- a/mlos_viz/setup.py
+++ b/mlos_viz/setup.py
@@ -84,6 +84,7 @@ setup(
     install_requires=[
         "mlos-bench==" + VERSION,
         "dabl>=0.3.1",
+        "matplotlib",
         "seaborn>=0.12.2",
     ],
     extras_require=extra_requires,

--- a/mlos_viz/setup.py
+++ b/mlos_viz/setup.py
@@ -83,8 +83,7 @@ setup(
     version=VERSION,
     install_requires=[
         "mlos-bench==" + VERSION,
-        "dabl>=0.2.6",
-        "matplotlib<3.9",  # FIXME: https://github.com/dabl/dabl/pull/341
+        "dabl>=0.3.1",
         "seaborn>=0.12.2",
     ],
     extras_require=extra_requires,


### PR DESCRIPTION
- Upgrade to a newer version of dabl with better sklearn support and explicit dependencies for some incompatibilities referenced.
  - https://github.com/dabl/dabl/pull/346
  - https://github.com/dabl/dabl/pull/343
  - https://github.com/dabl/dabl/pull/342
  - https://github.com/dabl/dabl/pull/341
- Drop some now unnecessary version restrictions.

See Also: #757
Closes: #826 