### PR TITLE
CI fixups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,6 +75,7 @@
                 "ms-python.pylint",
                 "ms-python.python",
                 "ms-python.vscode-pylance",
+                "ms-python.debugpy",
                 "ms-vsliveshare.vsliveshare",
                 "njpwerner.autodocstring",
                 "redhat.vscode-yaml",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -19,6 +19,7 @@
         "ms-python.pylint",
         "ms-python.python",
         "ms-python.vscode-pylance",
+        "ms-python.debugpy",
         "ms-vscode-remote.remote-containers",
         "ms-vsliveshare.vsliveshare",
         "njpwerner.autodocstring",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // See Also: https://code.visualstudio.com/docs/python/testing#_debug-tests
             "name": "Python: Debug Tests",
             "type": "debugpy",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Unit Test",
-            "type": "python",
-            "request": "test",
+            "name": "Python: Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
             "justMyCode": false,
             "env": {
                 // When debugging tests, only run a single pytest worker instance.

--- a/conda-envs/mlos-windows.yml
+++ b/conda-envs/mlos-windows.yml
@@ -17,6 +17,7 @@ dependencies:
   - ipykernel
   - nb_conda_kernels
   - matplotlib-base<3.9
+  - scikit-learn
   - seaborn
   - pandas
   - pyarrow

--- a/mlos_viz/mlos_viz/base.py
+++ b/mlos_viz/mlos_viz/base.py
@@ -46,6 +46,7 @@ def ignore_plotter_warnings() -> None:
             module="seaborn",  # but actually comes from pandas
             message="is_categorical_dtype is deprecated and will be removed in a future version.",
         )
+    # See Also: https://github.com/mwaskom/seaborn/issues/3804
     warnings.filterwarnings(
         "ignore",
         category=PendingDeprecationWarning,

--- a/mlos_viz/mlos_viz/base.py
+++ b/mlos_viz/mlos_viz/base.py
@@ -46,6 +46,15 @@ def ignore_plotter_warnings() -> None:
             module="seaborn",  # but actually comes from pandas
             message="is_categorical_dtype is deprecated and will be removed in a future version.",
         )
+    warnings.filterwarnings(
+        "ignore",
+        category=PendingDeprecationWarning,
+        module="seaborn",  # but actually comes from matplotlib
+        message=(
+            "vert: bool will be deprecated in a future version. "
+            "Use orientation: {'vertical', 'horizontal'} instead."
+        ),
+    )
 
 
 def _add_groupby_desc_column(

--- a/mlos_viz/setup.py
+++ b/mlos_viz/setup.py
@@ -83,7 +83,7 @@ setup(
     version=VERSION,
     install_requires=[
         "mlos-bench==" + VERSION,
-        "dabl>=0.3.1",
+        "dabl>=0.3.2",
         "matplotlib",
         "seaborn>=0.12.2",
     ],


### PR DESCRIPTION
# Pull Request

## Title

Some fixups to account for new versions of matplotlib so that CI runs again.

---

## Description

- Pulls in a new version of dabl with some fixes:
  https://github.com/dabl/dabl/pull/353
- Adds an ignore for a seaborn issue:
  https://github.com/mwaskom/seaborn/issues/3804
- Adjusts the python unit test debugger config to remove a deprecated extension:
  https://code.visualstudio.com/docs/python/testing#_debug-tests

---

## Type of Change

- 🛠️ Bug fix

---