### PR TITLE
devcontainer build fixups for macOS clients

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,8 +66,7 @@ COPY --from=deps-prep --chown=vscode:conda /tmp/conda-tmp/mlos_deps.yml /tmp/con
 RUN echo "Setup miniconda" \
     && curl -Ss https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/conda.gpg > /dev/null \
     && gpg --keyring /etc/apt/trusted.gpg.d/conda.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806 \
-    && mtype=`uname -m` && echo "# uname -m: $mtype" \
-    && echo "deb [arch=$mtype signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
+    && echo "deb [arch=amd64,arm64 signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
     && sudo apt-get update \
     && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends conda \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,12 +64,9 @@ COPY --from=deps-prep --chown=vscode:conda /tmp/conda-tmp/mlos_deps.yml /tmp/con
 # Combine the installation of miniconda and the mlos dependencies into a single step in order to save space.
 # This allows the mlos env to reference the base env's packages without duplication across layers.
 RUN echo "Setup miniconda" \
-    && curl -Ss https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/conda.gpg > /dev/null \
-    && gpg --keyring /etc/apt/trusted.gpg.d/conda.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806 \
-    && echo "deb [arch=amd64,arm64 signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
-    && sudo apt-get update \
-    && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends conda \
-    && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* \
+    && curl -Ss --url https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -o /tmp/miniconda3.sh \
+    && sh /tmp/miniconda3.sh -b -u -p /opt/conda \
+    && rm -rf /tmp/miniconda3.sh \
     && echo "# Adjust the conda installation to be user/group writable." \
     && sudo /opt/conda/bin/conda init --system \
     && sudo chgrp -R conda /opt/conda \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,7 +66,8 @@ COPY --from=deps-prep --chown=vscode:conda /tmp/conda-tmp/mlos_deps.yml /tmp/con
 RUN echo "Setup miniconda" \
     && curl -Ss https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/conda.gpg > /dev/null \
     && gpg --keyring /etc/apt/trusted.gpg.d/conda.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806 \
-    && echo "deb [arch=$(uname -m) signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
+    && mtype=`uname -m` && echo "# uname -m: $mtype" \
+    && echo "deb [arch=$mtype signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
     && sudo apt-get update \
     && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends conda \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -65,7 +65,7 @@ COPY --from=deps-prep --chown=vscode:conda /tmp/conda-tmp/mlos_deps.yml /tmp/con
 # This allows the mlos env to reference the base env's packages without duplication across layers.
 RUN echo "Setup miniconda" \
     && curl -Ss --url https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(uname -m).sh -o /tmp/miniconda3.sh \
-    && sh /tmp/miniconda3.sh -b -u -p /opt/conda \
+    && sudo sh /tmp/miniconda3.sh -b -u -p /opt/conda \
     && rm -rf /tmp/miniconda3.sh \
     && echo "# Adjust the conda installation to be user/group writable." \
     && sudo /opt/conda/bin/conda init --system \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=deps-prep --chown=vscode:conda /tmp/conda-tmp/mlos_deps.yml /tmp/con
 RUN echo "Setup miniconda" \
     && curl -Ss https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/conda.gpg > /dev/null \
     && gpg --keyring /etc/apt/trusted.gpg.d/conda.gpg --no-default-keyring --fingerprint 34161F5BF5EB1D4BFBBB8F0A8AEB4F8B29D82806 \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
+    && echo "deb [arch=$(uname -m) signed-by=/etc/apt/trusted.gpg.d/conda.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" | sudo tee /etc/apt/sources.list.d/conda.list \
     && sudo apt-get update \
     && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends conda \
     && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* \

