### PR TITLE
Temporarily workaround llamatune issues with numpy>=2.0

### DIFF
--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -94,6 +94,7 @@ setup(
         "scikit-learn>=1.3",
         "scipy>=1.3.2",
         "numpy>=1.24",
+        "numpy<2.0",  # FIXME: temporarily workaround llamatune issues
         'pandas >= 2.2.0;python_version>="3.9"',
         "ConfigSpace>=1.0",
     ],


### PR DESCRIPTION
# Pull Request

## Title

Temporarily workaround issues with LlamaTune and numpy>=2.0

______________________________________________________________________

## Description

LlamaTune has issues with numpy>=2.0 reporting errors like the following:

```
FAILED mlos_core/mlos_core/tests/spaces/adapters/llamatune_test.py::test_num_low_dims[2-param_space_kwargs1] - ValueError: Configuration(values={
  'int_0': 245,
  'int_1': 10,
  'int_2': 54,
})
The above configuration was not suggested by the optimizer. Approximate reverse mapping is currently disabled; thus *only* configurations suggested previously by the optimizer can be registered.
```

- See Also: #935 

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix

______________________________________________________________________

## Testing

- CI

______________________________________________________________________
