### PR TITLE
bugfix: local env not passed to the child process when shell_env_params present

### DIFF
--- a/mlos_bench/mlos_bench/services/local/local_exec.py
+++ b/mlos_bench/mlos_bench/services/local/local_exec.py
@@ -206,12 +206,12 @@ class LocalExecService(TempDirContextService, SupportsLocalExec):
         if env_params:
             env = {key: str(val) for (key, val) in env_params.items()}
 
+        env_copy = environ.copy()
         if sys.platform == "win32":
             # A hack to run Python on Windows with env variables set:
-            env_copy = environ.copy()
             env_copy["PYTHONPATH"] = ""
-            env_copy.update(env)
-            env = env_copy
+        env_copy.update(env)
+        env = env_copy
 
         try:
             if sys.platform != "win32":

--- a/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
+++ b/mlos_bench/mlos_bench/tests/services/local/local_exec_test.py
@@ -3,13 +3,13 @@
 # Licensed under the MIT License.
 #
 """Unit tests for the service to run the scripts locally."""
-import os
 import sys
 import tempfile
 
 import pandas
 import pytest
 
+from mlos_bench.os_environ import environ
 from mlos_bench.services.config_persistence import ConfigPersistenceService
 from mlos_bench.services.local.local_exec import LocalExecService, split_cmdline
 from mlos_bench.util import path_join
@@ -92,7 +92,7 @@ def test_run_script_multiline(local_exec_service: LocalExecService) -> None:
 def test_run_script_multiline_env(local_exec_service: LocalExecService) -> None:
     """Run a multiline script locally and pass the environment variables to it."""
     # `echo` should work on all platforms
-    os.environ["LOCAL_VAR"] = "LOCAL_VALUE"  # Make sure parent env is passed to child
+    environ["LOCAL_VAR"] = "LOCAL_VALUE"  # Make sure parent env is passed to child
     (return_code, stdout, stderr) = local_exec_service.local_exec(
         [
             r"echo $var $int_var $LOCAL_VAR",  # Unix shell


### PR DESCRIPTION
# Pull Request

## Title

Copy local environment variables and explicitly pass them to the child process.
______________________________________________________________________

## Description

When we explicitly provide the environment variables to pass to the `subprocess.run()` call, only those variables get passed to the child process. That prevents the child process from seeing the environment variables of the parent MLOS process. We've fixed that issue for MLOS on Windows but not for other systems. This PR fixes it for Linux and MacOS.

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix
- 🧪 Tests

______________________________________________________________________

## Testing

Update the existing unit tests to check for MLOS parameters *and* parent environment variables being passed to the child process.