--- a/.devcontainer/build/build-devcontainer-cli.ps1
+++ b/.devcontainer/build/build-devcontainer-cli.ps1
@@ -35,7 +35,7 @@ if ("$env:NO_CACHE" -eq 'true') {
 else {
     $cacheFrom = 'mloscore.azurecr.io/devcontainer-cli:latest'
     $devcontainer_cli_build_args += " --cache-from $cacheFrom"
-    docker pull $cacheFrom
+    docker pull --platform linux/amd64 $cacheFrom
 }
 
 $cmd = "docker.exe build -t devcontainer-cli:latest -t cspell:latest " +

--- a/.devcontainer/build/build-devcontainer-cli.sh
+++ b/.devcontainer/build/build-devcontainer-cli.sh
@@ -38,7 +38,7 @@ else
     cacheFrom='mloscore.azurecr.io/devcontainer-cli'
     tmpdir=$(mktemp -d)
     devcontainer_cli_build_args+=" --cache-from $cacheFrom"
-    docker --config="$tmpdir" pull "$cacheFrom" || true
+    docker --config="$tmpdir" pull --platform linux/$(uname -m) "$cacheFrom" || true
     rmdir "$tmpdir"
 fi
 

--- a/.devcontainer/build/build-devcontainer-cli.sh
+++ b/.devcontainer/build/build-devcontainer-cli.sh
@@ -25,7 +25,11 @@ if [ -w /var/run/docker-host.sock ]; then
 fi
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
+
+# TODO: Add multiplatform build support?
+#devcontainer_cli_build_args='--platform linux/amd64,linux/arm64'
 devcontainer_cli_build_args=''
+
 if docker buildx version 2>/dev/null; then
     devcontainer_cli_build_args+=' --progress=plain'
 else

--- a/.devcontainer/build/build-devcontainer-cli.sh
+++ b/.devcontainer/build/build-devcontainer-cli.sh
@@ -10,16 +10,18 @@ set -eu
 scriptdir=$(dirname "$(readlink -f "$0")")
 cd "$scriptdir/"
 
+source ../common.sh
+
 # Build the helper container that has the devcontainer CLI for building the devcontainer.
 
 if [ ! -w /var/run/docker.sock ]; then
     echo "ERROR: $USER does not have write access to /var/run/docker.sock. Please add $USER to the docker group." >&2
     exit 1
 fi
-DOCKER_GID=$(stat -c'%g' /var/run/docker.sock)
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
 # Make this work inside a devcontainer as well.
 if [ -w /var/run/docker-host.sock ]; then
-    DOCKER_GID=$(stat -c'%g' /var/run/docker-host.sock)
+    DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 fi
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}

--- a/.devcontainer/build/build-devcontainer-cli.sh
+++ b/.devcontainer/build/build-devcontainer-cli.sh
@@ -35,7 +35,7 @@ fi
 if [ "${NO_CACHE:-}" == 'true' ]; then
     devcontainer_cli_build_args+=' --no-cache --pull'
 else
-    cacheFrom='mloscore.azurecr.io/devcontainer-cli:latest'
+    cacheFrom='mloscore.azurecr.io/devcontainer-cli'
     tmpdir=$(mktemp -d)
     devcontainer_cli_build_args+=" --cache-from $cacheFrom"
     docker --config="$tmpdir" pull "$cacheFrom" || true

--- a/.devcontainer/build/build-devcontainer-cli.sh
+++ b/.devcontainer/build/build-devcontainer-cli.sh
@@ -18,13 +18,11 @@ if [ ! -w /var/run/docker.sock ]; then
     echo "ERROR: $USER does not have write access to /var/run/docker.sock. Please add $USER to the docker group." >&2
     exit 1
 fi
-docker_sock=
-if [ -e /var/run/docker-host.sock ]; then
-    docker_sock=$(readlink -f /var/run/docker-host.sock)
-else
-    docker_sock=$(readlink -f /var/run/docker.sock)
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
+# Make this work inside a devcontainer as well.
+if [ -w /var/run/docker-host.sock ]; then
+    DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 fi
-DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS "$docker_sock")
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 devcontainer_cli_build_args=''

--- a/.devcontainer/build/build-devcontainer-cli.sh
+++ b/.devcontainer/build/build-devcontainer-cli.sh
@@ -18,11 +18,13 @@ if [ ! -w /var/run/docker.sock ]; then
     echo "ERROR: $USER does not have write access to /var/run/docker.sock. Please add $USER to the docker group." >&2
     exit 1
 fi
-DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
-# Make this work inside a devcontainer as well.
-if [ -w /var/run/docker-host.sock ]; then
-    DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
+docker_sock=
+if [ -e /var/run/docker-host.sock ]; then
+    docker_sock=$(readlink -f /var/run/docker-host.sock)
+else
+    docker_sock=$(readlink -f /var/run/docker.sock)
 fi
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS "$docker_sock")
 
 export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 devcontainer_cli_build_args=''

