### PR TITLE
Prepare Experiment.load to handle async out of order trial completion

### DIFF
--- a/mlos_bench/mlos_bench/schedulers/base_scheduler.py
+++ b/mlos_bench/mlos_bench/schedulers/base_scheduler.py
@@ -100,8 +100,9 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
         self._optimizer = optimizer
         self._storage = storage
         self._root_env_config = root_env_config
-        self._last_trial_id = -1
+        self._longest_finished_trial_sequence_id = -1
         self._ran_trials: list[Storage.Trial] = []
+        self._registered_trial_ids: set[int] = set()
 
         _LOG.debug("Scheduler instantiated: %s :: %s", self, config)
 
@@ -240,7 +241,6 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
         self._in_context = False
         return False  # Do not suppress exceptions
 
-    @abstractmethod
     def start(self) -> None:
         """Start the scheduling loop."""
         assert self.experiment is not None
@@ -255,19 +255,62 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
 
         if self._config_id > 0:
             tunables = self.load_tunable_config(self._config_id)
-            self.schedule_trial(tunables)
+            # If a config_id is provided, assume it is expected to be run immediately.
+            self.add_trial_to_queue(tunables, ts_start=datetime.now(UTC))
+
+        is_warm_up: bool = self.optimizer.supports_preload
+        if not is_warm_up:
+            _LOG.warning("Skip pending trials and warm-up: %s", self.optimizer)
+
+        not_done: bool = True
+        while not_done:
+            _LOG.info(
+                "Optimization loop: Longest finished trial sequence ID: %d",
+                self._longest_finished_trial_sequence_id,
+            )
+            self.run_schedule(is_warm_up)
+            self.wait_for_trial_runners()
+            not_done = self.add_new_optimizer_suggestions()
+            self.assign_trial_runners(
+                self.experiment.pending_trials(
+                    datetime.now(UTC),
+                    running=False,
+                    trial_runner_assigned=False,
+                )
+            )
+            is_warm_up = False
+        self.wait_for_trial_runners(wait_all=True)
+
+    @abstractmethod
+    def wait_for_trial_runners(self, wait_all: bool = False) -> None:
+        """
+        Wait for (enough) TrialRunners to finish.
+
+        This is a blocking call that waits for enough of the the TrialRunners to finish.
+        The base class implementation waits for all of the TrialRunners to finish.
+        However this can be overridden in subclasses to implement a more asynchronous behavior.
+
+        Parameters
+        ----------
+        wait_all : bool
+            If True, wait for all TrialRunners to finish.
+            If False, wait for "enough" TrialRunners to finish (which for the
+            base class is all of them).
+        """
 
     def teardown(self) -> None:
         """
         Tear down the TrialRunners/Environment(s).
 
-        Call it after the completion of the `.start()` in the scheduler context.
+        Call it after the completion of the :py:meth:`Scheduler.start` in the
+        Scheduler context.
         """
         assert self.experiment is not None
         if self._do_teardown:
             for trial_runner in self._trial_runners.values():
                 assert not trial_runner.is_running
-                trial_runner.teardown()
+                with trial_runner:
+                    trial_runner.teardown()
 
     def get_best_observation(self) -> tuple[dict[str, float] | None, TunableGroups | None]:
         """Get the best observation from the optimizer."""
@@ -287,53 +330,111 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
             _LOG.debug("Config %d ::\n%s", config_id, json.dumps(tunable_values, indent=2))
         return tunables.copy()
 
-    def _schedule_new_optimizer_suggestions(self) -> bool:
+    def add_new_optimizer_suggestions(self) -> bool:
         """
         Optimizer part of the loop.
 
-        Load the results of the executed trials into the optimizer, suggest new
-        configurations, and add them to the queue. Return True if optimization is not
-        over, False otherwise.
+        Load the results of the executed trials into the
+        :py:class:`~.Optimizer`, suggest new configurations, and add them to the
+        queue.
+
+        Returns
+        -------
+        bool
+            The return value indicates whether the optimization process should
+            continue to get suggestions from the Optimizer or not.
+            See Also: :py:meth:`~.Scheduler.not_done`.
         """
         assert self.experiment is not None
