### PR TITLE
Fixup broken markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ To do this this repo provides two Python modules, which can be used independentl
   It is intended to provide a simple, easy to consume (e.g. via `pip`), with low dependencies abstraction to
 
   - describe a space of context, parameters, their ranges, constraints, etc. and result objectives
-  - an "optimizer" service [abstraction](https://microsoft.github.io/MLOS/overview.html#mlos-core-api) (e.g. [`register()`](https://microsoft.github.io/MLOS/generated/mlos_core.optimizers.optimizer.BaseOptimizer.html#mlos_core.optimizers.optimizer.BaseOptimizer.register) and [`suggest()`](https://microsoft.github.io/MLOS/generated/mlos_core.optimizers.optimizer.BaseOptimizer.html#mlos_core.optimizers.optimizer.BaseOptimizer.suggest)) so we can easily swap out different implementations methods of searching (e.g. random, BO, LLM, etc.)
-  - provide some helpers for [automating optimization experiment](https://microsoft.github.io/MLOS/overview.html#mlos-bench-api) runner loops and data collection
+  - an "optimizer" service [abstraction](https://microsoft.github.io/MLOS/source_tree_docs/index.html) (e.g. [`register()`](https://microsoft.github.io/MLOS/autoapi/mlos_bench/optimizers/base_optimizer/index.html#mlos_bench.optimizers.base_optimizer.Optimizer.register) and [`suggest()`](https://microsoft.github.io/MLOS/autoapi/mlos_bench/optimizers/base_optimizer/index.html#mlos_bench.optimizers.base_optimizer.Optimizer.suggest)) so we can easily swap out different implementations methods of searching (e.g. random, BO, LLM, etc.)
+  - provide some helpers for [automating optimization experiment](https://microsoft.github.io/MLOS/source_tree_docs/mlos_bench/index.html) runner loops and data collection
 
 For these design requirements we intend to reuse as much from existing OSS libraries as possible and layer policies and optimizations specifically geared towards autotuning systems over top.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,7 +6,7 @@ MLOS Documentation
 .. image:: badges/coverage.svg
    :target: htmlcov/index.html
 
-`MLOS <source_tree_docs/index.html>`_ is a project to enable autotuning for systems via `automated benchmarking <source_tree_docs/mlos_bench/index.html>`_ including managing the storage and `visualization <source_tree_docs/mlos_viz/index.html>`_ of the results.
+`MLOS <source_tree_docs/index.html>`_ is a project to enable `autotuning </autoapi/mlos_core/index.html>` with `mlos_core </autoapi/mlos_core/index.html>`_ for systems via `automated benchmarking </autoapi/mlos_bench/index.html>`_ with `mlos_bench </autoapi/mlos_bench/index.html>`_ including managing the storage and `visualization </autoapi/mlos_viz/index.html>`_ of the results via `mlos_viz </autoapi/mlos_viz/index.html>`_.
 
 See below for additional documentation sections.
 
@@ -14,7 +14,7 @@ Here is some documentation pulled from the markdown files in the `MLOS source tr
 
 .. toctree::
    :caption: Source Tree Documentation
-   :maxdepth: 5
+   :maxdepth: 4
 
    source_tree_docs/index
    source_tree_docs/mlos_core/index
@@ -26,7 +26,7 @@ Here is some documentation pulled from the Python docstrings in the `MLOS source
 .. toctree::
    :caption: API Reference
    :titlesonly:
-   :maxdepth: 5
+   :maxdepth: 4
 
    autoapi/mlos_core/index
    autoapi/mlos_bench/index


### PR DESCRIPTION
# Pull Request

## Title

Fixup broken markdown links after #869 

---

## Description

After #869 was merged the published documentation links changed which meant that future Markdown lint checks failed.

This PR fixes that. 

---

## Type of Change

- 🛠️ Bug fix
- 📝 Documentation update

---