### PR TITLE
Allow loading configs from JSON strings and test with new docstrings for tunables

### DIFF
--- a/mlos_bench/mlos_bench/config/__init__.py
+++ b/mlos_bench/mlos_bench/config/__init__.py
@@ -276,6 +276,9 @@ There are two forms of tunable configs:
   :py:class:`~mlos_bench.optimizers.manual_optimizer.ManualOptimizer` to run a
   benchmark with a particular config or set of configs.
 
+For more information on tunable configs, see the :py:mod:`mlos_bench.tunables`
+module.
+
 Class Configs
 ^^^^^^^^^^^^^
 

--- a/mlos_bench/mlos_bench/config/__init__.py
+++ b/mlos_bench/mlos_bench/config/__init__.py
@@ -61,7 +61,7 @@ Additional details about the organization of the files and directories are as fo
 - ``environments/``:
     Contains the configs for :py:mod:`~mlos_bench.environments`, and their
     associated scripts (if relevant, e.g., for
-    `:py:class:`~mlos_bench.environments.remote_env.RemoteEnv` or
+    :py:class:`~mlos_bench.environments.remote_env.RemoteEnv` or
     :py:class:`~mlos_bench.environments.script_env.ScriptEnv`) and
     :py:mod:`~mlos_bench.tunables`.
 
@@ -253,9 +253,9 @@ There are two forms of tunable configs:
          ],
        }
 
-  Since TunableParams are associated with Environments, they are typically kept
-  in the same directory as that environment and named something like
-  ``env-tunables.json``.
+  Since TunableParams are associated with an :py:mod:`~mlos_bench.environments`,
+  they are typically kept in the same directory as that Environment's config and
+  named something like ``env-tunables.json``.
 
 - "TunableValues" style configs which are used to specify the values for an
   instantiation of a set of tunables params.

--- a/mlos_bench/mlos_bench/config/__init__.py
+++ b/mlos_bench/mlos_bench/config/__init__.py
@@ -61,7 +61,7 @@ Additional details about the organization of the files and directories are as fo
 - ``environments/``:
     Contains the configs for :py:mod:`~mlos_bench.environments`, and their
     associated scripts (if relevant, e.g., for
-    :py:class:`~mlos_bench.environments.remote_env.RemoteEnv` or
+    :py:class:`~mlos_bench.environments.remote.remote_env.RemoteEnv` or
     :py:class:`~mlos_bench.environments.script_env.ScriptEnv`) and
     :py:mod:`~mlos_bench.tunables`.
 

--- a/mlos_bench/mlos_bench/environments/__init__.py
+++ b/mlos_bench/mlos_bench/environments/__init__.py
@@ -116,9 +116,11 @@ Notes
 
 See Also
 --------
-:py:mod:`mlos_bench.config`
-:py:mod:`mlos_bench.services`
-:py:mod:`mlos_bench.tunables`
+:py:mod:`mlos_bench.config` : Overview of the configuration system.
+:py:mod:`mlos_bench.services` : Overview of the Services available to the
+    Environments and their configurations.
+:py:mod:`mlos_bench.tunables` : Overview of the Tunables available to the
+    Environments and their configurations.
 """
 
 from mlos_bench.environments.base_environment import Environment

--- a/mlos_bench/mlos_bench/environments/__init__.py
+++ b/mlos_bench/mlos_bench/environments/__init__.py
@@ -113,6 +113,12 @@ Notes
 - See `mlos_bench/config/environments/README.md
   <https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/config/environments/>`_
   for additional config examples in the source tree.
+
+See Also
+--------
+:py:mod:`mlos_bench.config`
+:py:mod:`mlos_bench.services`
+:py:mod:`mlos_bench.tunables`
 """
 
 from mlos_bench.environments.base_environment import Environment

--- a/mlos_bench/mlos_bench/environments/base_environment.py
+++ b/mlos_bench/mlos_bench/environments/base_environment.py
@@ -149,6 +149,7 @@ class Environment(metaclass=abc.ABCMeta):
             )
             tunables = TunableGroups()
 
+        # TODO: add user docstrings for these in the module
         groups = self._expand_groups(
             config.get("tunable_params", []),
             (global_config or {}).get("tunable_params_map", {}),

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -187,7 +187,11 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
             # If the path contains braces, it is likely already a json string,
             # so just parse it.
             _LOG.info("Load config from json string: %s", json)
-            config: Any = json5.loads(json)
+            try:
+                config: Any = json5.loads(json)
+            except ValueError as ex:
+                _LOG.error("Failed to parse config from JSON string: %s", json)
+                raise ValueError(f"Failed to parse config from JSON string: {json}") from ex
         else:
             json = self.resolve_path(json)
             _LOG.info("Load config file: %s", json)

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -58,8 +58,9 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
     """
 
     BUILTIN_CONFIG_PATH = str(files("mlos_bench.config").joinpath("")).replace("\\", "/")
-    """A calculated path to the built-in configuration files shipped with the
-    mlos_bench package."""
+    """A calculated path to the built-in configuration files shipped with the mlos_bench
+    package.
+    """
 
     def __init__(
         self,

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -707,6 +707,8 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
             The larger collection of tunable parameters.
         """
         _LOG.info("Load tunables: '%s'", jsons)
+        if parent is None:
+            parent = TunableGroups()
         tunables = parent.copy()
         for json in jsons:
             config = self.load_config(json, ConfigSchema.TUNABLE_PARAMS)

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -182,6 +182,7 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         config : Union[dict, List[dict]]
             Free-format dictionary that contains the configuration.
         """
+        assert isinstance(json, str)
         if any(c in json for c in ("{", "[")):
             # If the path contains braces, it is likely already a json string,
             # so just parse it.

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -2,9 +2,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-"""Helper functions to load, instantiate, and serialize Python objects that
-encapsulate a benchmark :py:class:`.Environment`, :py:mod:`~mlos_bench.tunables`,
-:py:class:`.Service` functions, etc. from JSON configuration files and strings.
+"""
+Helper functions to load, instantiate, and serialize Python objects that encapsulate a
+benchmark :py:class:`.Environment`, :py:mod:`~mlos_bench.tunables`, :py:class:`.Service`
+functions, etc.
+
+from JSON configuration files and strings.
 """
 
 import logging
@@ -127,8 +130,8 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
 
     def resolve_path(self, file_path: str, extra_paths: Optional[Iterable[str]] = None) -> str:
         """
-        Resolves and prepends the suitable :py:attr:`.config_paths` to ``file_path``
-        if the latter is not absolute. If :py:attr:`.config_paths` is ``None`` or
+        Resolves and prepends the suitable :py:attr:`.config_paths` to ``file_path`` if
+        the latter is not absolute. If :py:attr:`.config_paths` is ``None`` or
         ``file_path`` is absolute, return ``file_path`` as is.
 
         Parameters
@@ -163,10 +166,10 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         schema_type: Optional[ConfigSchema],
     ) -> Dict[str, Any]:
         """
-        Load JSON config file or JSON string.
-        Search for a file relative to :py:attr:`.config_paths` if the input path is
-        not absolute. This method is exported to be used as a
-        :py:class:`.SupportsConfigLoading` type :py:class:`.Service`.
+        Load JSON config file or JSON string. Search for a file relative to
+        :py:attr:`.config_paths` if the input path is not absolute. This method is
+        exported to be used as a :py:class:`.SupportsConfigLoading` type
+        :py:class:`.Service`.
 
         Parameters
         ----------
@@ -652,8 +655,8 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
         parent: Optional[Service] = None,
     ) -> Service:
         """
-        Read the configuration files or JSON strings and bundle all Service methods
-        from those configs into a single Service object.
+        Read the configuration files or JSON strings and bundle all Service methods from
+        those configs into a single Service object.
 
         Notes
         -----

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -58,6 +58,8 @@ class ConfigPersistenceService(Service, SupportsConfigLoading):
     """
 
     BUILTIN_CONFIG_PATH = str(files("mlos_bench.config").joinpath("")).replace("\\", "/")
+    """A calculated path to the built-in configuration files shipped with the
+    mlos_bench package."""
 
     def __init__(
         self,

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -2,10 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-"""
-Helper functions to load, instantiate, and serialize Python objects that encapsulate a
-benchmark :py:class:`.Environment`, :py:mod:`~mlos_bench.tunables`, :py:class:`.Service`
-functions, etc. from JSON configuration files and strings.
+"""Helper functions to load, instantiate, and serialize Python objects that encapsulate
+a benchmark :py:class:`.Environment`, :py:mod:`~mlos_bench.tunables`,
+:py:class:`.Service` functions, etc from JSON configuration files and strings.
 """
 
 import logging

--- a/mlos_bench/mlos_bench/services/config_persistence.py
+++ b/mlos_bench/mlos_bench/services/config_persistence.py
@@ -5,9 +5,7 @@
 """
 Helper functions to load, instantiate, and serialize Python objects that encapsulate a
 benchmark :py:class:`.Environment`, :py:mod:`~mlos_bench.tunables`, :py:class:`.Service`
-functions, etc.
-
-from JSON configuration files and strings.
+functions, etc. from JSON configuration files and strings.
 """
 
 import logging

--- a/mlos_bench/mlos_bench/services/types/config_loader_type.py
+++ b/mlos_bench/mlos_bench/services/types/config_loader_type.py
@@ -50,7 +50,7 @@ class SupportsConfigLoading(Protocol):
 
     def load_config(
         self,
-        json_file_name: str,
+        json: str,
         schema_type: Optional[ConfigSchema],
     ) -> Union[dict, List[dict]]:
         """
@@ -59,8 +59,8 @@ class SupportsConfigLoading(Protocol):
 
         Parameters
         ----------
-        json_file_name : str
-            Path to the input config file.
+        json : str
+            Path to the input config file or a JSON string.
         schema_type : Optional[ConfigSchema]
             The schema type to validate the config against.
 
@@ -109,7 +109,7 @@ class SupportsConfigLoading(Protocol):
 
     def load_environment_list(
         self,
-        json_file_name: str,
+        json: str,
         tunables: "TunableGroups",
         global_config: Optional[dict] = None,
         parent_args: Optional[Dict[str, TunableValue]] = None,
@@ -121,8 +121,8 @@ class SupportsConfigLoading(Protocol):
 
         Parameters
         ----------
-        json_file_name : str
-            The environment JSON configuration file.
+        json : str
+            The environment JSON configuration file or a JSON string.
             Can contain either one environment or a list of environments.
         tunables : TunableGroups
             A (possibly empty) collection of tunables to add to the environment.
@@ -142,7 +142,7 @@ class SupportsConfigLoading(Protocol):
 
     def load_services(
         self,
-        json_file_names: Iterable[str],
+        jsons: Iterable[str],
         global_config: Optional[Dict[str, Any]] = None,
         parent: Optional["Service"] = None,
     ) -> "Service":
@@ -152,8 +152,8 @@ class SupportsConfigLoading(Protocol):
 
         Parameters
         ----------
-        json_file_names : list of str
-            A list of service JSON configuration files.
+        jsons : list of str
+            A list of service JSON configuration files or JSON strings.
         global_config : dict
             Global parameters to add to the service config.
         parent : Service

--- a/mlos_bench/mlos_bench/storage/__init__.py
+++ b/mlos_bench/mlos_bench/storage/__init__.py
@@ -88,10 +88,26 @@ sqlite::memory:
 >>> # Create a new experiment with a single trial.
 >>> # (Normally, we'd use a real environment config, but for this example we'll use a string.)
 >>> #
->>> from mlos_bench.tunables.tunable_groups import TunableGroups
+>>> # Create a dummy tunable group.
+>>> from mlos_bench.services.config_persistence import ConfigPersistenceService
+>>> config_persistence_service = ConfigPersistenceService()
+>>> tunables_config = '''
+... {
+...   "param_group": {
+...     "cost": 1,
+...     "params": {
+...       "param1": {
+...         "type": "int",
+...         "range": [0, 100],
+...         "default": 50
+...       }
+...     }
+...   }
+... }
+... '''
+>>> tunables = config_persistence_service.load_tunables([tunables_config])
 >>> from mlos_bench.environments.status import Status
 >>> from datetime import datetime
->>> tunables = TunableGroups()
 >>> with storage.experiment(
 ...   experiment_id="my_experiment_id",
 ...   trial_id=1,
@@ -122,12 +138,12 @@ sqlite::memory:
 {'objective_metric': 42}
 >>> # Retrieve the results of all Trials in the Experiment as a DataFrame.
 >>> experiment_data.results_df.columns.tolist()
-['trial_id', 'ts_start', 'ts_end', 'tunable_config_id', 'tunable_config_trial_group_id', 'status', 'result.objective_metric']
+['trial_id', 'ts_start', 'ts_end', 'tunable_config_id', 'tunable_config_trial_group_id', 'status', 'config.param1', 'result.objective_metric']
 >>> experiment_data.results_df.drop(columns=["ts_start"])
    trial_id  ... result.objective_metric
 0         1  ...                      42
 <BLANKLINE>
-[1 rows x 6 columns]
+[1 rows x 7 columns]
 
 See Also
 --------

--- a/mlos_bench/mlos_bench/storage/__init__.py
+++ b/mlos_bench/mlos_bench/storage/__init__.py
@@ -40,7 +40,94 @@ config.
 
 Example
 -------
-TODO: Add example usage.
+
+Here's a very basic example of the Storage APIs.
+
+>>> # Create a new storage object from a JSON config.
+>>> # Normally, we'd load these from a file, but for this example we'll use a string.
+>>> global_config = '''
+... {
+...     // Additional global configuration parameters can be added here.
+...     /* For instance:
+...     "storage_host": "some-remote-host",
+...     "storage_user": "mlos_bench",
+...     "storage_pass": "SuperSecretPassword",
+...     */
+... }
+... '''
+>>> storage_config = '''
+... {
+...     "class": "mlos_bench.storage.sql.storage.SqlStorage",
+...     "config": {
+...         // Don't create the schema until we actually need it.
+...         // (helps speed up initial launch and tests)
+...         "lazy_schema_create": true,
+...         // Parameters below must match kwargs of `sqlalchemy.URL.create()`:
+...         // Normally, we'd specify a real database, but for testing examples
+...         // we'll use an in-memory one.
+...         "drivername": "sqlite",
+...         "database": ":memory:"
+...         // Otherwise we might use something like the following
+...         // to pull the values from the globals:
+...         /*
+...         "host": "$storage_host",
+...         "username": "$storage_user",
+...         "password": "$storage_pass",
+...         */
+...     }
+... }
+... '''
+>>> from mlos_bench.storage import from_config
+>>> storage = from_config(storage_config, global_configs=[global_config])
+>>> storage
+sqlite::memory:
+>>> #
+>>> # Internally, mlos_bench will use this config and storage backend to track
+>>> # Experiments and Trials it creates.
+>>> # Most users won't need to do that, but it works something like the following:
+>>> # Create a new experiment with a single trial.
+>>> # (Normally, we'd use a real environment config, but for this example we'll use a string.)
+>>> #
+>>> from mlos_bench.tunables.tunable_groups import TunableGroups
+>>> from mlos_bench.environments.status import Status
+>>> from datetime import datetime
+>>> tunables = TunableGroups()
+>>> with storage.experiment(
+...   experiment_id="my_experiment_id",
+...   trial_id=1,
+...   root_env_config="root_env_config_info",
+...   description="some description",
+...   tunables=tunables,
+...   opt_targets={"objective_metric": "min"},
+... ) as experiment:
+...     # Create a dummy trial.
+...     trial = experiment.new_trial(tunables=tunables)
+...     # Pretend something ran with that trial and we have the results now.
+...     _ = trial.update(Status.SUCCEEDED, datetime.now(), {"objective_metric": 42})
+>>> #
+>>> # Now, once there's data to look at, in a Jupyter notebook or similar,
+>>> # we can also use the storage object to view the results.
+>>> #
+>>> storage.experiments
+{'my_experiment_id': Experiment :: my_experiment_id: 'some description'}
+>>> # Access ExperimentData by experiment id.
+>>> experiment_data = storage.experiments["my_experiment_id"]
+>>> experiment_data.trials
+{1: Trial :: my_experiment_id:1 cid:1 SUCCEEDED}
+>>> # Access TrialData for an Experiment by trial id.
+>>> trial_data = experiment_data.trials[1]
+>>> assert trial_data.status == Status.SUCCEEDED
+>>> # Retrieve the results from the TrialData as a dictionary.
+>>> trial_data.results_dict
+{'objective_metric': 42}
+>>> # Retrieve the results of all Trials in the Experiment as a DataFrame.
+>>> experiment_data.results_df.columns.tolist()
+['trial_id', 'ts_start', 'ts_end', 'tunable_config_id', 'tunable_config_trial_group_id', 'status', 'result.objective_metric']
+>>> experiment_data.results_df.drop(columns=["ts_start"])
+   trial_id  ... result.objective_metric
+0         1  ...                      42
+<BLANKLINE>
+[1 rows x 6 columns]
 
 See Also
 --------
@@ -53,7 +140,7 @@ Notes
 - See `sqlite-autotuning notebooks
   <https://github.com/Microsoft-CISL/sqlite-autotuning/blob/main/mlos_demo_sqlite_teachers.ipynb>`_
   for additional examples.
-"""
+"""  # pylint: disable=line-too-long # noqa: E501
 
 from mlos_bench.storage.base_storage import Storage
 from mlos_bench.storage.storage_factory import from_config

--- a/mlos_bench/mlos_bench/storage/__init__.py
+++ b/mlos_bench/mlos_bench/storage/__init__.py
@@ -133,6 +133,10 @@ sqlite::memory:
 >>> # Access TrialData for an Experiment by trial id.
 >>> trial_data = experiment_data.trials[1]
 >>> assert trial_data.status == Status.SUCCEEDED
+>>> # Retrieve the tunable configuration from the TrialData as a dictionary.
+>>> trial_config_data = trial_data.tunable_config
+>>> trial_config_data.config_dict
+{'param1': 50}
 >>> # Retrieve the results from the TrialData as a dictionary.
 >>> trial_data.results_dict
 {'objective_metric': 42}

--- a/mlos_bench/mlos_bench/storage/base_experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/base_experiment_data.py
@@ -13,8 +13,6 @@ multiple trials may use the same config (e.g., for repeat run variability analys
 
 See Also
 --------
-See Also
---------
 mlos_bench.storage :
     The base storage module for mlos_bench, which includes some basic examples
     in the documentation.

--- a/mlos_bench/mlos_bench/storage/base_experiment_data.py
+++ b/mlos_bench/mlos_bench/storage/base_experiment_data.py
@@ -13,6 +13,11 @@ multiple trials may use the same config (e.g., for repeat run variability analys
 
 See Also
 --------
+See Also
+--------
+mlos_bench.storage :
+    The base storage module for mlos_bench, which includes some basic examples
+    in the documentation.
 ExperimentData.results_df :
     Retrieves a pandas DataFrame of the Experiment's trials' results data.
 ExperimentData.trials :

--- a/mlos_bench/mlos_bench/storage/base_trial_data.py
+++ b/mlos_bench/mlos_bench/storage/base_trial_data.py
@@ -7,6 +7,11 @@ Base interface for accessing the stored benchmark trial data.
 
 A single trial is a single run of an experiment with a given configuration (e.g., set of
 tunable parameters).
+
+See Also
+--------
+:py:mod:`mlos_bench.storage` : The base storage module for mlos_bench, which
+    includes some basic examples in the documentation.
 """
 from abc import ABCMeta, abstractmethod
 from datetime import datetime

--- a/mlos_bench/mlos_bench/storage/base_tunable_config_data.py
+++ b/mlos_bench/mlos_bench/storage/base_tunable_config_data.py
@@ -7,6 +7,11 @@ Base interface for accessing the stored benchmark (tunable) config data.
 
 Note: a configuration in this context is the set of tunable parameter values and can
 be used by one or more trials.
+
+See Also
+--------
+:py:mod:`mlos_bench.storage` : The base storage module for mlos_bench, which
+    includes some basic examples in the documentation.
 """
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, Optional

--- a/mlos_bench/mlos_bench/storage/base_tunable_config_trial_group_data.py
+++ b/mlos_bench/mlos_bench/storage/base_tunable_config_trial_group_data.py
@@ -7,6 +7,11 @@ Base interface for accessing the stored benchmark config trial group data.
 
 Since a single config may be used by multiple trials, we can group them together for
 easier analysis.
+
+See Also
+--------
+:py:mod:`mlos_bench.storage` : The base storage module for mlos_bench, which
+    includes some basic examples in the documentation.
 """
 
 from abc import ABCMeta, abstractmethod

--- a/mlos_bench/mlos_bench/storage/sql/__init__.py
+++ b/mlos_bench/mlos_bench/storage/sql/__init__.py
@@ -16,15 +16,16 @@ are expected to interact with the data using the
 obtained from the initial :py:class:`.SqlStorage` instance obtained by
 :py:func:`mlos_bench.storage.storage_factory.from_config`.
 
-Examples
---------
-TODO: Add example usage.
-
 Notes
 -----
 See the `mlos_bench/config/storage
 <https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/config/storage>`_
 tree for some configuration examples.
+
+See Also
+--------
+:py:mod:`mlos_bench.storage` : The base storage module for mlos_bench, which
+    includes some basic examples in the documentation.
 """
 from mlos_bench.storage.sql.storage import SqlStorage
 

--- a/mlos_bench/mlos_bench/storage/storage_factory.py
+++ b/mlos_bench/mlos_bench/storage/storage_factory.py
@@ -20,7 +20,7 @@ from mlos_bench.storage.base_storage import Storage
 
 
 def from_config(
-    config_file: str,
+    config: str,
     global_configs: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> Storage:
@@ -29,8 +29,8 @@ def from_config(
 
     Parameters
     ----------
-    config_file : str
-        JSON5 config file to load.
+    config : str
+        JSON5 config file or string to load.
     global_configs : Optional[List[str]]
         An optional list of config files with global parameters.
     kwargs : dict
@@ -45,13 +45,13 @@ def from_config(
     config_loader = ConfigPersistenceService({"config_path": config_path})
     global_config = {}
     for fname in global_configs or []:
-        config = config_loader.load_config(fname, ConfigSchema.GLOBALS)
-        global_config.update(config)
-        config_path += config.get("config_path", [])
+        gconfig = config_loader.load_config(fname, ConfigSchema.GLOBALS)
+        global_config.update(gconfig)
+        config_path += gconfig.get("config_path", [])
         config_loader = ConfigPersistenceService({"config_path": config_path})
     global_config.update(kwargs)
 
-    class_config = config_loader.load_config(config_file, ConfigSchema.STORAGE)
+    class_config = config_loader.load_config(config, ConfigSchema.STORAGE)
     assert isinstance(class_config, Dict)
 
     ret = config_loader.build_storage(

--- a/mlos_bench/mlos_bench/tests/config/cli/test_load_cli_config_examples.py
+++ b/mlos_bench/mlos_bench/tests/config/cli/test_load_cli_config_examples.py
@@ -119,6 +119,7 @@ def test_load_cli_config_examples_via_launcher(
     # To do this we need to make sure to give it a few extra paths and globals
     # to look for for our examples.
     cli_args = (
+        # pylint: disable=inconsistent-quotes
         f"--config {config_path}"
         f" --config-path {files('mlos_bench.config')} "
         f" --config-path {files('mlos_bench.tests.config')}"

--- a/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
+++ b/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
@@ -7,7 +7,6 @@
 import os
 import sys
 
-import json5
 import pytest
 
 from mlos_bench.config.schemas import ConfigSchema

--- a/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
+++ b/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
@@ -105,6 +105,18 @@ def test_load_config(config_persistence_service: ConfigPersistenceService) -> No
     assert len(tunables_data) >= 1
 
 
+def test_load_bad_config_path(config_persistence_service: ConfigPersistenceService) -> None:
+    """Check if we can successfully load a config file located relative to
+    `config_path`.
+    """
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _ = config_persistence_service.load_config(
+            "DNE/tunable-values/tunable-values-example.jsonc-DNE-}]",
+            ConfigSchema.TUNABLE_VALUES,
+        )
+    assert "No such file or directory" in str(exc_info.value)
+
+
 def test_load_config_string(config_persistence_service: ConfigPersistenceService) -> None:
     """Check if we can load a valid json string as well."""
     json_str = """
@@ -117,3 +129,16 @@ def test_load_config_string(config_persistence_service: ConfigPersistenceService
     assert tunables_data is not None
     assert isinstance(tunables_data, dict)
     assert len(tunables_data) >= 1
+
+
+def test_load_bad_config_string(config_persistence_service: ConfigPersistenceService) -> None:
+    """Check how we handle loading a bad config string."""
+    json_str = """
+    {
+        "tunable_param_1": "value_1",
+        "tunable_param_2": "value_2",
+    //} // Missing closing brace
+    """
+    with pytest.raises(ValueError) as exc_info:
+        _ = config_persistence_service.load_config(json_str, ConfigSchema.TUNABLE_VALUES)
+    assert "Failed to parse config from JSON string" in str(exc_info.value)

--- a/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
+++ b/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
@@ -107,7 +107,7 @@ def test_load_config(config_persistence_service: ConfigPersistenceService) -> No
 
 
 def test_load_config_string(config_persistence_service: ConfigPersistenceService) -> None:
-    """Check if we can load a valid json string as well"""
+    """Check if we can load a valid json string as well."""
     json_str = """
     {
         "tunable_param_1": "value_1",

--- a/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
+++ b/mlos_bench/mlos_bench/tests/services/config_persistence_test.py
@@ -7,6 +7,7 @@
 import os
 import sys
 
+import json5
 import pytest
 
 from mlos_bench.config.schemas import ConfigSchema
@@ -100,6 +101,20 @@ def test_load_config(config_persistence_service: ConfigPersistenceService) -> No
         "tunable-values/tunable-values-example.jsonc",
         ConfigSchema.TUNABLE_VALUES,
     )
+    assert tunables_data is not None
+    assert isinstance(tunables_data, dict)
+    assert len(tunables_data) >= 1
+
+
+def test_load_config_string(config_persistence_service: ConfigPersistenceService) -> None:
+    """Check if we can load a valid json string as well"""
+    json_str = """
+    {
+        "tunable_param_1": "value_1",
+        "tunable_param_2": "value_2",
+    }
+    """
+    tunables_data = config_persistence_service.load_config(json_str, ConfigSchema.TUNABLE_VALUES)
     assert tunables_data is not None
     assert isinstance(tunables_data, dict)
     assert len(tunables_data) >= 1

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -198,6 +198,8 @@ Notes
 Internally, :py:class:`.TunableGroups` are converted to
 :external:py:class:`ConfigSpace.ConfigurationSpace` objects for use with
 :py:mod:`mlos_core`.
+See the "Spaces" section in the :py:mod:`mlos_core` module documentation for more
+information.
 
 See Also
 --------
@@ -205,6 +207,7 @@ See Also
 :py:mod:`mlos_bench.environments` : Overview of Environments and their configurations.
 :py:mod:`mlos_core.optimizers` : Overview of mlos_core optimizers.
 :py:mod:`mlos_core.spaces` : Overview of the mlos_core configuration space system.
+:py:meth:`.TunableGroups.assign` : Notes on special cases for assigning tunable values.
 """
 
 from mlos_bench.tunables.tunable import Tunable, TunableValue

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -2,7 +2,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-"""Tunables classes for Environments in mlos_bench."""
+"""Tunables classes for Environments in mlos_bench.
+
+TODO: Add more documentation and examples here.
+
+
+Examples
+--------
+>>> from mlos_bench.tunables import TunableGroups
+>>> from mlos_bench.services.config_persistence import ConfigPersistenceService
+>>> service = ConfigPersistenceService()
+>>> tunables = service.load_tunables(jsons=['{"tunable_group_name": {"cost": 1, "params": {"param1": {"type": "categorical", "values": ["red", "blue", "green"], "default": "green"}}}}'], parent=TunableGroups())
+>>> tunables
+{ tunable_group_name::param1[categorical](['red', 'blue', 'green']:green)=green }
+"""
 
 from mlos_bench.tunables.tunable import Tunable, TunableValue
 from mlos_bench.tunables.tunable_groups import TunableGroups

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-"""Tunables classes for Environments in mlos_bench.
+"""
+Tunables classes for Environments in mlos_bench.
 
 .. contents:: Table of Contents
    :depth: 3

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -201,10 +201,10 @@ Internally, :py:class:`.TunableGroups` are converted to
 
 See Also
 --------
-:py:mod:`mlos_bench.config`
-:py:mod:`mlos_bench.environments`
-:py:mod:`mlos_core.optimizers`
-:py:mod:`mlos_core.spaces`
+:py:mod:`mlos_bench.config` : Overview of the configuration system.
+:py:mod:`mlos_bench.environments` : Overview of Environments and their configurations.
+:py:mod:`mlos_core.optimizers` : Overview of mlos_core optimizers.
+:py:mod:`mlos_core.spaces` : Overview of the mlos_core configuration space system.
 """
 
 from mlos_bench.tunables.tunable import Tunable, TunableValue

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -4,17 +4,206 @@
 #
 """Tunables classes for Environments in mlos_bench.
 
-TODO: Add more documentation and examples here.
+.. contents:: Table of Contents
+   :depth: 3
 
+Overview
+^^^^^^^^
+
+mlos_bench uses the concept of "tunables" to define the configuration space for an
+:py:class:`~mlos_bench.environments.base_environment.Environment`.
+
+An :py:class:`~mlos_bench.optimizers.base_optimizer.Optimizer` can then use these
+tunables to explore the configuration space in order to improve some target
+objective metrics (e.g., reduce tail latency, reduce cost, improve throughput,
+etc.).
+
+They are similar to the concept of "hyperparameters" in machine learning, but are
+used to configure the system being tested.
+
+Classes
+^^^^^^^
+
+Tunable
++++++++
+
+The :py:class:`~mlos_bench.tunables.tunable.Tunable` class is used to define a
+single tunable parameter.
+A ``Tunable`` can be a ``categorical`` or numeric (``int`` or ``float``) and always has
+at least a domain (``range`` or set of ``values``) and default.
+Each type can also have a number of additional properties that can optionally be set
+to help control the sampling of the tunable.
+
+For instance:
+
+- Numeric tunables can have a ``distribution`` property to specify the sampling
+  distribution.  ``log`` sampling can also be enabled for numeric tunables.
+- Categorical tunables can have a ``values_weights`` property to specify biased
+  sampling of the values
+- ``special`` values can be marked to indicate that they need more explicit testing
+  This can be useful for values that indicate "automatic" or "disabled" behavior.
+
+The full set of supported properties can be found in the `JSON schema for tunable
+parameters
+<https://github.com/microsoft/MLOS/blob/main/mlos_bench/mlos_bench/config/schemas/tunables/tunable-params-schema.json>`_
+and seen in some of the `test examples in the source tree
+<https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/tests/config/schemas/tunable-params/test-cases/good/>`_.
+
+CovariantGroup
+++++++++++++++
+
+The :py:class:`~mlos_bench.tunables.covariant_group.CovariantTunableGroup` class is
+used to define a group of related tunable parameters that are all configured
+together with the same ``cost`` (e.g., is a more expensive operation required to
+reconfigure the system like redeployed vs. restarted vs. reloaded).
+Optimizers can use this information to explore the configuration space more efficiently.
+
+TunableGroups
++++++++++++++
+
+The :py:class:`~mlos_bench.tunables.tunable_groups.TunableGroups` class is used to
+define an entire set of tunable paratmers (e.g., combined set of covariant groups).
+
+Usage
+^^^^^
+
+Most user interactions with tunables will be through JSON configuration files.
+
+Since tunables are associated with an Environment, their configs are typically
+colocated with the environment configs (e.g., ``env-name-tunables.jsonc``) and
+loaded with the Environment using the ``include_tunables`` property in the
+Environment config.
+
+Then individual covariant groups can be enabled via the ``tunable_params` and
+``tunable_params_map`` properties, possibly via ``globals`` variable expansion.
+
+See the :py:mod:`mlos_bench.config` and :py:mod:`mlos_bench.environments` module
+documentation for more information.
+
+In benchmarking-only mode (e.g., without an ``Optimizer`` specified), ``mlos_bench``
+can still run with a particular set of ``--tunable-values`` (e.g., a simple
+key-value file declaring a set of values to assign to the set of configured tunable
+parameters) in order to manually explore a configuration space.
+
+See the :py:mod:`mlos_bench.run` module documentation for more information.
+
+During an Environment's ``setup`` and ``run`` phases the tunables can be exported to
+a JSON file using the ``dump_params_file`` property of the Environment config for
+the user scripts to use when configuring the target system.
+The ``meta`` property of the tunable config can be used to add additional
+information for this step (e.g., a unit suffix to append to the value).
+
+See the :py:mod:`mlos_bench.environments` module documentation for more information.
 
 Examples
 --------
->>> from mlos_bench.tunables import TunableGroups
+Here's a short (incomplete) example of some of the TunableGroups JSON configuration
+options, expressed in Python (for testing purposes).
+However, most of the time you will be loading these from a JSON config file stored
+along with the associated Environment config.
+
+For more tunable parameters examples refer to the `JSON schema
+<https://github.com/microsoft/MLOS/blob/main/mlos_bench/mlos_bench/config/schemas/tunables/tunable-params-schema.json>`_
+or some of the `test examples in the source tree
+<https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/tests/config/schemas/tunable-params/test-cases/good/>`_.
+
+There are also examples of `tunable values in the source tree
+<https://github.com/microsoft/MLOS/tree/main/mlos_bench/mlos_bench/tests/config/schemas/tunable-values/test-cases/good/>`_.
+
+>>> # Load tunables from JSON string.
+>>> import json5
 >>> from mlos_bench.services.config_persistence import ConfigPersistenceService
 >>> service = ConfigPersistenceService()
->>> tunables = service.load_tunables(jsons=['{"tunable_group_name": {"cost": 1, "params": {"param1": {"type": "categorical", "values": ["red", "blue", "green"], "default": "green"}}}}'], parent=TunableGroups())
->>> tunables
-{ tunable_group_name::param1[categorical](['red', 'blue', 'green']:green)=green }
+>>> json_config = '''
+... {
+...   "group_1": {
+...     "cost": 1,
+...     "params": {
+...       "colors": {
+...         "type": "categorical",
+...         // Values for the categorical tunable.
+...         "values": ["red", "blue", "green"],
+...         // Weights for each value in the categorical distribution.
+...         "values_weights": [0.1, 0.2, 0.7],
+...         // Default value.
+...         "default": "green",
+...       },
+...       "int_param": {
+...         "type": "int",
+...         "range": [-1, 10],
+...         "default": 5,
+...         // Mark some values as "special", that need more explicit testing.
+...         // e.g., maybe these indicate "automatic" or "disabled" behavior for
+...         // the system being tested instead of an explicit size
+...         "special": [-1, 0],
+...         // Optionally specify a sampling distribution.
+...         "distribution": {
+...             "type": "uniform" // alternatively, "beta" or "normal"
+...         },
+...         // Free form key-value pairs that can be used with the
+...         // tunable upon sampling for composing configs.
+...         "meta": {
+...           "suffix": "MB"
+...         }
+...       },
+...       "float_param": {
+...         "type": "float",
+...         "range": [1, 10000],
+...         "default": 1,
+...         // Quantize the range into 100 bins
+...         "quantization_bins": 100,
+...         // enable log sampling of the bins
+...         "log": true
+...       }
+...     }
+...   }
+... }
+... '''
+>>> tunables = service.load_tunables(jsons=[json_config])
+>>> # Retrieve the current value for the tunable groups.
+>>> tunables.get_param_values()
+{'colors': 'green', 'int_param': 5, 'float_param': 1.0}
+>>> # Or an individual parameter:
+>>> tunables["colors"]
+'green'
+>>> # Assign new values to the tunable groups.
+>>> tunable_values = json5.loads('''
+... {
+...   // can be partially specified
+...   "colors": "red"
+... }
+... ''')
+>>> _ = tunables.assign(tunable_values)
+>>> tunables.get_param_values()
+{'colors': 'red', 'int_param': 5, 'float_param': 1.0}
+>>> # Check if the tunables have been updated.
+>>> # mlos_bench uses this to reinvoke the setup() phase of the
+>>> # associated Environment to reconfigure the system.
+>>> tunables.is_updated()
+True
+>>> # Reset the tunables to their default values.
+>>> # As a special case, an empty json object will reset all tunables to the defaults.
+>>> tunable_values = json5.loads('''
+... {}
+... ''')
+>>> _ = tunables.assign(tunable_values)
+>>> tunables.is_defaults()
+True
+>>> tunables.get_param_values()
+{'colors': 'green', 'int_param': 5, 'float_param': 1.0}
+
+Notes
+-----
+Internally, :py:class:`.TunableGroups` are converted to
+:external:py:class:`ConfigSpace.ConfigurationSpace` objects for use with
+:py:mod:`mlos_core`.
+
+See Also
+--------
+:py:mod:`mlos_bench.config`
+:py:mod:`mlos_bench.environments`
+:py:mod:`mlos_core.optimizers`
+:py:mod:`mlos_core.spaces`
 """
 
 from mlos_bench.tunables.tunable import Tunable, TunableValue

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -75,7 +75,7 @@ colocated with the environment configs (e.g., ``env-name-tunables.jsonc``) and
 loaded with the Environment using the ``include_tunables`` property in the
 Environment config.
 
-Then individual covariant groups can be enabled via the ``tunable_params` and
+Then individual covariant groups can be enabled via the ``tunable_params`` and
 ``tunable_params_map`` properties, possibly via ``globals`` variable expansion.
 
 See the :py:mod:`mlos_bench.config` and :py:mod:`mlos_bench.environments` module

--- a/mlos_bench/mlos_bench/tunables/__init__.py
+++ b/mlos_bench/mlos_bench/tunables/__init__.py
@@ -63,7 +63,7 @@ TunableGroups
 +++++++++++++
 
 The :py:class:`~mlos_bench.tunables.tunable_groups.TunableGroups` class is used to
-define an entire set of tunable paratmers (e.g., combined set of covariant groups).
+define an entire set of tunable parameters (e.g., combined set of covariant groups).
 
 Usage
 ^^^^^

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -100,6 +100,11 @@ class Tunable:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             Human-readable identifier of the tunable parameter.
         config : dict
             Python dict that represents a Tunable (e.g., deserialized from JSON)
+
+        See Also
+        --------
+        :py:mod:`mlos_bench.tunables` : for more information on tunable parameters and
+            their configuration.
         """
         if not isinstance(name, str) or "!" in name:  # TODO: Use a regex here and in JSON schema
             raise ValueError(f"Invalid name of the tunable: {name}")

--- a/mlos_bench/mlos_bench/tunables/tunable.py
+++ b/mlos_bench/mlos_bench/tunables/tunable.py
@@ -25,22 +25,28 @@ import numpy as np
 from mlos_bench.util import nullable
 
 _LOG = logging.getLogger(__name__)
-"""A tunable parameter value type alias."""
+
 TunableValue = Union[int, float, Optional[str]]
-"""Tunable value type."""
+"""A tunable parameter value type alias."""
+
 TunableValueType = Union[Type[int], Type[float], Type[str]]
+"""Tunable value type."""
+
+TunableValueTypeTuple = (int, float, str, type(None))
 """
 Tunable value type tuple.
 
 For checking with isinstance()
 """
-TunableValueTypeTuple = (int, float, str, type(None))
-"""The string name of a tunable value type."""
+
 TunableValueTypeName = Literal["int", "float", "categorical"]
-"""Tunable values dictionary type."""
+"""The string name of a tunable value type."""
+
 TunableValuesDict = Dict[str, TunableValue]
-"""Tunable value distribution type."""
+"""Tunable values dictionary type."""
+
 DistributionName = Literal["uniform", "normal", "beta"]
+"""Tunable value distribution type."""
 
 
 class DistributionDict(TypedDict, total=False):

--- a/mlos_bench/mlos_bench/tunables/tunable_groups.py
+++ b/mlos_bench/mlos_bench/tunables/tunable_groups.py
@@ -17,7 +17,6 @@ _LOG = logging.getLogger(__name__)
 class TunableGroups:
     """A collection of :py:class:`.CovariantTunableGroup` s of :py:class:`.Tunable`
     parameters.
-
     """
 
     def __init__(self, config: Optional[dict] = None):

--- a/mlos_bench/mlos_bench/tunables/tunable_groups.py
+++ b/mlos_bench/mlos_bench/tunables/tunable_groups.py
@@ -15,7 +15,10 @@ _LOG = logging.getLogger(__name__)
 
 
 class TunableGroups:
-    """A collection of covariant groups of tunable parameters."""
+    """A collection of :py:class:`.CovariantTunableGroup` s of :py:class:`.Tunable`
+    parameters.
+
+    """
 
     def __init__(self, config: Optional[dict] = None):
         """
@@ -25,6 +28,11 @@ class TunableGroups:
         ----------
         config : dict
             Python dict of serialized representation of the covariant tunable groups.
+
+        See Also
+        --------
+        :py:mod:`mlos_bench.tunables` : for more information on tunable parameters and
+            their configuration.
         """
         if config is None:
             config = {}

--- a/mlos_core/mlos_core/spaces/__init__.py
+++ b/mlos_core/mlos_core/spaces/__init__.py
@@ -2,4 +2,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-"""Space adapters and converters."""
+"""Space adapters and converters.
+
+See Also
+--------
+:py:mod:`mlos_core` : for an overview of configuration spaces in ``mlos_core``.
+"""

--- a/mlos_core/mlos_core/spaces/__init__.py
+++ b/mlos_core/mlos_core/spaces/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-"""Space adapters and converters.
+"""
+Space adapters and converters.
 
 See Also
 --------

--- a/mlos_core/mlos_core/spaces/converters/__init__.py
+++ b/mlos_core/mlos_core/spaces/converters/__init__.py
@@ -11,4 +11,8 @@ as input to the underlying Optimizer's parameter description language (in case i
 doesn't use :py:class:`ConfigSpace.ConfigurationSpace`).
 
 They are not generally intended to be used directly by the user.
+
+See Also
+--------
+:py:mod:`mlos_core` : for an overview of configuration spaces in ``mlos_core``.
 """


### PR DESCRIPTION
# Pull Request

## Title

Allow loading configs from JSON strings not just files and add docs for Tunables to demonstrate and test it.

---

## Description

Adds basic support for loading a JSON config string directly.

The main purpose is to be able to show examples in docstrings that are testable (so that they don't become stale examples).

- [x] Add basic example of usage and testing in a tunables docstring example.
- [x] Add `pytest` unit tests for config string loading as well (we already have file loading tests).
- Closes #881 

---

## Type of Change

- ✨ New feature
- 📝 Documentation update
- 🧪 Tests

---

## Testing

- [x] Adds additional unit tests.

---

## Additional Notes (optional)

Split out from #887 

---