-        (trial_ids, configs, scores, status) = self.experiment.load(self._last_trial_id)
+        # Load the results of the trials that have been run since the last time
+        # we queried the Optimizer.
+        # Note: We need to handle the case of straggler trials that finish out of order.
+        (trial_ids, configs, scores, status) = self.experiment.load(
+            last_trial_id=self._longest_finished_trial_sequence_id,
+            omit_registered_trial_ids=self._registered_trial_ids,
+        )
         _LOG.info("QUEUE: Update the optimizer with trial results: %s", trial_ids)
         self.optimizer.bulk_register(configs, scores, status)
-        self._last_trial_id = max(trial_ids, default=self._last_trial_id)
+        # Mark those trials as registered so we don't load them again.
+        self._registered_trial_ids.update(trial_ids)
+        # Update the longest finished trial sequence ID.
+        self._longest_finished_trial_sequence_id = max(
+            [
+                self.experiment.get_longest_prefix_finished_trial_id(),
+                self._longest_finished_trial_sequence_id,
+            ],
+            default=self._longest_finished_trial_sequence_id,
+        )
+        # Remove trial ids that are older than the longest finished trial sequence ID.
+        # This is an optimization to avoid a long list of trial ids to omit from
+        # the load() operation or a long list of trial ids to maintain in memory.
+        self._registered_trial_ids = {
+            trial_id
+            for trial_id in self._registered_trial_ids
+            if trial_id > self._longest_finished_trial_sequence_id
+        }
 
+        # Check if the optimizer has converged or not.
         not_done = self.not_done()
         if not_done:
+            # TODO: Allow scheduling multiple configs at once (e.g., in the case of idle workers).
             tunables = self.optimizer.suggest()
-            self.schedule_trial(tunables)
-
+            self.add_trial_to_queue(tunables)
         return not_done
 
-    def schedule_trial(self, tunables: TunableGroups) -> None:
-        """Add a configuration to the queue of trials."""
-        # TODO: Alternative scheduling policies may prefer to expand repeats over
-        # time as well as space, or adjust the number of repeats (budget) of a given
-        # trial based on whether initial results are promising.
+    def add_trial_to_queue(
+        self,
+        tunables: TunableGroups,
+        ts_start: datetime | None = None,
+    ) -> None:
+        """
+        Add a configuration to the queue of trials 1 or more times.
+
+        (e.g., according to the :py:attr:`~.Scheduler.trial_config_repeat_count`)
+
+        Parameters
+        ----------
+        tunables : TunableGroups
+            The tunable configuration to add to the queue.
+
+        ts_start : datetime | None
+            Optional timestamp to use to start the trial.
+
+        Notes
+        -----
+        Alternative scheduling policies may prefer to expand repeats over
+        time as well as space, or adjust the number of repeats (budget) of a given
+        trial based on whether initial results are promising.
+        """
         for repeat_i in range(1, self._trial_config_repeat_count + 1):
             self._add_trial_to_queue(
                 tunables,
-                config={
-                    # Add some additional metadata to track for the trial such as the
-                    # optimizer config used.
-                    # Note: these values are unfortunately mutable at the moment.
-                    # Consider them as hints of what the config was the trial *started*.
-                    # It is possible that the experiment configs were changed
-                    # between resuming the experiment (since that is not currently
-                    # prevented).
-                    "optimizer": self.optimizer.name,
-                    "repeat_i": repeat_i,
-                    "is_defaults": tunables.is_defaults(),
-                    **{
-                        f"opt_{key}_{i}": val
-                        for (i, opt_target) in enumerate(self.optimizer.targets.items())
-                        for (key, val) in zip(["target", "direction"], opt_target)
-                    },
-                },
+                ts_start=ts_start,
+                config=self._augment_trial_config_metadata(tunables, repeat_i),
             )