--- a/.devcontainer/build/build-devcontainer.ps1
+++ b/.devcontainer/build/build-devcontainer.ps1
@@ -42,13 +42,13 @@ if ($null -eq $env:DOCKER_BUILDKIT) {
 $devcontainer_build_args = ''
 if ("$env:NO_CACHE" -eq 'true') {
     $base_image = (Get-Content "$rootdir/.devcontainer/Dockerfile" | Select-String '^FROM' | Select-Object -ExpandProperty Line | ForEach-Object { $_ -replace '^FROM\s+','' } | ForEach-Object { $_ -replace ' AS\s+.*','' } | Select-Object -First 1)
-    docker pull $base_image
+    docker pull --platform linux/amd64 $base_image
     $devcontainer_build_args = '--no-cache'
 }
 else {
     $cacheFrom = 'mloscore.azurecr.io/mlos-devcontainer:latest'
     $devcontainer_build_args = "--cache-from $cacheFrom"
-    docker pull "$cacheFrom"
+    docker pull --platform linux/amd64 "$cacheFrom"
 }
 
 # Make this work inside a devcontainer as well.

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -12,16 +12,18 @@ repo_root=$(readlink -f "$scriptdir/../..")
 repo_name=$(basename "$repo_root")
 cd "$scriptdir/"
 
+source ../common.sh
+
 DEVCONTAINER_IMAGE="devcontainer-cli:latest"
 MLOS_AUTOTUNING_IMAGE="mlos-devcontainer:latest"
 
 # Build the helper container that has the devcontainer CLI for building the devcontainer.
 NO_CACHE=${NO_CACHE:-} ./build-devcontainer-cli.sh
 
-DOCKER_GID=$(stat -c'%g' /var/run/docker.sock)
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
 # Make this work inside a devcontainer as well.
 if [ -w /var/run/docker-host.sock ]; then
-    DOCKER_GID=$(stat -c'%g' /var/run/docker-host.sock)
+    DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 fi
 
 # Build the devcontainer image.

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -25,6 +25,9 @@ DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
 if [ -w /var/run/docker-host.sock ]; then
     DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 fi
+if [[ $OSTYPE =~ darwin* ]]; then
+    DOCKER_GID=0
+fi
 
 # Build the devcontainer image.
 rootdir="$repo_root"

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -20,11 +20,14 @@ MLOS_AUTOTUNING_IMAGE="mlos-devcontainer:latest"
 # Build the helper container that has the devcontainer CLI for building the devcontainer.
 NO_CACHE=${NO_CACHE:-} ./build-devcontainer-cli.sh
 
-DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
-# Make this work inside a devcontainer as well.
-if [ -w /var/run/docker-host.sock ]; then
-    DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
+docker_sock=
+if [ -e /var/run/docker-host.sock ]; then
+    docker_sock=$(readlink -f /var/run/docker-host.sock)
+else
+    docker_sock=$(readlink -f /var/run/docker.sock)
 fi
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS "$docker_sock")
+
 
 # Build the devcontainer image.
 rootdir="$repo_root"

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -47,13 +47,13 @@ fi
 devcontainer_build_args=''
 if [ "${NO_CACHE:-}" == 'true' ]; then
     base_image=$(grep '^FROM ' "$rootdir/.devcontainer/Dockerfile" | sed -e 's/^FROM //' -e 's/ AS .*//' | head -n1)
-    docker pull "$base_image" || true
+    docker pull --platform linux/$(uname -m) "$base_image" || true
     devcontainer_build_args='--no-cache'
 else
     cache_from='mloscore.azurecr.io/mlos-devcontainer'
     devcontainer_build_args="--cache-from $cache_from --cache-from mlos-devcontainer"
     tmpdir=$(mktemp -d)
-    docker --config="$tmpdir" pull "$cache_from" || true
+    docker --config="$tmpdir" pull --platform linux/$(uname -m) "$cache_from" || true
     rmdir "$tmpdir"
 fi
 

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -44,6 +44,8 @@ else
     eval "pushd "$rootdir/"; $initializeCommand; popd"
 fi
 
+# TODO: Add multi-platform build support?
+#devcontainer_build_args='--platform linux/amd64,linux/arm64'
 devcontainer_build_args=''
 if [ "${NO_CACHE:-}" == 'true' ]; then
     base_image=$(grep '^FROM ' "$rootdir/.devcontainer/Dockerfile" | sed -e 's/^FROM //' -e 's/ AS .*//' | head -n1)

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -47,8 +47,8 @@ if [ "${NO_CACHE:-}" == 'true' ]; then
     docker pull "$base_image" || true
     devcontainer_build_args='--no-cache'
 else
