### PR TITLE
Make Storage objects picklable and resumable by mp.Pool workers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -147,7 +147,7 @@
     "[python]": {
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit",
-            "source.unusedImports": "explicit"
+            //"source.unusedImports": "explicit"
         },
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,

--- a/mlos_bench/mlos_bench/environments/status.py
+++ b/mlos_bench/mlos_bench/environments/status.py
@@ -7,8 +7,8 @@
 import enum
 import logging
 
-
 _LOG = logging.getLogger(__name__)
+
 
 class Status(enum.Enum):
     """Enum for the status of the benchmark/environment Trial or Experiment."""

--- a/mlos_bench/mlos_bench/environments/status.py
+++ b/mlos_bench/mlos_bench/environments/status.py
@@ -91,4 +91,4 @@ class Status(enum.Enum):
         """Check if the status of the benchmark/environment Trial or Experiment is
         TIMED_OUT.
         """
-        return self == Status.FAILED
+        return self == Status.TIMED_OUT

--- a/mlos_bench/mlos_bench/environments/status.py
+++ b/mlos_bench/mlos_bench/environments/status.py
@@ -5,7 +5,10 @@
 """Enum for the status of the benchmark/environment Trial or Experiment."""
 
 import enum
+import logging
 
+
+_LOG = logging.getLogger(__name__)
 
 class Status(enum.Enum):
     """Enum for the status of the benchmark/environment Trial or Experiment."""
@@ -18,6 +21,21 @@ class Status(enum.Enum):
     CANCELED = 5
     FAILED = 6
     TIMED_OUT = 7
+
+    @staticmethod
+    def from_str(status_str: str) -> "Status":
+        """Convert a string to a Status enum."""
+        if status_str.isdigit():
+            try:
+                return Status(int(status_str))
+            except ValueError:
+                _LOG.warning("Unknown status: %d", int(status_str))
+        try:
+            status_str = status_str.upper()
+            return Status[status_str]
+        except KeyError:
+            _LOG.warning("Unknown status: %s", status_str)
+        return Status.UNKNOWN
 
     def is_good(self) -> bool:
         """Check if the status of the benchmark/environment is good."""

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -353,7 +353,7 @@ class Storage(metaclass=ABCMeta):
             timestamp: datetime,
             *,
             running: bool,
-        ) -> Iterator["Storage.Trial"]:
+        ) -> Iterator[Storage.Trial]:
             """
             Return an iterator over the pending trials that are scheduled to run on or
             before the specified timestamp.

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -144,8 +144,10 @@ class Storage(metaclass=ABCMeta):
         opt_targets: dict[str, Literal["min", "max"]],
     ) -> Storage.Experiment:
         """
-        Create a new experiment in the storage.
+        Create or reload an experiment in the Storage.
 
+        Notes
+        -----
         We need the `opt_target` parameter here to know what metric to retrieve
         when we load the data from previous trials. Later we will replace it with
         full metadata about the optimization direction, multiple objectives, etc.
@@ -468,10 +470,11 @@ class Storage(metaclass=ABCMeta):
             tunable_config_id: int,
             trial_runner_id: int | None,
             opt_targets: dict[str, Literal["min", "max"]],
+            status: Status,
+            restoring: bool,
             config: dict[str, Any] | None = None,
-            status: Status = Status.UNKNOWN,
         ):
-            if status not in (Status.UNKNOWN, Status.PENDING):
+            if not restoring and status not in (Status.UNKNOWN, Status.PENDING):
                 raise ValueError(f"Invalid status for a new trial: {status}")
             self._tunables = tunables
             self._experiment_id = experiment_id

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -22,9 +22,11 @@ mlos_bench.storage.base_trial_data.TrialData :
     Base interface for accessing the stored benchmark trial data.
 """
 
+from __future__ import annotations
+
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import AbstractContextManager as ContextManager
 from datetime import datetime
 from types import TracebackType
@@ -95,6 +97,25 @@ class Storage(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def get_experiment_by_id(
+        self,
+        experiment_id: str,
+    ) -> Storage.Experiment | None:
+        """
+        Gets an Experiment by its ID.
+
+        Parameters
+        ----------
+        experiment_id : str
+            ID of the Experiment to retrieve.
+
+        Returns
+        -------
+        experiment : Storage.Experiment | None
+            The Experiment object, or None if it doesn't exist.
+        """
+
+    @abstractmethod
     def experiment(  # pylint: disable=too-many-arguments
         self,
         *,
@@ -104,7 +125,7 @@ class Storage(metaclass=ABCMeta):
         description: str,
         tunables: TunableGroups,
         opt_targets: dict[str, Literal["min", "max"]],
-    ) -> "Storage.Experiment":
+    ) -> Storage.Experiment:
         """
         Create a new experiment in the storage.
 
