### PR TITLE
make docstring test work in all environments

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -52,6 +52,12 @@ def pytest_configure(config: pytest.Config) -> None:
         except ImportError:
             pass
 
+    # Set pandas display options to make inline tests stable.
+    import pandas  # pylint: disable=import-outside-toplevel
+
+    pandas.options.display.width = 120
+    pandas.options.display.max_columns = 10
+
     # Create a temporary directory for sharing files between master and worker nodes.
     if is_master(config):
         # Add it to the config so that it can passed to the worker nodes.

--- a/mlos_bench/mlos_bench/storage/__init__.py
+++ b/mlos_bench/mlos_bench/storage/__init__.py
@@ -43,6 +43,10 @@ Example
 
 Here's a very basic example of the Storage APIs.
 
+>>> # Import and configure Pandas to make unit tests pass.
+>>> import pandas
+>>> pandas.options.display.width = 120
+>>> pandas.options.display.max_columns = 10
 >>> # Create a new storage object from a JSON config.
 >>> # Normally, we'd load these from a file, but for this example we'll use a string.
 >>> global_config = '''
@@ -143,11 +147,12 @@ sqlite::memory:
 >>> # Retrieve the results of all Trials in the Experiment as a DataFrame.
 >>> experiment_data.results_df.columns.tolist()
 ['trial_id', 'ts_start', 'ts_end', 'tunable_config_id', 'tunable_config_trial_group_id', 'status', 'config.param1', 'result.objective_metric']
->>> experiment_data.results_df.drop(columns=["ts_start"])
-   trial_id  ... result.objective_metric
-0         1  ...                      42
-<BLANKLINE>
-[1 rows x 7 columns]
+>>> # Drop the timestamp columns to make it a repeatable test.
+>>> experiment_data.results_df.drop(columns=["ts_start", "ts_end"])
+   trial_id  tunable_config_id  tunable_config_trial_group_id     status  config.param1  result.objective_metric
+0         1                  1                              1  SUCCEEDED             50                       42
+
+[1 rows x 6 columns]
 
 See Also
 --------

--- a/mlos_bench/mlos_bench/storage/__init__.py
+++ b/mlos_bench/mlos_bench/storage/__init__.py
@@ -43,10 +43,6 @@ Example
 
 Here's a very basic example of the Storage APIs.
 
->>> # Import and configure Pandas to make unit tests pass.
->>> import pandas
->>> pandas.options.display.width = 120
->>> pandas.options.display.max_columns = 10
 >>> # Create a new storage object from a JSON config.
 >>> # Normally, we'd load these from a file, but for this example we'll use a string.
 >>> global_config = '''


### PR DESCRIPTION
# Pull Request

## Title

Make inline unit tests that display Pandas DataFrame work in all environments, regardless of terminal width.

---

## Description

Inline tests in docstrings sometimes fail if the terminal width does not match the expected one and the pandas DataFrame got displayed differently.

- **Issue link**: Closes #895 

---

## Type of Change

- 🛠️ Bug fix
- 📝 Documentation update
- 🧪 Tests

---

## Testing

Unit tests should pass now

---
