### PR TITLE
Fix dtype casting issue with numpy in LlamaTune adapter

### DIFF
--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -16,7 +16,6 @@ See Also: `LlamaTune: Sample-Efficient DBMS Configuration Tuning
 import os
 from importlib.metadata import version
 from typing import Any
-from packaging.version import Version
 from warnings import warn
 
 import ConfigSpace
@@ -25,12 +24,14 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 from ConfigSpace.hyperparameters import NumericalHyperparameter
+from packaging.version import Version
 from sklearn.preprocessing import MinMaxScaler
 
 from mlos_core.spaces.adapters.adapter import BaseSpaceAdapter
 from mlos_core.util import normalize_config
 
 _NUMPY_VERS = Version(version("numpy"))
+
 
 class LlamaTuneAdapter(BaseSpaceAdapter):  # pylint: disable=too-many-instance-attributes
     """Implementation of LlamaTune, a set of parameter space transformation techniques,

--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -385,6 +385,15 @@ class LlamaTuneAdapter(BaseSpaceAdapter):  # pylint: disable=too-many-instance-a
 
                 orig_value = param.to_value(value)
                 orig_value = np.clip(orig_value, param.lower, param.upper)
+
+                try:
+                    # Convert numpy types to native Python types (e.g., np.int64 to int)
+                    # This was performed automatically in NumPy<2.0, but not anymore.
+                    # see, https://numpy.org/doc/stable/reference/generated/numpy.can_cast.html
+                    orig_value = orig_value.item()
+                except AttributeError:
+                    pass
+
             else:
                 raise NotImplementedError(
                     "Only Categorical, Integer, and Float hyperparameters are currently supported."

--- a/mlos_core/mlos_core/spaces/adapters/llamatune.py
+++ b/mlos_core/mlos_core/spaces/adapters/llamatune.py
@@ -14,7 +14,9 @@ See Also: `LlamaTune: Sample-Efficient DBMS Configuration Tuning
 <https://www.microsoft.com/en-us/research/publication/llamatune-sample-efficient-dbms-configuration-tuning>`_.
 """
 import os
+from importlib.metadata import version
 from typing import Any
+from packaging.version import Version
 from warnings import warn
 
 import ConfigSpace
@@ -28,6 +30,7 @@ from sklearn.preprocessing import MinMaxScaler
 from mlos_core.spaces.adapters.adapter import BaseSpaceAdapter
 from mlos_core.util import normalize_config
 
+_NUMPY_VERS = Version(version("numpy"))
 
 class LlamaTuneAdapter(BaseSpaceAdapter):  # pylint: disable=too-many-instance-attributes
     """Implementation of LlamaTune, a set of parameter space transformation techniques,
@@ -386,13 +389,11 @@ class LlamaTuneAdapter(BaseSpaceAdapter):  # pylint: disable=too-many-instance-a
                 orig_value = param.to_value(value)
                 orig_value = np.clip(orig_value, param.lower, param.upper)
 
-                try:
+                if _NUMPY_VERS >= Version("2.0"):
                     # Convert numpy types to native Python types (e.g., np.int64 to int)
                     # This was performed automatically in NumPy<2.0, but not anymore.
                     # see, https://numpy.org/doc/stable/reference/generated/numpy.can_cast.html
                     orig_value = orig_value.item()
-                except AttributeError:
-                    pass
 
             else:
                 raise NotImplementedError(

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -94,7 +94,6 @@ setup(
         "scikit-learn>=1.3",
         "scipy>=1.3.2",
         "numpy>=1.24",
-        "numpy<2.0",  # FIXME: temporarily workaround llamatune issues
         'pandas >= 2.2.0;python_version>="3.9"',
         "ConfigSpace>=1.0",
     ],

--- a/mlos_core/setup.py
+++ b/mlos_core/setup.py
@@ -94,6 +94,7 @@ setup(
         "scikit-learn>=1.3",
         "scipy>=1.3.2",
         "numpy>=1.24",
+        "numpy<2.0",  # FIXME: temporarily workaround llamatune issues
         'pandas >= 2.2.0;python_version>="3.9"',
         "ConfigSpace>=1.0",
     ],

--- a/mlos_viz/mlos_viz/base.py
+++ b/mlos_viz/mlos_viz/base.py
@@ -8,12 +8,12 @@ import re
 import warnings
 from collections.abc import Callable, Iterable
 from importlib.metadata import version
-from packaging.version import Version
 from typing import Any, Literal
 
 import pandas
 import seaborn as sns
 from matplotlib import pyplot as plt
+from packaging.version import Version
 from pandas.api.types import is_numeric_dtype
 from pandas.core.groupby.generic import SeriesGroupBy
 

--- a/mlos_viz/mlos_viz/base.py
+++ b/mlos_viz/mlos_viz/base.py
@@ -8,6 +8,7 @@ import re
 import warnings
 from collections.abc import Callable, Iterable
 from importlib.metadata import version
+from packaging.version import Version
 from typing import Any, Literal
 
 import pandas
@@ -19,7 +20,7 @@ from pandas.core.groupby.generic import SeriesGroupBy
 from mlos_bench.storage.base_experiment_data import ExperimentData
 from mlos_viz.util import expand_results_data_args
 
-_SEABORN_VERS = version("seaborn")
+_SEABORN_VERS = Version(version("seaborn"))
 
 
 def _get_kwarg_defaults(target: Callable, **kwargs: Any) -> dict[str, Any]:
@@ -40,7 +41,7 @@ def ignore_plotter_warnings() -> None:
     adding them to the warnings filter.
     """
     warnings.filterwarnings("ignore", category=FutureWarning)
-    if _SEABORN_VERS <= "0.13.1":
+    if _SEABORN_VERS <= Version("0.13.1"):
         warnings.filterwarnings(
             "ignore",
             category=DeprecationWarning,


### PR DESCRIPTION
# Pull Request

## Description

This PR addresses a breaking change in NumPy's [universal function](https://numpy.org/doc/stable/reference/ufuncs.html) (ufunc) behavior in version 2.0, specifically affecting `np.clip` in the LlamaTune adapter code.

**Key Changes**:
- Resolves an issue where configuration retrieval fails due to type casting differences
- Explicitly casts `np.clip` output from NumPy data type (e.g., `int64`) to native Python type (e.g., `int`)

**Problem Context:**
In NumPy 2.0+, when ufuncs receive Python scalars as input, the output is [no longer](https://numpy.org/doc/stable/reference/generated/numpy.can_cast.html#numpy.can_cast) automatically cast to Python scalars. This prevents retrieving previously suggested configurations stored in `self._suggested_configs` dict during `self.inverse_transform` method calls.

**Technical Solution:**
Implement explicit type casting to ensure consistent configuration representation in `self._suggested_configs` across `self.transform` and `self.inverse_transform` method calls.

- **Closes #935** 

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix

______________________________________________________________________

## Testing

- **Environment**: Ubuntu 22.04 with Python 3.13
- **NumPy Versions Tested**: 1.26.4 and 2.2.2
- **Verification**: Existing test suite passed across both versions

______________________________________________________________________