@@ -161,7 +182,7 @@ class Storage(metaclass=ABCMeta):
             self._opt_targets = opt_targets
             self._in_context = False
 
-        def __enter__(self) -> "Storage.Experiment":
+        def __enter__(self) -> Storage.Experiment:
             """
             Enter the context of the experiment.
 
@@ -308,6 +329,25 @@ class Storage(metaclass=ABCMeta):
             """
 
         @abstractmethod
+        def get_trial_by_id(
+            self,
+            trial_id: int,
+        ) -> Storage.Trial | None:
+            """
+            Gets a Trial by its ID.
+
+            Parameters
+            ----------
+            trial_id : int
+                ID of the Trial to retrieve for this Experiment.
+
+            Returns
+            -------
+            trial : Storage.Trial | None
+                The Trial object, or None if it doesn't exist.
+            """
+
+        @abstractmethod
         def pending_trials(
             self,
             timestamp: datetime,
@@ -337,7 +377,7 @@ class Storage(metaclass=ABCMeta):
             tunables: TunableGroups,
             ts_start: datetime | None = None,
             config: dict[str, Any] | None = None,
-        ) -> "Storage.Trial":
+        ) -> Storage.Trial:
             """
             Create a new experiment run in the storage.
 
@@ -374,7 +414,7 @@ class Storage(metaclass=ABCMeta):
             tunables: TunableGroups,
             ts_start: datetime | None = None,
             config: dict[str, Any] | None = None,
-        ) -> "Storage.Trial":
+        ) -> Storage.Trial:
             """
             Create a new experiment run in the storage.
 

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterator, Mapping
 from contextlib import AbstractContextManager as ContextManager
 from datetime import datetime
 from types import TracebackType

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -492,6 +492,11 @@ class Storage(metaclass=ABCMeta):
             )
 
         @property
+        def experiment_id(self) -> str:
+            """Experiment ID of the Trial."""
+            return self._experiment_id
+
+        @property
         def trial_id(self) -> int:
             """ID of the current trial."""
             return self._trial_id

--- a/mlos_bench/mlos_bench/storage/base_storage.py
+++ b/mlos_bench/mlos_bench/storage/base_storage.py
@@ -100,6 +100,8 @@ class Storage(metaclass=ABCMeta):
     def get_experiment_by_id(
         self,
         experiment_id: str,
+        tunables: TunableGroups,
+        opt_targets: dict[str, Literal["min", "max"]],
     ) -> Storage.Experiment | None:
         """
         Gets an Experiment by its ID.
@@ -108,11 +110,26 @@ class Storage(metaclass=ABCMeta):
         ----------
         experiment_id : str
             ID of the Experiment to retrieve.
+        tunables : TunableGroups
+            The tunables for the Experiment.
+        opt_targets : dict[str, Literal["min", "max"]]
+            The optimization targets for the Experiment's
+            :py:class:`~mlos_bench.optimizers.base_optimizer.Optimizer`.
 
         Returns
         -------
         experiment : Storage.Experiment | None
             The Experiment object, or None if it doesn't exist.
+
+        Notes
+        -----
+        Tunables are not stored in the database for the Experiment, only for the
+        Trials, so currently they can change if the user (incorrectly) adjusts
+        the configs on disk between resume runs.
+        Since this method is generally meant to load th Experiment from the
+        database for a child process to execute a Trial in the background we are
+        generally safe to simply pass these values from the parent process
+        rather than look them up in the database.
         """
 
     @abstractmethod

