### PR TITLE
Temporarily avoid new version of FLAML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,13 +559,13 @@ build/dist-test-env.$(PYTHON_VERSION).build-stamp: mlos_viz/dist/tmp/mlos_viz-la
 	# Install some additional dependencies necessary for clean building some of the wheels.
 	conda install -y ${CONDA_INFO_LEVEL} -n mlos-dist-test-$(PYTHON_VERSION) swig libpq
 	# Test a clean install of the mlos_core wheel.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl[full-tests]"
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "`readlink -f mlos_core/dist/tmp/mlos_core-latest-py3-none-any.whl`[full-tests]"
 	# Test a clean install of the mlos_bench wheel.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl[full-tests]"
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "`readlink -f mlos_bench/dist/tmp/mlos_bench-latest-py3-none-any.whl`[full-tests]"
 	# Test that the config dir for mlos_bench got distributed.
 	test -e `conda env list | grep "mlos-dist-test-$(PYTHON_VERSION) " | awk '{ print $$2 }'`/lib/python$(PYTHON_VERS_REQ)/site-packages/mlos_bench/config/README.md
 	# Test a clean install of the mlos_viz wheel.
-	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl[full-tests]"
+	conda run -n mlos-dist-test-$(PYTHON_VERSION) pip install "`readlink -f mlos_viz/dist/tmp/mlos_viz-latest-py3-none-any.whl`[full-tests]"
 	touch $@
 
 .PHONY: dist-test

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -68,7 +68,10 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
 
 
 extra_requires: Dict[str, List[str]] = {  # pylint: disable=consider-using-namedtuple-or-dataclass
-    "flaml": ["flaml[blendsearch]"],
+    "flaml": [
+        "flaml<2.2.0",  # FIXME: temporarily avoid changes in new FLAML package (#839).
+        "flaml[blendsearch]",
+    ],
     # NOTE: Major refactoring on SMAC and ConfigSpace v1.0 starting from v2.2
     "smac": ["smac>=2.2.0"],
 }


### PR DESCRIPTION
See Also: #839

Also fixes `make dist-test` rules to workaround recently broken `pip` version interpretation when using symlinked whl files.
https://github.com/pypa/pip/issues/12911