### PR TITLE
Bugfix: Fix crashing in postgres-backed storage

### DIFF
--- a/mlos_bench/mlos_bench/storage/sql/trial.py
+++ b/mlos_bench/mlos_bench/storage/sql/trial.py
@@ -116,6 +116,7 @@ class Trial(Storage.Trial):
         metrics = super().update(status, timestamp, metrics)
         with self._engine.begin() as conn:
             self._update_status(conn, status, timestamp)
+        with self._engine.begin() as conn:
             try:
                 if status.is_completed():
                     # Final update of the status and ts_end:


### PR DESCRIPTION
# Pull Request

## Title

In PostgreSQL, attempting to insert a record with conflicting keys fails (a benign action in MLOS), fails the entire transaction thus preventing the update of other tables. Splitting the update into two independent transactions solves the problem.
______________________________________________________________________

## Description

Update tables `trial_status` and `trial` in separate transactions (that's OK for MLOS) to make sure PG won't fail the update of `trial` if there is a duplicate record in `trial_status`.

- **Issue link**: Closes #999 

______________________________________________________________________

## Type of Change

- 🛠️ Bug fix

______________________________________________________________________

## Testing

Run TQP benchmark with PostgreSQL storage.
