### PR TITLE
Bug fix: restore trial_runner_id on reload from Storage

### DIFF
--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -409,7 +409,7 @@ class Storage(metaclass=ABCMeta):
             experiment_id: str,
             trial_id: int,
             tunable_config_id: int,
-            trial_runner_id: int | None = None,
+            trial_runner_id: int | None,
             opt_targets: dict[str, Literal["min", "max"]],
             config: dict[str, Any] | None = None,
             status: Status = Status.UNKNOWN,

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -276,6 +276,7 @@ class Experiment(Storage.Experiment):
                     experiment_id=self._experiment_id,
                     trial_id=trial.trial_id,
                     config_id=trial.config_id,
+                    trial_runner_id=trial.trial_runner_id,
                     opt_targets=self._opt_targets,
                     config=config,
                 )
@@ -350,6 +351,7 @@ class Experiment(Storage.Experiment):
                     experiment_id=self._experiment_id,
                     trial_id=self._trial_id,
                     config_id=config_id,
+                    trial_runner_id=None,  # initially, Trials are not assigned to a TrialRunner
                     opt_targets=self._opt_targets,
                     config=config,
                     status=new_trial_status,

--- a/mlos_bench/mlos_bench/storage/sql/trial.py
+++ b/mlos_bench/mlos_bench/storage/sql/trial.py
@@ -38,7 +38,7 @@ class Trial(Storage.Trial):
         experiment_id: str,
         trial_id: int,
         config_id: int,
-        trial_runner_id: int | None = None,
+        trial_runner_id: int | None,
         opt_targets: dict[str, Literal["min", "max"]],
         config: dict[str, Any] | None = None,
         status: Status = Status.UNKNOWN,

--- a/mlos_bench/mlos_bench/tests/storage/trial_schedule_test.py
+++ b/mlos_bench/mlos_bench/tests/storage/trial_schedule_test.py
@@ -64,14 +64,21 @@ def test_schedule_trial(
     # Scheduler side: get trials ready to run at certain timestamps:
 
     # Pretend 1 minute has passed, get trials scheduled to run:
-    pending_trials = exp_storage.pending_trials(timestamp + timedelta_1min, running=False)
-    pending_ids = _trial_ids(pending_trials)
+    pending_ids = _trial_ids(exp_storage.pending_trials(timestamp + timedelta_1min, running=False))
     assert pending_ids == {
         trial_now1.trial_id,
         trial_now2.trial_id,
     }
-    pending_trial_now2 = next(iter(t for t in pending_trials if t.trial_id == trial_now2.trial_id))
-    assert pending_trial_now2.trial_runner_id == trial_now2_data.trial_runner_id
+
+    # Make sure that the pending trials and trial_runner_ids match.
+    pending_trial_runner_ids = {
+        pending_trial.trial_id: pending_trial.trial_runner_id
+        for pending_trial in exp_storage.pending_trials(timestamp + timedelta_1min, running=False)
+    }
+    assert pending_trial_runner_ids == {
+        trial_now1.trial_id: trial_now1.trial_runner_id,
+        trial_now2.trial_id: trial_now2.trial_runner_id,
+    }
 
     # Get trials scheduled to run within the next 1 hour:
     pending_ids = _trial_ids(exp_storage.pending_trials(timestamp + timedelta_1hr, running=False))


### PR DESCRIPTION
# Pull Request

## Title

Bug fix: restore trial_runner_id on reload from Storage

______________________________________________________________________

## Description

@jsfreischuetz noticed that `pending_trials` was returning `Trial` objects without a `trial_runner_id` even though they were previously set.

This change fixes that and closes #968.

- Requires explicit `trial_runner_id` on `Trial` object instantiation
- Adds it in places where it was missing.

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix
- 🧪 Tests

______________________________________________________________________

## Testing

New and existing tests.

______________________________________________________________________

## Additional Notes (optional)

Found in the course of work on #967

______________________________________________________________________
