### PR TITLE
Tweaks for some pylint warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -125,6 +125,10 @@
     ],
     "esbonio.sphinx.confDir": "${workspaceFolder}/doc/source",
     "esbonio.sphinx.buildDir": "${workspaceFolder}/doc/build/",
+    "pylint.severity": {
+        // display refactor warnings as information messages
+        "refactor": "Information"
+    },
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -395,7 +395,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         _LOG.info("Created: Scheduler %s", inst)
         return inst
 
-    def build_environment(  # pylint: disable=too-many-arguments
+    def build_environment(
         self,
         config: Dict[str, Any],
         tunables: TunableGroups,
@@ -403,6 +403,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         parent_args: Optional[Dict[str, TunableValue]] = None,
         service: Optional[Service] = None,
     ) -> Environment:
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         Factory method for a new environment with a given config.
 
@@ -566,7 +567,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
 
         return self._build_composite_service(config_list, global_config, parent)
 
-    def load_environment(  # pylint: disable=too-many-arguments
+    def load_environment(
         self,
         json_file_name: str,
         tunables: TunableGroups,
@@ -574,6 +575,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         parent_args: Optional[Dict[str, TunableValue]] = None,
         service: Optional[Service] = None,
     ) -> Environment:
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         Load and build new environment from the config file.
 
@@ -600,7 +602,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         assert isinstance(config, dict)
         return self.build_environment(config, tunables, global_config, parent_args, service)
 
-    def load_environment_list(  # pylint: disable=too-many-arguments
+    def load_environment_list(
         self,
         json_file_name: str,
         tunables: TunableGroups,
@@ -608,6 +610,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         parent_args: Optional[Dict[str, TunableValue]] = None,
         service: Optional[Service] = None,
     ) -> List[Environment]:
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         Load and build a list of environments from the config file.
 

--- a/mlos_bench/mlos_bench/services/remote/azure/azure_auth.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_auth.py
@@ -111,7 +111,7 @@ class AzureAuthService(Service, SupportsAuth[TokenCredential]):
         cert_bytes = b64decode(secret.value)
 
         # Reauthenticate as the service principal.
-        self._cred = CertificateCredential(
+        self._cred = CertificateCredential(  # pylint: disable=redefined-variable-type
             tenant_id=tenant_id,
             client_id=sp_client_id,
             certificate_data=cert_bytes,

--- a/mlos_bench/mlos_bench/services/remote/ssh/ssh_fileshare.py
+++ b/mlos_bench/mlos_bench/services/remote/ssh/ssh_fileshare.py
@@ -35,7 +35,7 @@ class SshFileShareService(FileShareService, SshService):
         remote_path: str,
         recursive: bool = True,
     ) -> None:
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         Starts a file copy operation.
 

--- a/mlos_bench/mlos_bench/services/types/config_loader_type.py
+++ b/mlos_bench/mlos_bench/services/types/config_loader_type.py
@@ -78,6 +78,7 @@ class SupportsConfigLoading(Protocol):
         parent_args: Optional[Dict[str, TunableValue]] = None,
         service: Optional["Service"] = None,
     ) -> "Environment":
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         Factory method for a new environment with a given config.
 
@@ -106,7 +107,7 @@ class SupportsConfigLoading(Protocol):
             An instance of the `Environment` class initialized with `config`.
         """
 
-    def load_environment_list(  # pylint: disable=too-many-arguments
+    def load_environment_list(
         self,
         json_file_name: str,
         tunables: "TunableGroups",
@@ -114,6 +115,7 @@ class SupportsConfigLoading(Protocol):
         parent_args: Optional[Dict[str, TunableValue]] = None,
         service: Optional["Service"] = None,
     ) -> List["Environment"]:
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         Load and build a list of environments from the config file.
 

--- a/mlos_bench/mlos_bench/tests/conftest.py
+++ b/mlos_bench/mlos_bench/tests/conftest.py
@@ -143,7 +143,7 @@ def locked_docker_services(
     """A locked version of the docker_services fixture to implement xdist single
     instance locking.
     """
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     # Mark the services as in use with the reader lock.
     docker_services_lock.acquire_read_lock()
     # Acquire the setup lock to prevent multiple setup operations at once.

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_network_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_network_services_test.py
@@ -75,7 +75,6 @@ def test_wait_network_deployment_retry(
     ],
 )
 @patch("mlos_bench.services.remote.azure.azure_deployment_services.requests")
-# pylint: disable=too-many-arguments
 def test_network_operation_status(
     mock_requests: MagicMock,
     azure_network_service: AzureNetworkService,
@@ -85,6 +84,7 @@ def test_network_operation_status(
     operation_status: Status,
 ) -> None:
     """Test network operation status."""
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     mock_response = MagicMock()
     mock_response.status_code = http_status_code
     mock_requests.post.return_value = mock_response

--- a/mlos_bench/mlos_bench/tests/services/remote/azure/azure_vm_services_test.py
+++ b/mlos_bench/mlos_bench/tests/services/remote/azure/azure_vm_services_test.py
@@ -139,7 +139,6 @@ def test_azure_vm_service_custom_data(azure_auth_service: AzureAuthService) -> N
     ],
 )
 @patch("mlos_bench.services.remote.azure.azure_deployment_services.requests")
-# pylint: disable=too-many-arguments
 def test_vm_operation_status(
     mock_requests: MagicMock,
     azure_vm_service: AzureVMService,
@@ -149,6 +148,7 @@ def test_vm_operation_status(
     operation_status: Status,
 ) -> None:
     """Test VM operation status."""
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     mock_response = MagicMock()
     mock_response.status_code = http_status_code
     mock_requests.post.return_value = mock_response


### PR DESCRIPTION
Minor adjustments to both display in vscode and quiet some pylint warnings.

Note: in the future I'd like to get some changes from #330 incorporated to allow more self-contained config examples, with relative paths support, added, which means changing a pile of APIs, in which case we can probably make all of these require named position values and remove those exceptions.