+
+    def _augment_trial_config_metadata(
+        self,
+        tunables: TunableGroups,
+        repeat_i: int,
+    ) -> dict[str, Any]:
+        return {
+            # Add some additional metadata to track for the trial such as the
+            # optimizer config used.
+            # Note: these values are unfortunately mutable at the moment.
+            # Consider them as hints of what the config was the trial *started*.
+            # It is possible that the experiment configs were changed
+            # between resuming the experiment (since that is not currently
+            # prevented).
+            "optimizer": self.optimizer.name,
+            "repeat_i": repeat_i,
+            "is_defaults": tunables.is_defaults(),
+            **{
+                f"opt_{key}_{i}": val
+                for (i, opt_target) in enumerate(self.optimizer.targets.items())
+                for (key, val) in zip(["target", "direction"], opt_target)
+            },
+        }
 
     def _add_trial_to_queue(
         self,
@@ -352,10 +453,10 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
 
     def assign_trial_runners(self, trials: Iterable[Storage.Trial]) -> None:
         """
-        Assigns TrialRunners to the given Trial in batch.
+        Assigns :py:class:`~.TrialRunner`s to the given :py:class:`~.Trial`s in batch.
 
-        The base class implements a simple round-robin scheduling algorithm for each
-        Trial in sequence.
+        The base class implements a simple round-robin scheduling algorithm for
+        each Trial in sequence.
 
         Subclasses can override this method to implement a more sophisticated policy.
         For instance::
@@ -374,6 +475,11 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
                     # Call the base class method to assign the TrialRunner in the Trial's metadata.
                     trial.set_trial_runner(trial_runner)
                 ...
+
+        Notes
+        -----
+        Subclasses are *not* required to assign a TrialRunner to the Trial
+        (e.g., if the Trial should be deferred to a later time).
 
         Parameters
         ----------
@@ -411,7 +517,8 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
 
     def get_trial_runner(self, trial: Storage.Trial) -> TrialRunner:
         """
-        Gets the TrialRunner associated with the given Trial.
+        Gets the :py:class:`~.TrialRunner` associated with the given
+        :py:class:`~.Storage.Trial`.
 
         Parameters
         ----------
@@ -434,25 +541,30 @@ class Scheduler(ContextManager, metaclass=ABCMeta):
         assert trial_runner.trial_runner_id == trial.trial_runner_id
         return trial_runner
 
-    def _run_schedule(self, running: bool = False) -> None:
+    def run_schedule(self, running: bool = False) -> None:
         """
-        Scheduler part of the loop.
+        Runs the current schedule of trials.
 
-        Check for pending trials in the queue and run them.
+        Check for :py:class:`.Trial`s with `:py:attr:`.Status.PENDING` and an
+        assigned :py:attr:`~.Trial.trial_runner_id` in the queue and run them
+        with :py:meth:`~.Scheduler.run_trial`.
         """
         assert self.experiment is not None
-        # Make sure that any pending trials have a TrialRunner assigned.
         pending_trials = list(self.experiment.pending_trials(datetime.now(UTC), running=running))
-        self.assign_trial_runners(pending_trials)
         for trial in pending_trials:
+            if trial.trial_runner_id is None:
+                logging.warning("Trial %s has no TrialRunner assigned yet.")
+                continue
             self.run_trial(trial)
 
     def not_done(self) -> bool:
         """
         Check the stopping conditions.
 
-        By default, stop when the optimizer converges or max limit of trials reached.
+        By default, stop when the :py:class:`.Optimizer` converges or the limit
+        of :py:attr:`~.Scheduler.max_trials` is reached.
         """
+        # TODO: Add more stopping conditions: https://github.com/microsoft/MLOS/issues/427
         return self.optimizer.not_converged() and (
             self._trial_count < self._max_trials or self._max_trials <= 0
         )

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -285,9 +285,19 @@ class Storage(metaclass=ABCMeta):
             """
 
         @abstractmethod
+        def get_longest_prefix_finished_trial_id(self) -> int:
+            """
+            Calculate the last trial ID for the experiment.
+
+            This is used to determine the last trial ID that finished (failed or
+            successful) such that all Trials before it are also finished.
+            """
+
+        @abstractmethod
         def load(
             self,
             last_trial_id: int = -1,
+            omit_registered_trial_ids: Iterable[int] | None = None,
         ) -> tuple[list[int], list[dict], list[dict[str, Any] | None], list[Status]]:
             """
             Load (tunable values, benchmark scores, status) to warm-up the optimizer.
@@ -296,10 +306,20 @@ class Storage(metaclass=ABCMeta):
             that were scheduled *after* the given trial ID. Otherwise, return data from ALL
             merged-in experiments and attempt to impute the missing tunable values.
 
+            Additionally, if `omit_registered_trial_ids` is provided, omit the
+            trials matching those ids.
+
+            The parameters together allow us to efficiently load data from
+            finished trials that we haven't registered with the Optimizer yet
+            for bulk registering.
+
             Parameters
             ----------
             last_trial_id : int
                 (Optional) Trial ID to start from.
+            omit_registered_trial_ids : Iterable[int] | None = None,
+                (Optional) List of trial IDs to omit. If None, load all trials.
+
 
             Returns
             -------

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -8,7 +8,7 @@ the benchmark experiment data using `SQLAlchemy <https://sqlalchemy.org>`_ backe
 
 import hashlib
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from datetime import datetime
 from typing import Any, Literal
 
@@ -153,13 +153,43 @@ class Experiment(Storage.Experiment):
                 for row in cur_telemetry.fetchall()
             ]
 
