### PR TITLE
speed improvement on licenseheaders pre-commit partial files run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
     -   id: licenseheaders
         files: '\.(sh|cmd|ps1|sql|py)$'
-        args: [-t, doc/mit-license.tmpl, -E, .py, .sh, .ps1, .sql, .cmd, -x, mlos_bench/setup.py, mlos_core/setup.py, mlos_viz/setup.py]
+        args: [-t, doc/mit-license.tmpl, -E, .py, .sh, .ps1, .sql, .cmd, -x, mlos_bench/setup.py, mlos_core/setup.py, mlos_viz/setup.py, -f]
         require_serial: true
         stages: [pre-commit, manual]
 -   repo: https://github.com/asottile/pyupgrade


### PR DESCRIPTION
When doing partial `pre-commit run` on staged changes, only run `licenceheaders` on the changed files, not all of them.