### PR TITLE
Refactor Scheduler schema definitions to make it easier to add new ones.

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/schedulers/base-scheduler-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/schedulers/base-scheduler-subschema.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/schedulers/base-scheduler-subschema.json",
+    "title": "mlos_bench base Scheduler config schema definitions",
+    "description": "mlos_bench base Scheduler config schema definitions for all Scheduler types.",
+
+    "$defs": {
+        "base_scheduler_config": {
+            "$comment": "config properties common to all Scheduler types.",
+            "description": "The scheduler-specific config.",
+            "type": "object",
+            "minProperties": 1,
+            "properties": {
+                "experiment_id": {
+                    "$ref": "../cli/common-defs-subschemas.json#/$defs/experiment_id"
+                },
+                "trial_id": {
+                    "$ref": "../cli/common-defs-subschemas.json#/$defs/trial_id"
+                },
+                "config_id": {
+                    "$ref": "../cli/common-defs-subschemas.json#/$defs/config_id"
+                },
+                "teardown": {
+                    "description": "Whether to teardown the experiment after running it.",
+                    "type": "boolean"
+                },
+                "max_trials": {
+                    "description": "Max. number of trials to run. Use -1 or 0 for unlimited.",
+                    "type": "integer",
+                    "minimum": -1,
+                    "examples": [50, -1]
+                },
+                "trial_config_repeat_count": {
+                    "description": "Number of times to repeat a config.",
+                    "type": "integer",
+                    "minimum": 1,
+                    "examples": [3, 5]
+                }
+            }
+        }
+    },
+
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "description": "The schema to use for validating the scheduler config (accepts both URLs and local paths).",
+            "type": "string",
+            "$comment": "This is optional, but if provided, should match the name of the root schema file.",
+            "pattern": "/schemas/schedulers/scheduler-schema.json$"
+        },
+
+        "description": {
+            "description": "Optional description of the config.",
+            "type": "string"
+        },
+
+        "class": {
+            "description": "The name of the scheduler class to use.",
+            "type": "string",
+            "$comment": "Exact matches are handled elsewhere.",
+            "pattern": "^mlos_bench[.]schedulers[.]"
+        },
+
+        "config": {
+            "$ref": "#/$defs/base_scheduler_config"
+        }
+    },
+    "required": ["class"]
+}

--- a/mlos_bench/mlos_bench/config/schemas/schedulers/scheduler-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/schedulers/scheduler-schema.json
@@ -2,105 +2,23 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/schedulers/scheduler-schema.json",
     "title": "mlos_bench Scheduler config",
-
-    "$defs": {
-        "comment": {
-            "$comment": "This section contains reusable partial schema bits (or just split out for readability)"
-        },
-
-        "config_base_scheduler": {
-            "$comment": "config properties common to all Scheduler types.",
-            "type": "object",
-            "properties": {
-                "experiment_id": {
-                    "$ref": "../cli/common-defs-subschemas.json#/$defs/experiment_id"
-                },
-                "trial_id": {
-                    "$ref": "../cli/common-defs-subschemas.json#/$defs/trial_id"
-                },
-                "config_id": {
-                    "$ref": "../cli/common-defs-subschemas.json#/$defs/config_id"
-                },
-                "teardown": {
-                    "description": "Whether to teardown the experiment after running it.",
-                    "type": "boolean"
-                },
-                "max_trials": {
-                    "description": "Max. number of trials to run. Use -1 or 0 for unlimited.",
-                    "type": "integer",
-                    "minimum": -1,
-                    "examples": [50, -1]
-                },
-                "trial_config_repeat_count": {
-                    "description": "Number of times to repeat a config.",
-                    "type": "integer",
-                    "minimum": 1,
-                    "examples": [3, 5]
-                }
-            }
-        }
-    },
-
     "description": "config for the mlos_bench scheduler",
     "$comment": "top level schema document rules",
+
     "type": "object",