-    cache_from='mloscore.azurecr.io/mlos-devcontainer:latest'
-    devcontainer_build_args="--cache-from $cache_from --cache-from mlos-devcontainer:latest"
+    cache_from='mloscore.azurecr.io/mlos-devcontainer'
+    devcontainer_build_args="--cache-from $cache_from --cache-from mlos-devcontainer"
     tmpdir=$(mktemp -d)
     docker --config="$tmpdir" pull "$cache_from" || true
     rmdir "$tmpdir"

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -20,14 +20,11 @@ MLOS_AUTOTUNING_IMAGE="mlos-devcontainer:latest"
 # Build the helper container that has the devcontainer CLI for building the devcontainer.
 NO_CACHE=${NO_CACHE:-} ./build-devcontainer-cli.sh
 
-docker_sock=
-if [ -e /var/run/docker-host.sock ]; then
-    docker_sock=$(readlink -f /var/run/docker-host.sock)
-else
-    docker_sock=$(readlink -f /var/run/docker.sock)
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
+# Make this work inside a devcontainer as well.
+if [ -w /var/run/docker-host.sock ]; then
+    DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 fi
-DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS "$docker_sock")
-
 
 # Build the devcontainer image.
 rootdir="$repo_root"

--- a/.devcontainer/build/build-devcontainer.sh
+++ b/.devcontainer/build/build-devcontainer.sh
@@ -32,7 +32,7 @@ rootdir="$repo_root"
 # Run the initialize command on the host first.
 # Note: command should already pull the cached image if possible.
 pwd
-devcontainer_json=$(cat "$rootdir/.devcontainer/devcontainer.json" | sed -e 's|^\s*//.*||' -e 's|/\*|\n&|g;s|*/|&\n|g' | sed -e '/\/\*/,/*\//d')
+devcontainer_json=$(cat "$rootdir/.devcontainer/devcontainer.json" | sed -e 's|^[ \t]*//.*||' -e 's|/\*|\n&|g;s|*/|&\n|g' | sed -e '/\/\*/,/*\//d')
 initializeCommand=$(echo "$devcontainer_json" | docker run -i --rm $DEVCONTAINER_IMAGE jq -e -r '.initializeCommand[]')
 if [ -z "$initializeCommand" ]; then
     echo "No initializeCommand found in devcontainer.json" >&2

--- a/.devcontainer/common.sh
+++ b/.devcontainer/common.sh
@@ -1,6 +1,6 @@
 case $OSTYPE in
     linux*)
-        STAT_FORMAT_GID_ARGS="-c'%g'"
+        STAT_FORMAT_GID_ARGS="-c%g"
         STAT_FORMAT_INODE_ARGS="-c%i"
         ;;
     darwin*)

--- a/.devcontainer/common.sh
+++ b/.devcontainer/common.sh
@@ -1,0 +1,14 @@
+case $OSTYPE in
+    linux*)
+        STAT_FORMAT_GID_ARGS="-c'%g'"
+        STAT_FORMAT_INODE_ARGS="-c'%i'"
+        ;;
+    darwin*)
+        STAT_FORMAT_GID_ARGS="-f%g"
+        STAT_FORMAT_INODE_ARGS="-f%i"
+        ;;
+    *)
+        echo "ERROR: Unhandled OSTYPE: $OSTYPE"
+        exit 1
+        ;;
+esac

--- a/.devcontainer/common.sh
+++ b/.devcontainer/common.sh
@@ -1,3 +1,7 @@
+##
+## Copyright (c) Microsoft Corporation.
+## Licensed under the MIT License.
+##
 case $OSTYPE in
     linux*)
         STAT_FORMAT_GID_ARGS="-c%g"

--- a/.devcontainer/common.sh
+++ b/.devcontainer/common.sh
@@ -1,7 +1,7 @@
 case $OSTYPE in
     linux*)
         STAT_FORMAT_GID_ARGS="-c'%g'"
-        STAT_FORMAT_INODE_ARGS="-c'%i'"
+        STAT_FORMAT_INODE_ARGS="-c%i"
         ;;
     darwin*)
         STAT_FORMAT_GID_ARGS="-f%g"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,8 +4,6 @@ services:
       context: ./tmp
       dockerfile: ../Dockerfile
       args:
-        DOCKER_BUILDKIT: 1
-        COMPOSE_DOCKER_CLI_BUILD: 1
         BUILDKIT_INLINE_CACHE: 1
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
@@ -33,8 +31,6 @@ services:
       context: ./tmp
       dockerfile: ../../doc/Dockerfile
       args:
