### PR TITLE
Azure retry on result timeout / server busy

### DIFF
--- a/mlos_bench/mlos_bench/services/remote/azure/azure_deployment_services.py
+++ b/mlos_bench/mlos_bench/services/remote/azure/azure_deployment_services.py
@@ -140,7 +140,11 @@ class AzureDeploymentService(Service, metaclass=abc.ABCMeta):
         session = requests.Session()
         session.mount(
             "https://",
-            HTTPAdapter(max_retries=Retry(total=total_retries, backoff_factor=backoff_factor)),
+            HTTPAdapter(
+                max_retries=Retry(
+                    total=total_retries, backoff_factor=backoff_factor, status_forcelist=[503]
+                )
+            ),
         )
         session.headers.update(self._get_headers())
         return session


### PR DESCRIPTION
# Pull Request

## Azure retry on result timeout / server busy

This fixes a small issue where Azure ARM requests could intermittently fail if the corresponding control plane is too busy.


______________________________________________________________________

## Description

This manifests as a HTTP 503 response code, with a message like:
```
ERROR Response: <Response [503]> :: {"error":{"code":"ServerTimeout","message":"The request timed out. Diagnostic information: timestamp '20250209T125446Z', subscription id '...', tracking id '...', request correlation id '...'."}}
```

According to the official docs, these responses indicate the request should be retried: https://learn.microsoft.com/en-us/rest/api/storageservices/common-rest-api-error-codes

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix

______________________________________________________________________

## Testing

Manual testing, fix that we have been using for a while in experiments but have not merged yet.

______________________________________________________________________

## Additional Notes (optional)


______________________________________________________________________
