### PR TITLE
Various quick CI fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,7 +757,7 @@ build/check-doc.build-stamp: doc/build/html/index.html doc/build/html/htmlcov/in
 		| egrep -C1 -e WARNING -e CRITICAL -e ERROR \
 		| egrep -v \
 			-e "warnings.warn\(f'\"{wd.path}\" is shallow and may cause errors'\)" \
-			-e "No such file or directory: '.*.examples'.$$" \
+			-e "No such file or directory: '.*.examples'.( \[docutils\]\s*)?$$" \
 			-e 'Problems with "include" directive path:' \
 			-e 'duplicate object description' \
 			-e "document isn't included in any toctree" \

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
+"""Sphinx configuration for MLOS documentation."""
+# pylint: disable=invalid-name
 
 # Configuration file for the Sphinx documentation builder.
 #
@@ -21,30 +23,31 @@ import sys
 
 from logging import warning
 
-import sphinx_rtd_theme
+import sphinx_rtd_theme  # pylint: disable=unused-import
 
 
-sys.path.insert(0, os.path.abspath('../../mlos_core/mlos_core'))
-sys.path.insert(1, os.path.abspath('../../mlos_bench/mlos_bench'))
-sys.path.insert(1, os.path.abspath('../../mlos_viz/mlos_viz'))
+sys.path.insert(0, os.path.abspath("../../mlos_core/mlos_core"))
+sys.path.insert(1, os.path.abspath("../../mlos_bench/mlos_bench"))
+sys.path.insert(1, os.path.abspath("../../mlos_viz/mlos_viz"))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'MLOS'
-copyright = '2024, Microsoft GSL'
-author = 'Microsoft GSL'
+project = "MLOS"
+copyright = "2024, Microsoft GSL"  # pylint: disable=redefined-builtin
+author = "Microsoft GSL"
 
 # The full version, including alpha/beta/rc tags
 try:
     from version import VERSION
 except ImportError:
-    VERSION = '0.0.1-dev'
+    VERSION = "0.0.1-dev"
     warning(f"version.py not found, using dummy VERSION={VERSION}")
 
 try:
     from setuptools_scm import get_version
-    version = get_version(root='../..', relative_to=__file__, fallback_version=VERSION)
+
+    version = get_version(root="../..", relative_to=__file__, fallback_version=VERSION)
     if version is not None:
         VERSION = version
 except ImportError:
@@ -60,25 +63,25 @@ release = VERSION
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'nbsphinx',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.doctest',
+    "nbsphinx",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
     # 'sphinx.ext.intersphinx',
     # 'sphinx.ext.linkcode',
-    'numpydoc',
-    'matplotlib.sphinxext.plot_directive',
-    'myst_parser',
+    "numpydoc",
+    "matplotlib.sphinxext.plot_directive",
+    "myst_parser",
 ]
 
 source_suffix = {
-    '.rst': 'restructuredtext',
+    ".rst": "restructuredtext",
     # '.txt': 'markdown',
-    '.md': 'markdown',
+    ".md": "markdown",
 }
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # generate autosummary even if no references
 autosummary_generate = True
@@ -100,7 +103,7 @@ autodoc_default_options = {
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '_templates']
+exclude_patterns = ["_build", "_templates"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -114,10 +117,10 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # -- nbsphinx options for rendering notebooks -------------------------------
 # nbsphinx_execute = 'never'   # enable to stop nbsphinx from executing notebooks
-nbsphinx_kernel_name = 'python3'
+nbsphinx_kernel_name = "python3"
 # Exclude build directory and Jupyter backup files:
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -111,8 +111,8 @@ exclude_patterns = ["_build", "_templates"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/mlos_core/mlos_core/tests/spaces/spaces_test.py
+++ b/mlos_core/mlos_core/tests/spaces/spaces_test.py
@@ -26,7 +26,7 @@ from mlos_core.spaces.converters.flaml import (
 OptimizerSpace = Union[FlamlSpace, CS.ConfigurationSpace]
 OptimizerParam = Union[FlamlDomain, Hyperparameter]
 
-NP_E = np.e  # type: ignore[misc]    # false positive (read deleted variable)
+NP_E: float = np.e  # type: ignore[misc]    # false positive (read deleted variable)
 
 
 def assert_is_uniform(arr: npt.NDArray) -> None:

--- a/mlos_core/mlos_core/tests/spaces/spaces_test.py
+++ b/mlos_core/mlos_core/tests/spaces/spaces_test.py
@@ -26,6 +26,8 @@ from mlos_core.spaces.converters.flaml import (
 OptimizerSpace = Union[FlamlSpace, CS.ConfigurationSpace]
 OptimizerParam = Union[FlamlDomain, Hyperparameter]
 
+NP_E = np.e  # type: ignore[misc]    # false positive (read deleted variable)
+
 
 def assert_is_uniform(arr: npt.NDArray) -> None:
     """Implements a few tests for uniformity."""
@@ -44,7 +46,7 @@ def assert_is_uniform(arr: npt.NDArray) -> None:
     assert f_p_value > 0.5
 
 
-def assert_is_log_uniform(arr: npt.NDArray, base: float = np.e) -> None:
+def assert_is_log_uniform(arr: npt.NDArray, base: float = NP_E) -> None:
     """Checks whether an array is log uniformly distributed."""
     logs = np.log(arr) / np.log(base)
     assert_is_uniform(logs)

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -97,6 +97,9 @@ setup(
         'pandas >= 2.2.0;python_version>="3.9"',
         'pandas >= 1.0.3;python_version<"3.9"',
         "ConfigSpace>=1.0",
+        # pyparsing (required by matplotlib and needed for the notebook examples)
+        # 3.2 has incompatibilities with python 3.8 due to type hints
+        'pyparsing<3.2; python_version<"3.9"',
     ],
     extras_require=extra_requires,
     **_get_long_desc_from_readme("https://github.com/microsoft/MLOS/tree/main/mlos_core"),


### PR DESCRIPTION
# Pull Request

## Title

Quick fixups to the documentation build.

---

## Description

- Expands one of the ignored warnings.
- Reformats the sphinx conf for black and pylint.
- Removes a warning from that file around redefinition of `html_theme_path`.
- Adds a dependency requirement tweak for `pyparsing` when installing under python 3.8 (unrelated other CI bug).
- Adds a workaround to a mypy false positive with in checking `np.e` as a "deleted variable" (e.g., `e` is used in a try/except block)

---

## Type of Change

- 🛠️ Bug fix
- 📝 Documentation update

---

## Testing

- Ran `make doc` and `make check-doc`.
- Ran `make notebook-exec-test`.

---

## Additional Notes (optional)

This is a quick fix to get the CI pipeline working again.
The more complete fix to remove warning ignores from doc generation, improve cross reference linking, etc. will be handled later in #869 

---