-    "properties": {
-        "$schema": {
-            "description": "The schema to use for validating the scheduler config (accepts both URLs and local paths).",
-            "type": "string",
-            "$comment": "This is optional, but if provided, should match the name of this file.",
-            "pattern": "/schemas/schedulers/scheduler-schema.json$"
-        },
-
-        "description": {
-            "description": "Optional description of the config.",
-            "type": "string"
-        },
-
-        "class": {
-            "description": "The name of the scheduler class to use.",
-            "$comment": "required",
-            "enum": [
-                "mlos_bench.schedulers.SyncScheduler",
-                "mlos_bench.schedulers.sync_scheduler.SyncScheduler"
-            ]
-        },
-
-        "config": {
-            "description": "The scheduler-specific config.",
-            "$comment": "Stub for scheduler-specific config appended with condition statements below",
-            "type": "object",
-            "minProperties": 1
-        }
-    },
-    "required": ["class"],
-
-    "oneOf": [
+    "allOf": [
         {
-            "$comment": "extensions to the 'config' object properties when synchronous scheduler is being used",
-            "if": {
-                "properties": {
-                    "class": {
-                        "enum": [
-                            "mlos_bench.schedulers.SyncScheduler",
-                            "mlos_bench.schedulers.sync_scheduler.SyncScheduler"
-                        ]
-                    }
-                },
-                "required": ["class"]
-            },
-            "then": {
-                "properties": {
-                    "config": {
-                        "type": "object",
-                        "allOf": [{ "$ref": "#/$defs/config_base_scheduler" }],
-                        "$comment": "disallow other properties",
-                        "unevaluatedProperties": false
-                    }
+            "$comment": "All scheduler subschemas support these base properties.",
+            "$ref": "./base-scheduler-subschema.json"
+        },
+        {
+            "$comment": "The set of known Scheduler subschemas.  Add others as needed.",
+            "oneOf": [
+                {
+                    "$ref": "./sync-scheduler-subschema.json"
                 }
-            },
-            "else": false
+            ]
         }
     ],
-    "unevaluatedProperties": false
+    "required": ["class"]
 }

--- a/mlos_bench/mlos_bench/config/schemas/schedulers/scheduler-schema.json
+++ b/mlos_bench/mlos_bench/config/schemas/schedulers/scheduler-schema.json
@@ -20,5 +20,6 @@
             ]
         }
     ],
-    "required": ["class"]
+    "required": ["class"],
+    "unevaluatedProperties": false
 }

--- a/mlos_bench/mlos_bench/config/schemas/schedulers/sync-scheduler-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/schedulers/sync-scheduler-subschema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/microsoft/MLOS/main/mlos_bench/mlos_bench/config/schemas/schedulers/sync-scheduler-subschema.json",
+    "title": "mlos_bench SyncScheduler config",
+    "description": "config for an mlos_bench SyncScheduler",
+    "type": "object",
+    "properties": {
+        "class": {
+            "enum": [
+                "mlos_bench.schedulers.SyncScheduler",
+                "mlos_bench.schedulers.sync_scheduler.SyncScheduler"
+            ]
+        },
+        "config": {
+            "type": "object",
+            "$comment": "No extra properties supported by SyncScheduler.",
+            "allOf": [
+                {
+                    "$ref": "base-scheduler-subschema.json#/$defs/base_scheduler_config"
+                }
+            ],
+            "minProperties": 1,
+            "unevaluatedProperties": false
+        }
+    },
+    "required": ["class"]
+}


### PR DESCRIPTION
# Pull Request

## Title

Refactor Scheduler schema definitions to make it easier to add new ones.

______________________________________________________________________

## Description

Simple refactor of the Scheduler schemas to allow making new ones as a copy/edit of the `synchscheduler-subschema.json`.

______________________________________________________________________

## Type of Change

- 🔄 Refactor

______________________________________________________________________

## Testing

- Exisiting CI checks for good and bad scheduler config files still pass.
- Adding additional tests to actually load those configs with `mlos_bench` next.

______________________________________________________________________

## Additional Notes (optional)

- Splitting some new testing infra out from #973.
- Adding `MockScheduler` next, then `ParallelScheduler` in #971.

______________________________________________________________________
