### PR TITLE
Fixup: use corrected python build package name from conda forge

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -138,6 +138,13 @@ jobs:
         set -x
         docker exec --user vscode --env USER=vscode mlos-devcontainer make CONDA_INFO_LEVEL=-v conda-env
 
+    - name: Verify expected version of python in conda env
+      timeout-minutes: 2
+      run: |
+        set -x
+        docker exec --user vscode --env USER=vscode mlos-devcontainer conda run -n mlos python -c \
+          'from sys import version_info as vers; assert (vers.major, vers.minor) == (3, 12), f"Unexpected python version: {vers}"'
+
     - name: Check for missing licenseheaders
       timeout-minutes: 3
       run: |

--- a/conda-envs/mlos-3.10.yml
+++ b/conda-envs/mlos-3.10.yml
@@ -11,7 +11,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.11.yml
+++ b/conda-envs/mlos-3.11.yml
@@ -11,7 +11,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.12.yml
+++ b/conda-envs/mlos-3.12.yml
@@ -13,7 +13,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.8.yml
+++ b/conda-envs/mlos-3.8.yml
@@ -11,7 +11,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-3.9.yml
+++ b/conda-envs/mlos-3.9.yml
@@ -11,7 +11,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -12,7 +12,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels

--- a/conda-envs/mlos.yml
+++ b/conda-envs/mlos.yml
@@ -11,7 +11,7 @@ dependencies:
   - pycodestyle
   - pydocstyle
   - flake8
-  - build
+  - python-build
   - jupyter
   - ipykernel
   - nb_conda_kernels


### PR DESCRIPTION
The [`build`](https://anaconda.org/conda-forge/build) name in conda-forge apparently hasn't been updated in 3 years.
Whereas [`python-build`](https://anaconda.org/conda-forge/python-build) is updated frequently.
Probably this is for namespacing reasons.