--- a/mlos_bench/mlos_bench/storage/sql/common.py
+++ b/mlos_bench/mlos_bench/storage/sql/common.py
@@ -95,7 +95,7 @@ def get_trials(
                 config_id=trial.config_id,
                 ts_start=utcify_timestamp(trial.ts_start, origin="utc"),
                 ts_end=utcify_nullable_timestamp(trial.ts_end, origin="utc"),
-                status=Status[trial.status],
+                status=Status.from_str(trial.status),
                 trial_runner_id=trial.trial_runner_id,
             )
             for trial in trials.fetchall()

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -188,7 +188,7 @@ class Experiment(Storage.Experiment):
             status: list[Status] = []
 
             for trial in cur_trials.fetchall():
-                stat = Status[trial.status]
+                stat = Status.from_str(trial.status)
                 status.append(stat)
                 trial_ids.append(trial.trial_id)
                 configs.append(

--- a/mlos_bench/mlos_bench/storage/sql/experiment.py
+++ b/mlos_bench/mlos_bench/storage/sql/experiment.py
@@ -273,8 +273,8 @@ class Experiment(Storage.Experiment):
                 trial_runner_id=trial.trial_runner_id,
                 opt_targets=self._opt_targets,
                 status=Status.from_str(trial.status),
-                config=config,
                 restoring=True,
+                config=config,
             )
 
     def pending_trials(self, timestamp: datetime, *, running: bool) -> Iterator[Storage.Trial]:
@@ -320,6 +320,8 @@ class Experiment(Storage.Experiment):
                     config_id=trial.config_id,
                     trial_runner_id=trial.trial_runner_id,
                     opt_targets=self._opt_targets,
+                    status=Status.from_str(trial.status),
+                    restoring=True,
                     config=config,
                 )
 
@@ -395,8 +397,9 @@ class Experiment(Storage.Experiment):
                     config_id=config_id,
                     trial_runner_id=None,  # initially, Trials are not assigned to a TrialRunner
                     opt_targets=self._opt_targets,
-                    config=config,
                     status=new_trial_status,
+                    restoring=False,
+                    config=config,
                 )
                 self._trial_id += 1
                 return trial

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -21,10 +21,10 @@ _LOG = logging.getLogger(__name__)
 
 
 class SqlStorage(Storage):
-    # pylint: disable=too-many-instance-attributes
     """An implementation of the :py:class:`~.Storage` interface using SQLAlchemy
     backend.
     """
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -92,7 +92,7 @@ class SqlStorage(Storage):
 
     def get_experiment_by_id(
         self,
-        experiment_id,
+        experiment_id: str,
         tunables: TunableGroups,
         opt_targets: dict[str, Literal["min", "max"]],
     ) -> Storage.Experiment | None:

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -89,13 +89,13 @@ class SqlStorage(Storage):
     def __repr__(self) -> str:
         return self._repr
 
-    # TODO: Implement me:
-    # TODO: Needs tests.
-    def get_experiment_by_id(self, experiment_id):
+    def get_experiment_by_id(
+        self,
+        experiment_id,
+        tunables: TunableGroups,
+        opt_targets: dict[str, Literal["min", "max"]],
+    ) -> Storage.Experiment | None:
         with self._engine.connect() as conn:
-            # TODO: need to join with the trial table to get the max trial_id,
-            # objectives to get the opt_targets, and tunable_params to get the
-            # tunables.
             cur_exp = conn.execute(
                 self._schema.experiment.select().where(
                     self._schema.experiment.c.exp_id == experiment_id,
@@ -108,12 +108,11 @@ class SqlStorage(Storage):
                 engine=self._engine,
                 schema=self._schema,
                 experiment_id=exp.exp_id,
-                trial_id=-1,
-                tunables=TunableGroups(),
+                trial_id=-1,  # will be loaded upon __enter__ which calls _setup()
                 description=exp.description,
                 root_env_config=exp.root_env_config,
-                git_repo=exp.git_repo,
-                git_commit=exp.git_commit,
+                tunables=tunables,
+                opt_targets=opt_targets,
             )
 
     def experiment(  # pylint: disable=too-many-arguments

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -24,6 +24,7 @@ class SqlStorage(Storage):
     """An implementation of the :py:class:`~.Storage` interface using SQLAlchemy
     backend.
     """
+
     # pylint: disable=too-many-instance-attributes
 
     def __init__(

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -21,6 +21,7 @@ _LOG = logging.getLogger(__name__)
 
 
 class SqlStorage(Storage):
+    # pylint: disable=too-many-instance-attributes
     """An implementation of the :py:class:`~.Storage` interface using SQLAlchemy
     backend.
     """

--- a/mlos_bench/mlos_bench/storage/sql/storage.py
+++ b/mlos_bench/mlos_bench/storage/sql/storage.py
@@ -7,7 +7,7 @@
 import logging
 from typing import Literal
 
-from sqlalchemy import URL, create_engine
+from sqlalchemy import URL, Engine, create_engine
 
 from mlos_bench.services.base_service import Service
 from mlos_bench.storage.base_experiment_data import ExperimentData
@@ -32,20 +32,43 @@ class SqlStorage(Storage):
         service: Service | None = None,
     ):
         super().__init__(config, global_config, service)
-        lazy_schema_create = self._config.pop("lazy_schema_create", False)
+        self._lazy_schema_create = self._config.pop("lazy_schema_create", False)
         self._log_sql = self._config.pop("log_sql", False)
         self._url = URL.create(**self._config)
         self._repr = f"{self._url.get_backend_name()}:{self._url.database}"
+        self._engine: Engine
+        self._db_schema: DbSchema
+        self._schema_created = False
+        self._schema_updated = False
+        self._init_engine()
+
+    def _init_engine(self) -> None:
+        """Initialize the SQLAlchemy engine."""
+        # This is a no-op, as the engine is created in __init__.
         _LOG.info("Connect to the database: %s", self)
         self._engine = create_engine(self._url, echo=self._log_sql)
         self._db_schema = DbSchema(self._engine)
-        self._schema_created = False
-        self._schema_updated = False
-        if not lazy_schema_create:
+        if not self._lazy_schema_create:
             assert self._schema
             self.update_schema()
         else:
             _LOG.info("Using lazy schema create for database: %s", self)
+
+    # Make the object picklable.
+
+    def __getstate__(self) -> dict:
+        """Return the state of the object for pickling."""
+        state = self.__dict__.copy()
+        # Don't pickle the engine, as it cannot be pickled.
+        state.pop("_engine", None)
+        state.pop("_db_schema", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore the state of the object from pickling."""
+        self.__dict__.update(state)
+        # Recreate the engine and schema.
+        self._init_engine()
 
     @property
     def _schema(self) -> DbSchema:
@@ -65,6 +88,33 @@ class SqlStorage(Storage):
 
     def __repr__(self) -> str:
         return self._repr
+
+    # TODO: Implement me:
+    # TODO: Needs tests.
+    def get_experiment_by_id(self, experiment_id):
+        with self._engine.connect() as conn:
+            # TODO: need to join with the trial table to get the max trial_id,
+            # objectives to get the opt_targets, and tunable_params to get the
+            # tunables.
+            cur_exp = conn.execute(
+                self._schema.experiment.select().where(
+                    self._schema.experiment.c.exp_id == experiment_id,
+                )
+            )
+            exp = cur_exp.fetchone()
+            if exp is None:
+                return None
+            return Experiment(
+                engine=self._engine,
+                schema=self._schema,
+                experiment_id=exp.exp_id,
+                trial_id=-1,
+                tunables=TunableGroups(),
+                description=exp.description,
+                root_env_config=exp.root_env_config,
+                git_repo=exp.git_repo,
+                git_commit=exp.git_commit,
+            )
 
     def experiment(  # pylint: disable=too-many-arguments
         self,

--- a/mlos_bench/mlos_bench/storage/sql/trial.py
+++ b/mlos_bench/mlos_bench/storage/sql/trial.py
@@ -52,8 +52,8 @@ class Trial(Storage.Trial):
             trial_runner_id=trial_runner_id,
             opt_targets=opt_targets,
             status=status,
-            config=config,
             restoring=restoring,
+            config=config,
         )
         self._engine = engine
         self._schema = schema

--- a/mlos_bench/mlos_bench/storage/sql/trial.py
+++ b/mlos_bench/mlos_bench/storage/sql/trial.py
@@ -40,8 +40,9 @@ class Trial(Storage.Trial):
         config_id: int,
         trial_runner_id: int | None,
         opt_targets: dict[str, Literal["min", "max"]],
+        status: Status,
+        restoring: bool,
         config: dict[str, Any] | None = None,
-        status: Status = Status.UNKNOWN,
     ):
         super().__init__(
             tunables=tunables,
@@ -50,8 +51,9 @@ class Trial(Storage.Trial):
             tunable_config_id=config_id,
             trial_runner_id=trial_runner_id,
             opt_targets=opt_targets,
-            config=config,
             status=status,
+            config=config,
+            restoring=restoring,
         )
         self._engine = engine
         self._schema = schema

--- a/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
+++ b/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
@@ -40,6 +40,7 @@ def test_storage_pickle_restore_experiment_and_trial(tunable_groups: TunableGrou
         with experiment:
             trial = experiment.new_trial(tunable_groups)
             trial_id_created = trial.trial_id
+            trial.set_trial_runner(1)
 
         # Pickle and unpickle the Storage object
         pickled = pickle.dumps(storage)
@@ -65,3 +66,6 @@ def test_storage_pickle_restore_experiment_and_trial(tunable_groups: TunableGrou
             assert restored_trial.trial_id == trial.trial_id
             assert restored_trial.experiment_id == trial.experiment_id
             assert restored_trial.tunables == trial.tunables
+            assert restored_trial.status == trial.status
+            assert restored_trial.config() == trial.config()
+            assert restored_trial.trial_runner_id == trial.trial_runner_id

--- a/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
+++ b/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
@@ -1,9 +1,8 @@
-
+#
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""
-Test pickling and unpickling of Storage, and restoring Experiment and Trial by id.
-"""
+#
+"""Test pickling and unpickling of Storage, and restoring Experiment and Trial by id."""
 import os
 import pickle
 import tempfile
@@ -12,10 +11,11 @@ from typing import Literal
 from mlos_bench.storage.sql.storage import SqlStorage
 from mlos_bench.tunables.tunable_groups import TunableGroups
 
+
 def test_storage_pickle_restore_experiment_and_trial(tunable_groups: TunableGroups) -> None:
     # pylint: disable=too-many-locals
-    """Check that we can pickle and unpickle the Storage object, and restore
-    Experiment and Trial by id.
+    """Check that we can pickle and unpickle the Storage object, and restore Experiment
+    and Trial by id.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "mlos_bench.sqlite")

--- a/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
+++ b/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
@@ -6,10 +6,12 @@
 import json
 import os
 import pickle
+import sys
 import tempfile
 from datetime import datetime
 from typing import Literal
 
+import pytest
 from pytz import UTC
 
 from mlos_bench.environments.status import Status
@@ -18,11 +20,15 @@ from mlos_bench.storage.storage_factory import from_config
 from mlos_bench.tunables.tunable_groups import TunableGroups
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows doesn't support multiple processes accessing the same file.",
+)
 def test_storage_pickle_restore_experiment_and_trial(tunable_groups: TunableGroups) -> None:
-    # pylint: disable=too-many-locals
     """Check that we can pickle and unpickle the Storage object, and restore Experiment
     and Trial by id.
     """
+    # pylint: disable=too-many-locals
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "mlos_bench.sqlite")
         config_str = json.dumps(

--- a/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
+++ b/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
@@ -20,6 +20,8 @@ from mlos_bench.storage.storage_factory import from_config
 from mlos_bench.tunables.tunable_groups import TunableGroups
 
 
+# TODO: When we introduce ParallelTrialScheduler warn at config startup time
+# that it is incompatible with sqlite storage on Windows.
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Windows doesn't support multiple processes accessing the same file.",

--- a/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
+++ b/mlos_bench/mlos_bench/tests/storage/test_storage_pickling.py
@@ -1,0 +1,67 @@
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Test pickling and unpickling of Storage, and restoring Experiment and Trial by id.
+"""
+import os
+import pickle
+import tempfile
+from typing import Literal
+
+from mlos_bench.storage.sql.storage import SqlStorage
+from mlos_bench.tunables.tunable_groups import TunableGroups
+
+def test_storage_pickle_restore_experiment_and_trial(tunable_groups: TunableGroups) -> None:
+    # pylint: disable=too-many-locals
+    """Check that we can pickle and unpickle the Storage object, and restore
+    Experiment and Trial by id.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "mlos_bench.sqlite")
+        config = {
+            "drivername": "sqlite",
+            "database": db_path,
+            "lazy_schema_create": False,
+        }
+        storage = SqlStorage(config)
+        storage.update_schema()
+
+        # Create an Experiment and a Trial
+        opt_targets: dict[str, Literal["min", "max"]] = {"metric": "min"}
+        experiment = storage.experiment(
+            experiment_id="experiment_id",
+            trial_id=0,
+            root_env_config="dummy_env.json",
+            description="Pickle test experiment",
+            tunables=tunable_groups,
+            opt_targets=opt_targets,
+        )
+        with experiment:
+            trial = experiment.new_trial(tunable_groups)
+            trial_id_created = trial.trial_id
+
+        # Pickle and unpickle the Storage object
+        pickled = pickle.dumps(storage)
+        restored_storage = pickle.loads(pickled)
+        assert isinstance(restored_storage, SqlStorage)
+
+        # Restore the Experiment from storage by id
+        restored_experiment = restored_storage.get_experiment_by_id(
+            experiment_id=experiment.experiment_id,
+            tunables=tunable_groups,
+            opt_targets=opt_targets,
+        )
+        assert restored_experiment is not None
+        assert restored_experiment.experiment_id == experiment.experiment_id
+        assert restored_experiment.description == experiment.description
+        assert restored_experiment.root_env_config == experiment.root_env_config
+        assert restored_experiment.opt_targets == experiment.opt_targets
+
+        # Restore the Trial from storage by id
+        with restored_experiment:
+            restored_trial = restored_experiment.get_trial_by_id(trial_id_created)
+            assert restored_trial is not None
+            assert restored_trial.trial_id == trial.trial_id
+            assert restored_trial.experiment_id == trial.experiment_id
+            assert restored_trial.tunables == trial.tunables


