### PR TITLE
Add support for Python 3.13 and mark is as the expected default

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -142,8 +142,9 @@ jobs:
       timeout-minutes: 2
       run: |
         set -x
-        docker exec --user vscode --env USER=vscode mlos-devcontainer conda run -n mlos python -c \
-          'from sys import version_info as vers; assert (vers.major, vers.minor) == (3, 12), f"Unexpected python version: {vers}"'
+        docker exec --user vscode --env USER=vscode mlos-devcontainer \
+        conda run -n mlos python -c \
+          'from sys import version_info as vers; assert (vers.major, vers.minor) == (3, 13), f"Unexpected python version: {vers}"'
 
     - name: Check for missing licenseheaders
       timeout-minutes: 3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     env:
       cache_cur_date: unset
@@ -135,6 +136,14 @@ jobs:
         ls -l $CONDA_DIR/envs/$CONDA_ENV_NAME/lib/python*/site-packages/
         conda run -n $CONDA_ENV_NAME pip cache dir
         conda run -n $CONDA_ENV_NAME pip cache info
+
+    - name: Verify expected version of python in conda env
+      if: ${{ matrix.python_version == '' }}
+      timeout-minutes: 2
+      run: |
+        set -x
+        conda run -n mlos python -c \
+          'from sys import version_info as vers; assert (vers.major, vers.minor) == (3, 13), f"Unexpected python version: {vers}"'
 
     # This is moreso about code cleanliness, which is a dev thing, not a
     # functionality thing, and the rules for that change between python versions,

--- a/conda-envs/mlos-3.13.yml
+++ b/conda-envs/mlos-3.13.yml
@@ -1,0 +1,49 @@
+name: mlos-3.13
+channels:
+  # Use conda-forge to allow other packages to install with python 3.12.
+  # See Also: https://github.com/microsoft/MLOS/issues/832
+  - conda-forge
+  - defaults
+dependencies:
+  # Basic dev environment packages.
+  # All other dependencies for the mlos modules come from pip.
+  - pip
+  - pylint
+  - black
+  - pycodestyle
+  - pydocstyle
+  - flake8
+  - python-build
+  - jupyter
+  - ipykernel
+  - nb_conda_kernels
+  - matplotlib-base
+  - seaborn
+  - pandas
+  - pyarrow
+  - swig
+  # FIXME: Temporarily avoid broken libpq that's missing client headers.
+  - libpq<17.0
+  - python=3.13
+  # See comments in mlos.yml.
+  #- gcc_linux-64
+  - pip:
+    - bump2version
+    - check-jsonschema
+    - isort
+    - docformatter
+    - licenseheaders
+    - mypy
+    - pandas-stubs
+    - types-beautifulsoup4
+    - types-colorama
+    - types-jsonschema
+    - types-pygments
+    - types-requests
+    - types-setuptools
+    # Workaround a pylance issue in vscode that prevents it finding the latest
+    # method of pip installing editable modules.
+    # https://github.com/microsoft/pylance-release/issues/3473
+    - "--config-settings editable_mode=compat --editable ../mlos_core[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_bench[full-tests]"
+    - "--config-settings editable_mode=compat --editable ../mlos_viz[full-tests]"


### PR DESCRIPTION
# Pull Request

## Title

Add support for Python 3.13 and mark is as the expected default.

---

## Description

Upstream changed the default version of python, so this addresses changes in checks in the pipelines.

So far it seems to "just work (tm)"

---

## Type of Change

- 🛠️ Bug fix
- ✨ New feature
- 🧪 Tests

---

## Testing

Usual CI tests.

---