### PR TITLE
Enable pre-commit autoupdate PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
     # hook versions.
     # In the future we may consider to integrate it into the usual CI jobs to
     # automatically fixup formatting in PRs.
-    autofix_prs: false
+    autofix_prs: true
     # skip local hooks - they should be managed manually via conda-envs/*.yml
     skip: [mypy, pylint, pycodestyle]
     autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,7 @@
 # Enable automatic updates via Github Actions as well.
 # See https://pre-commit.ci
 ci:
-    # For now we only use pre-commit.ci to do automatic updates of the pre-commit
-    # hook versions.
-    # In the future we may consider to integrate it into the usual CI jobs to
-    # automatically fixup formatting in PRs.
+    # Let pre-commit.ci automatically update PRs with formatting fixes.
     autofix_prs: true
     # skip local hooks - they should be managed manually via conda-envs/*.yml
     skip: [mypy, pylint, pycodestyle]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
     # automatically fixup formatting in PRs.
     autofix_prs: false
     # skip local hooks - they should be managed manually via conda-envs/*.yml
-    skip: [mypy, pylint]
+    skip: [mypy, pylint, pycodestyle]
     autoupdate_schedule: monthly
     autoupdate_commit_msg: |
         [pre-commit.ci] pre-commit autoupdate
@@ -19,6 +19,7 @@ ci:
         - https://github.com/microsoft/MLOS/blob/main/conda-envs/mlos.yml
         - https://pypi.org/project/mypy/
         - https://pypi.org/project/pylint/
+        - https://pypi.org/project/pycodestyle/
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,25 @@
+# Enable automatic updates via Github Actions as well.
+# See https://pre-commit.ci
+ci:
+    # For now we only use pre-commit.ci to do automatic updates of the pre-commit
+    # hook versions.
+    # In the future we may consider to integrate it into the usual CI jobs to
+    # automatically fixup formatting in PRs.
+    autofix_prs: false
+    # skip local hooks - they should be managed manually via conda-envs/*.yml
+    skip: [mypy, pylint]
+    autoupdate_schedule: monthly
+    autoupdate_commit_msg: |
+        [pre-commit.ci] pre-commit autoupdate
+
+        for more information, see https://pre-commit.ci
+
+        NOTE: Be sure to also check for other possible hook updates in the conda-envs/*.yml files (e.g., mypy, pylint, etc.).
+        See Also:
+        - https://github.com/microsoft/MLOS/blob/main/conda-envs/mlos.yml
+        - https://pypi.org/project/mypy/
+        - https://pypi.org/project/pylint/
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ default_stages: [pre-commit]
 # are partitioned and the hook executable called in parallel across them, not
 # whether hooks themselves are parallelized.
 # As such, some hooks (e.g., pylint) which do internal parallelism need it set
-# for effeciency and correctness anyways.
+# for efficiency and correctness anyways.
 
 repos:
 #

--- a/mlos_bench/mlos_bench/tests/storage/sql/fixtures.py
+++ b/mlos_bench/mlos_bench/tests/storage/sql/fixtures.py
@@ -4,8 +4,8 @@
 #
 """Test fixtures for mlos_bench storage."""
 
-from random import seed as rand_seed
 from collections.abc import Generator
+from random import seed as rand_seed
 
 import pytest
 

--- a/mlos_bench/mlos_bench/tests/storage/sql/fixtures.py
+++ b/mlos_bench/mlos_bench/tests/storage/sql/fixtures.py
@@ -4,8 +4,8 @@
 #
 """Test fixtures for mlos_bench storage."""
 
-from collections.abc import Generator
 from random import seed as rand_seed
+from collections.abc import Generator
 
 import pytest
 


### PR DESCRIPTION
# Pull Request

## Title

Enable pre-commit autoupdate PRs

---

## Description

Adds configs for pre-commit.ci to use to scan our repo and automatically submit PRs to update pre-commit hook version monthly.

---

## Type of Change

- ✨ New feature

---

## Additional Notes (optional)

This also enables autofix PRs to hopefully improve the turnaround time on PR reviews by automatically applying formatting fixups to a PR.

This could get confusing or annoying if PR authors don't locally pull after fixes are applied or if the formatters do something drastic that we aren't anticipating, so we may consider to disable this in the future as well.

---