-        DOCKER_BUILDKIT: 1
-        COMPOSE_DOCKER_CLI_BUILD: 1
         BUILDKIT_INLINE_CACHE: 1
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,6 +4,7 @@ services:
       context: ./tmp
       dockerfile: ../Dockerfile
       args:
+        DOCKER_BUILKIT: 1
         BUILDKIT_INLINE_CACHE: 1
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
@@ -31,6 +32,7 @@ services:
       context: ./tmp
       dockerfile: ../../doc/Dockerfile
       args:
+        DOCKER_BUILKIT: 1
         BUILDKIT_INLINE_CACHE: 1
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,7 +4,8 @@ services:
       context: ./tmp
       dockerfile: ../Dockerfile
       args:
-        DOCKER_BUILKIT: 1
+        DOCKER_BUILDKIT: 1
+        COMPOSE_DOCKER_CLI_BUILD: 1
         BUILDKIT_INLINE_CACHE: 1
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
@@ -32,7 +33,8 @@ services:
       context: ./tmp
       dockerfile: ../../doc/Dockerfile
       args:
-        DOCKER_BUILKIT: 1
+        DOCKER_BUILDKIT: 1
+        COMPOSE_DOCKER_CLI_BUILD: 1
         BUILDKIT_INLINE_CACHE: 1
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -20,6 +20,7 @@ if [ ! -f .env ]; then
 fi
 # Also prep the random NGINX_PORT for the docker-compose command.
 if ! [ -e .devcontainer/.env ] || ! egrep -q "^NGINX_PORT=[0-9]+$" .devcontainer/.env; then
+    RANDOM=$$
     NGINX_PORT=$((($RANDOM % 30000) + 1 + 80))
     echo "NGINX_PORT=$NGINX_PORT" > .devcontainer/.env
 fi

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -56,6 +56,6 @@ if [ "${NO_CACHE:-}" != 'true' ]; then
     ## Make sure we use an empty config to avoid auth issues for devs with the
     ## registry, which should allow anonymous pulls
     #tmpdir=$(mktemp -d)
-    #docker --config="$tmpdir" pull -q "$cacheFrom" >/dev/null || true
+    #docker --config="$tmpdir" pull --platform linux/$(uname -m) -q "$cacheFrom" >/dev/null || true
     #rmdir "$tmpdir"
 fi

--- a/.devcontainer/scripts/prep-container-build
+++ b/.devcontainer/scripts/prep-container-build
@@ -20,7 +20,7 @@ if [ ! -f .env ]; then
 fi
 # Also prep the random NGINX_PORT for the docker-compose command.
 if ! [ -e .devcontainer/.env ] || ! egrep -q "^NGINX_PORT=[0-9]+$" .devcontainer/.env; then
-    NGINX_PORT=$(($(shuf -i 0-30000 -n 1) + 80))
+    NGINX_PORT=$((($RANDOM % 30000) + 1 + 80))
     echo "NGINX_PORT=$NGINX_PORT" > .devcontainer/.env
 fi
 

--- a/.devcontainer/scripts/prep-container-build.ps1
+++ b/.devcontainer/scripts/prep-container-build.ps1
@@ -49,5 +49,5 @@ if ($env:NO_CACHE -ne 'true') {
     $cacheFrom = 'mloscore.azurecr.io/mlos-devcontainer'
     # Skip pulling for now (see TODO note above)
     Write-Host "Consider pulling image $cacheFrom for build caching."
-    #docker pull $cacheFrom
+    #docker pull --platform linux/amd64 $cacheFrom
 }

--- a/.devcontainer/scripts/run-devcontainer.sh
+++ b/.devcontainer/scripts/run-devcontainer.sh
@@ -24,13 +24,11 @@ container_name="$repo_name.$(stat $STAT_FORMAT_INODE_ARGS "$repo_root/")"
 # Be sure to use the host workspace folder if available.
 workspace_root=${LOCAL_WORKSPACE_FOLDER:-$repo_root}
 
-docker_sock=
 if [ -e /var/run/docker-host.sock ]; then
-    docker_sock=$(readlink -f /var/run/docker-host.sock)
+    docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 else
-    docker_sock=$(readlink -f /var/run/docker.sock)
+    docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
 fi
-DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS "$docker_sock")
 
 set -x
 mkdir -p "/tmp/$container_name/dc/shellhistory"
@@ -38,7 +36,7 @@ docker run -it --rm \
     --name "$container_name" \
     --user vscode \
     --env USER=vscode \