+    # TODO: Add a test for this method.
+    def get_longest_prefix_finished_trial_id(self) -> int:
+        with self._engine.connect() as conn:
+            # Get the first (minimum) trial ID with an unfinished status.
+            first_unfinished_trial_id_stmt = (
+                self._schema.trial.select()
+                .with_only_columns(
+                    func.min(self._schema.trial.c.trial_id),
+                )
+                .where(
+                    self._schema.trial.c.exp_id == self._experiment_id,
+                    func.not_(
+                        self._schema.trial.c.status.in_(
+                            [
+                                Status.SUCCEEDED.name,
+                                Status.FAILED.name,
+                                Status.TIMED_OUT.name,
+                            ]
+                        ),
+                    ),
+                )
+            )
+
+            max_trial_id = conn.execute(first_unfinished_trial_id_stmt).scalar()
+            if max_trial_id is None:
+                return -1
+            # Return one less than the first unfinished trial ID - it should be
+            # finished (or not exist, which is fine as a limit).
+            return int(max_trial_id) - 1
+
     def load(
         self,
         last_trial_id: int = -1,
+        omit_registered_trial_ids: Iterable[int] | None = None,
     ) -> tuple[list[int], list[dict], list[dict[str, Any] | None], list[Status]]:
-
         with self._engine.connect() as conn:
-            cur_trials = conn.execute(
+            stmt = (
                 self._schema.trial.select()
                 .with_only_columns(
                     self._schema.trial.c.trial_id,
@@ -181,6 +211,15 @@ class Experiment(Storage.Experiment):
                     self._schema.trial.c.trial_id.asc(),
                 )
             )
+
+            # TODO: Add a test for this parameter.
+
+            # Note: if we have a very large number of trials, this may encounter
+            # SQL text length limits, so we may need to chunk this.
+            if omit_registered_trial_ids is not None:
+                stmt = stmt.where(self._schema.trial.c.trial_id.notin_(omit_registered_trial_ids))
+
+            cur_trials = conn.execute(stmt)
 
             trial_ids: list[int] = []
             configs: list[dict[str, Any]] = []


### PR DESCRIPTION
# Pull Request

## Title

Prepare `Experiment.load` to handle async out of order trial completion

______________________________________________________________________

## Description

In the case of `ParallelTrialScheduler` (#971) where Trials may complete out of order relative to what they were submitted in, we can no longer rely only on `_last_trial_id` to fetch the latest Trial results when registering finished Trial scores with the Optimizer since that may cause us to skip trial_ids that are less than that that haven't completed yet.

This change enables us to handle that situation by doing the following:
1. Track the a `set()` of `registered_trial_ids` and allow omitting them from being returned by the `Experiment.load()` operation.
2. As an optimization (and since that set could otherwise grow large and cause SQL query text construction issues), we also track the first unfinished `trial_id` in the Experiment.  This allows us to remove all `trial_ids < first_unfinished_trial_id` from the `registered_trial_ids` set.

- [ ] Needs tests.

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix
- ✨ New feature
- 🔄 Refactor
- 🧪 Tests

______________________________________________________________________

## Testing

- New unit tests.
- End to end tests as a part of #971 

______________________________________________________________________

## Additional Notes (optional)

This should have no impact on the `SyncScheduler`.

- [ ] Still includes some additional changes intended to be split out to a separate PR.

______________________________________________________________________