### PR DESCRIPTION
# Pull Request

## Title

Make Storage objects picklable and resumable by mp.Pool workers.

______________________________________________________________________

## Description

To support a `ParallelTrialScheduler` with `Trials` running thru `TrialRunners` in separate processes using `multiprocessing.Pool` we need to be able to "send" all necessary state to "blank" python processes using pickle since python doesn't actually use a `fork` strategy for multiprocessing.

This change enables that by doing the following:

1. Allow pickling the core `Storage` class by hooking `__getstate__` and `__setstate__` to disconnect the `Engine` prior to pickling and reconnect on unpickling (restore).
2. Allow recreating an `Experiment` and `Trial` object by fetching it from the `Storage` by `experiment_id` and `trial_id` respectively.

These two things allow gathering the details necessary for a `TrialRunner` running in a separate child process to reconnect to the DB independently, `run_trial`, and save the telemetry and results to the DB.
After which, the "MainProcess" can `load` the results from the Experiment from the Storage again to `bulk_register` the scores from those completed `Trials` and start a new set.

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix
- ✨ New feature
- 🔄 Refactor
- 🧪 Tests

______________________________________________________________________

## Testing

- [x] New CI tests

______________________________________________________________________

## Additional Notes (optional)

This change should have no impact on the existing `SyncScheduler`.

______________________________________________________________________