-    --group-add $DOCKER_GID \
+    --group-add $docker_gid \
     -v "$HOME/.azure":/dc/azure \
     -v "/tmp/$container_name/dc/shellhistory:/dc/shellhistory" \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/.devcontainer/scripts/run-devcontainer.sh
+++ b/.devcontainer/scripts/run-devcontainer.sh
@@ -24,11 +24,13 @@ container_name="$repo_name.$(stat $STAT_FORMAT_INODE_ARGS "$repo_root/")"
 # Be sure to use the host workspace folder if available.
 workspace_root=${LOCAL_WORKSPACE_FOLDER:-$repo_root}
 
+docker_sock=
 if [ -e /var/run/docker-host.sock ]; then
-    docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
+    docker_sock=$(readlink -f /var/run/docker-host.sock)
 else
-    docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
+    docker_sock=$(readlink -f /var/run/docker.sock)
 fi
+DOCKER_GID=$(stat $STAT_FORMAT_GID_ARGS "$docker_sock")
 
 set -x
 mkdir -p "/tmp/$container_name/dc/shellhistory"
@@ -36,7 +38,7 @@ docker run -it --rm \
     --name "$container_name" \
     --user vscode \
     --env USER=vscode \
-    --group-add $docker_gid \
+    --group-add $DOCKER_GID \
     -v "$HOME/.azure":/dc/azure \
     -v "/tmp/$container_name/dc/shellhistory:/dc/shellhistory" \
     -v /var/run/docker.sock:/var/run/docker.sock \

--- a/.devcontainer/scripts/run-devcontainer.sh
+++ b/.devcontainer/scripts/run-devcontainer.sh
@@ -17,15 +17,17 @@ repo_root=$(readlink -f "$scriptdir/../..")
 repo_name=$(basename "$repo_root")
 cd "$repo_root"
 
-container_name="$repo_name.$(stat -c%i "$repo_root/")"
+source .devcontainer/common.sh
+
+container_name="$repo_name.$(stat $STAT_FORMAT_INODE_ARGS "$repo_root/")"
 
 # Be sure to use the host workspace folder if available.
 workspace_root=${LOCAL_WORKSPACE_FOLDER:-$repo_root}
 
 if [ -e /var/run/docker-host.sock ]; then
-    docker_gid=$(stat -c%g /var/run/docker-host.sock)
+    docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker-host.sock)
 else
-    docker_gid=$(stat -c%g /var/run/docker.sock)
+    docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
 fi
 
 set -x

--- a/.devcontainer/scripts/run-devcontainer.sh
+++ b/.devcontainer/scripts/run-devcontainer.sh
@@ -29,6 +29,9 @@ if [ -e /var/run/docker-host.sock ]; then
 else
     docker_gid=$(stat $STAT_FORMAT_GID_ARGS /var/run/docker.sock)
 fi
+if [[ $OSTYPE =~ darwin* ]]; then
+    docker_gid=0
+fi
 
 set -x
 mkdir -p "/tmp/$container_name/dc/shellhistory"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -19,6 +19,7 @@
         "ms-python.pylint",
         "ms-python.python",
         "ms-python.vscode-pylance",
+        "ms-vscode-remote.remote-containers",
         "ms-vsliveshare.vsliveshare",
         "njpwerner.autodocstring",
         "redhat.vscode-yaml",

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MKDIR_BUILD := $(shell test -d build || mkdir build)
 #CONDA_INFO_LEVEL ?= -q
 
 # Run make in parallel by default.
-MAKEFLAGS += -j$(shell nproc)
+MAKEFLAGS += -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu)
 #MAKEFLAGS += -Oline
 
 .PHONY: all


### PR DESCRIPTION
# Pull Request

## Title

Fixups to the devcontainer build for macOS clients.

---

## Description

- Use a more portalable random number generator
- Address some differences in docker.sock privileges.
- Address differences in `stat` arguments.
- Switch to wget mode for conda installation to workaround lack of arm64 apt repo.
- When pulling base images to prime cache, use the appropriate architecture (for Windows we only support amd64 for now).
- Remove `:latest` from `cache-from` args for `podman` compliance.
- Address some differences in `sed` syntax.

- Fixes #873 

---

## Type of Change

- 🛠️ Bug fix

---

## Testing

- local MacBook testing
- CI testing for Linux

---

## Additional Notes

Doesn't currently do builds for arm64 platform in the pipeline.
Can work towards addressing that in the future.